### PR TITLE
document form resets when closing metadata panel

### DIFF
--- a/app/react/Documents/actions/actions.js
+++ b/app/react/Documents/actions/actions.js
@@ -47,7 +47,7 @@ export function changeTemplate(form, doc, template) {
 
     newDoc.template = template._id;
 
-    dispatch(formActions.merge(form, newDoc));
     dispatch(formActions.setInitial(form));
+    dispatch(formActions.change(form, newDoc));
   };
 }

--- a/app/react/Documents/actions/specs/actions.spec.js
+++ b/app/react/Documents/actions/specs/actions.spec.js
@@ -37,8 +37,8 @@ describe('documentFormActions', () => {
 
   describe('changeTemplate', () => {
     it('should change the document template and remove/add metadata properties', () => {
-      spyOn(formActions, 'merge').and.returnValue('formMerge');
       spyOn(formActions, 'setInitial').and.returnValue('forminitial');
+      spyOn(formActions, 'change').and.returnValue('formMerge');
       let dispatch = jasmine.createSpy('dispatch');
       let doc = {title: 'test', template: 'templateId', metadata: {test: 'test', test2: 'test2'}};
       let template = {_id: 'newTemplate', properties: [{name: 'test'}, {name: 'newProp'}]};
@@ -48,8 +48,8 @@ describe('documentFormActions', () => {
 
       let expectedDoc = {title: 'test', template: 'newTemplate', metadata: {test: 'test', newProp: ''}};
       expect(dispatch).toHaveBeenCalledWith('formMerge');
-      expect(formActions.merge).toHaveBeenCalledWith('formNamespace', expectedDoc);
       expect(formActions.setInitial).toHaveBeenCalledWith('formNamespace');
+      expect(formActions.change).toHaveBeenCalledWith('formNamespace', expectedDoc);
     });
   });
 });

--- a/app/react/Documents/components/DocumentForm.js
+++ b/app/react/Documents/components/DocumentForm.js
@@ -37,6 +37,7 @@ export class DocumentForm extends Component {
           <label>Document Type <span className="required">*</span></label>
           <FormField>
             <Select options={templateOptions}
+              value={template._id}
               onChange={(e) => {
                 this.props.changeTemplate(model, document, templates.find((t) => t._id === e.target.value));
               }}
@@ -46,7 +47,7 @@ export class DocumentForm extends Component {
 
         {template.properties.map((property, index) => {
           return (
-            <FormGroup key={index} {...state.fields[`${model}.${property.name}`]} submitFailed={state.submitFailed}>
+            <FormGroup key={index} {...state.fields[`metadata.${property.name}`]} submitFailed={state.submitFailed}>
               <label>
                 {property.label}
                 {property.required ? <span className="required">*</span> : ''}

--- a/app/react/Documents/components/specs/DocumentForm.spec.js
+++ b/app/react/Documents/components/specs/DocumentForm.spec.js
@@ -23,7 +23,7 @@ describe('DocumentForm', () => {
       thesauris: Immutable.fromJS([{_id: 'thesauriId', name: 'thesauri', values: [{label: 'option1', id: '1'}]}]),
       onSubmit: jasmine.createSpy('onSubmit'),
       changeTemplate: jasmine.createSpy('changeTemplate'),
-      state: {fields: {title: {prop: 'prop'}}},
+      state: {fields: {title: {titleProp: 'prop'}, 'metadata.field1': {field1Prop: 'prop'}}},
       model: 'document'
     };
   });
@@ -57,6 +57,15 @@ describe('DocumentForm', () => {
       template.simulate('change', {target: {value: '2'}});
       expect(props.changeTemplate).toHaveBeenCalledWith(props.model, props.document, props.templates.toJS()[1]);
     });
+  });
+
+  it('should pass the field state to every fields', () => {
+    render();
+    let FormGroup = component.findWhere((node) => node.props().titleProp === 'prop');
+    expect(FormGroup.length).toBe(1);
+
+    FormGroup = component.findWhere((node) => node.props().field1Prop === 'prop');
+    expect(FormGroup.length).toBe(1);
   });
 
   it('should render dynamic fields based on the template selected', () => {

--- a/app/react/Modals/index.js
+++ b/app/react/Modals/index.js
@@ -1,0 +1,2 @@
+import * as actions from './actions/modalActions';
+export default {actions};

--- a/app/react/Viewer/components/ConfirmCloseForm.js
+++ b/app/react/Viewer/components/ConfirmCloseForm.js
@@ -27,7 +27,7 @@ export class ConfirmCloseForm extends Component {
 
         <Modal.Body>
           <h4>Confirm</h4>
-          <p>All changes will be lost, are you sure you want to proceed ?</p>
+          <p>All changes will be lost, are you sure you want to proceed?</p>
         </Modal.Body>
 
         <Modal.Footer>

--- a/app/react/Viewer/components/ConfirmCloseForm.js
+++ b/app/react/Viewer/components/ConfirmCloseForm.js
@@ -1,0 +1,62 @@
+import React, {Component, PropTypes} from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import {actions as formActions} from 'react-redux-form';
+
+import {closePanel} from '../actions/uiActions';
+import {hideModal} from 'app/Modals/actions/modalActions';
+import Modal from 'app/Layout/Modal';
+
+export class ConfirmCloseForm extends Component {
+
+  confirm() {
+    this.props.hideModal('ConfirmCloseForm');
+    this.props.closePanel();
+    this.props.resetForm('documentViewer.docForm');
+  }
+
+  render() {
+    if (!this.props.doc) {
+      return false;
+    }
+
+    let doc = this.props.doc;
+
+    return (
+      <Modal isOpen={!!doc} type="danger">
+
+        <Modal.Body>
+          <h4>Confirm</h4>
+          <p>All changes will be lost, are you sure you want to proceed ?</p>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <button type="button" className="btn btn-default cancel-button" onClick={() => this.props.hideModal('ConfirmCloseForm')}>
+            <i className="fa fa-close"></i> Cancel
+          </button>
+          <button type="button" className="btn btn-danger confirm-button" onClick={() => this.confirm()}>
+            <i className="fa fa-trash"></i> Ok
+          </button>
+        </Modal.Footer>
+
+      </Modal>
+    );
+  }
+}
+
+ConfirmCloseForm.propTypes = {
+  hideModal: PropTypes.func,
+  resetForm: PropTypes.func,
+  closePanel: PropTypes.func,
+  doc: PropTypes.object
+};
+
+const mapStateToProps = (state) => {
+  return {doc: state.modals.get('ConfirmCloseForm')};
+};
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({closePanel, hideModal, resetForm: formActions.reset}, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ConfirmCloseForm);

--- a/app/react/Viewer/components/ViewMetadataPanel.js
+++ b/app/react/Viewer/components/ViewMetadataPanel.js
@@ -5,11 +5,17 @@ import documents from 'app/Documents';
 import {bindActionCreators} from 'redux';
 import {saveDocument} from '../actions/documentActions';
 import {closePanel} from '../actions/uiActions';
+import {actions as formActions} from 'react-redux-form';
 
 import DocumentForm from '../containers/DocumentForm';
 import {ShowDocument} from 'app/Documents';
 
 export class ViewMetadataPanel extends Component {
+  close() {
+    this.props.resetForm('documentViewer.docForm');
+    this.props.closePanel();
+  }
+
   submit(doc) {
     this.props.saveDocument(doc);
   }
@@ -20,7 +26,7 @@ export class ViewMetadataPanel extends Component {
     return (
       <SidePanel open={this.props.open}>
         <h1>{doc.title}</h1>
-        <i className="fa fa-close close-modal" onClick={this.props.closePanel}/>
+        <i className="fa fa-close close-modal" onClick={this.close.bind(this)}/>
         {(() => {
           if (docBeingEdited) {
             return <DocumentForm onSubmit={this.submit.bind(this)} />;
@@ -37,7 +43,8 @@ ViewMetadataPanel.propTypes = {
   docBeingEdited: PropTypes.bool,
   open: PropTypes.bool,
   saveDocument: PropTypes.func,
-  closePanel: PropTypes.func
+  closePanel: PropTypes.func,
+  resetForm: PropTypes.func
 };
 
 const mapStateToProps = ({documentViewer}) => {
@@ -49,7 +56,7 @@ const mapStateToProps = ({documentViewer}) => {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({saveDocument, closePanel}, dispatch);
+  return bindActionCreators({saveDocument, closePanel, resetForm: formActions.reset}, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ViewMetadataPanel);

--- a/app/react/Viewer/components/ViewMetadataPanel.js
+++ b/app/react/Viewer/components/ViewMetadataPanel.js
@@ -9,9 +9,13 @@ import {actions as formActions} from 'react-redux-form';
 
 import DocumentForm from '../containers/DocumentForm';
 import {ShowDocument} from 'app/Documents';
+import modals from 'app/Modals';
 
 export class ViewMetadataPanel extends Component {
   close() {
+    if (this.props.formState.dirty) {
+      return this.props.showModal('ConfirmCloseForm', this.props.doc);
+    }
     this.props.resetForm('documentViewer.docForm');
     this.props.closePanel();
   }
@@ -40,10 +44,12 @@ export class ViewMetadataPanel extends Component {
 
 ViewMetadataPanel.propTypes = {
   doc: PropTypes.object,
+  formState: PropTypes.object,
   docBeingEdited: PropTypes.bool,
   open: PropTypes.bool,
   saveDocument: PropTypes.func,
   closePanel: PropTypes.func,
+  showModal: PropTypes.func,
   resetForm: PropTypes.func
 };
 
@@ -51,12 +57,13 @@ const mapStateToProps = ({documentViewer}) => {
   return {
     open: documentViewer.uiState.get('panel') === 'viewMetadataPanel',
     doc: documents.helpers.prepareMetadata(documentViewer.doc.toJS(), documentViewer.templates.toJS(), documentViewer.thesauris.toJS()),
-    docBeingEdited: !!documentViewer.docForm._id
+    docBeingEdited: !!documentViewer.docForm._id,
+    formState: documentViewer.docFormState
   };
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({saveDocument, closePanel, resetForm: formActions.reset}, dispatch);
+  return bindActionCreators({showModal: modals.actions.showModal, saveDocument, closePanel, resetForm: formActions.reset}, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ViewMetadataPanel);

--- a/app/react/Viewer/components/Viewer.js
+++ b/app/react/Viewer/components/Viewer.js
@@ -15,6 +15,7 @@ import ViewerTextSelectedMenu from './ViewerTextSelectedMenu';
 import ViewerSaveReferenceMenu from './ViewerSaveReferenceMenu';
 import ViewerSaveTargetReferenceMenu from './ViewerSaveTargetReferenceMenu';
 import MetadataPanelMenu from './MetadataPanelMenu';
+import ConfirmCloseForm from './ConfirmCloseForm';
 import {actions} from 'app/BasicReducer';
 
 export class Viewer extends Component {
@@ -47,6 +48,7 @@ export class Viewer extends Component {
           <TargetDocument />
         </main>
 
+        <ConfirmCloseForm />
         <CreateReferencePanel />
         <ViewReferencesPanel />
         <ViewMetadataPanel />

--- a/app/react/Viewer/components/specs/ConfirmCloseForm.spec.js
+++ b/app/react/Viewer/components/specs/ConfirmCloseForm.spec.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Modal from 'app/Layout/Modal';
+
+import {ConfirmCloseForm} from '../ConfirmCloseForm';
+
+describe('ConfirmCloseForm', () => {
+  let component;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      hideModal: jasmine.createSpy('hideModal'),
+      resetForm: jasmine.createSpy('resetForm'),
+      closePanel: jasmine.createSpy('closePanel'),
+      doc: {_id: 'docId', title: 'test'}
+    };
+  });
+
+  let render = () => {
+    component = shallow(<ConfirmCloseForm {...props} />);
+  };
+
+  it('should open modal if doc is not undefined', () => {
+    render();
+    expect(component.find(Modal).props().isOpen).toBe(true);
+  });
+
+  describe('when clicking Ok', () => {
+    it('should close modal and reset form', () => {
+      render();
+      component.find('.confirm-button').simulate('click');
+      expect(props.hideModal).toHaveBeenCalledWith('ConfirmCloseForm');
+      expect(props.resetForm).toHaveBeenCalledWith('documentViewer.docForm');
+      expect(props.closePanel).toHaveBeenCalled();
+    });
+  });
+
+  describe('when clicking cancel button', () => {
+    it('should call hideModal', () => {
+      render();
+      component.find('.cancel-button').simulate('click');
+      expect(props.hideModal).toHaveBeenCalledWith('ConfirmCloseForm');
+    });
+  });
+});

--- a/app/react/Viewer/components/specs/ViewMetadataPanel.spec.js
+++ b/app/react/Viewer/components/specs/ViewMetadataPanel.spec.js
@@ -14,7 +14,8 @@ describe('ViewMetadataPanel', () => {
 
   beforeEach(() => {
     props = {
-      doc: {metadata: []}
+      doc: {metadata: []},
+      showModal: jasmine.createSpy('showModal')
     };
   });
 
@@ -39,16 +40,28 @@ describe('ViewMetadataPanel', () => {
   });
 
   describe('close', () => {
-    it('should close panel and reset form', () => {
-      props.closePanel = jasmine.createSpy('closePanel');
-      props.resetForm = jasmine.createSpy('resetForm');
-      props.docBeingEdited = true;
-      render();
+    describe('when form is dirty', () => {
+      it('should showModal ConfirmCloseForm', () => {
+        props.formState = {dirty: true};
+        render();
+        component.find('i').simulate('click');
+        expect(props.showModal).toHaveBeenCalledWith('ConfirmCloseForm', props.doc);
+      });
+    });
 
-      component.find('i').simulate('click');
+    describe('when form is not dirty', () => {
+      it('should close panel and reset form', () => {
+        props.closePanel = jasmine.createSpy('closePanel');
+        props.resetForm = jasmine.createSpy('resetForm');
+        props.formState = {dirty: false};
+        props.docBeingEdited = true;
+        render();
 
-      expect(props.closePanel).toHaveBeenCalled();
-      expect(props.resetForm).toHaveBeenCalledWith('documentViewer.docForm');
+        component.find('i').simulate('click');
+
+        expect(props.closePanel).toHaveBeenCalled();
+        expect(props.resetForm).toHaveBeenCalledWith('documentViewer.docForm');
+      });
     });
   });
 

--- a/app/react/Viewer/components/specs/ViewMetadataPanel.spec.js
+++ b/app/react/Viewer/components/specs/ViewMetadataPanel.spec.js
@@ -38,6 +38,20 @@ describe('ViewMetadataPanel', () => {
     });
   });
 
+  describe('close', () => {
+    it('should close panel and reset form', () => {
+      props.closePanel = jasmine.createSpy('closePanel');
+      props.resetForm = jasmine.createSpy('resetForm');
+      props.docBeingEdited = true;
+      render();
+
+      component.find('i').simulate('click');
+
+      expect(props.closePanel).toHaveBeenCalled();
+      expect(props.resetForm).toHaveBeenCalledWith('documentViewer.docForm');
+    });
+  });
+
   describe('onSubmit', () => {
     it('should saveDocument', () => {
       props.saveDocument = jasmine.createSpy('saveDocument');


### PR DESCRIPTION
solves #70 

When clicking outside, this panel does not close, the only way to close it is clicking on the close button, this is when the form resets.