### PR TITLE
be able to copy/paste text on the document viewer

### DIFF
--- a/app/react/Viewer/components/Document.js
+++ b/app/react/Viewer/components/Document.js
@@ -41,7 +41,7 @@ export class Document extends Component {
 
   componentDidUpdate() {
     this.text.renderReferences(this.props.references);
-    this.text.simulateSelection(this.props.selection);
+    this.text.simulateSelection(this.props.selection, this.props.forceSimulateSelection);
     this.text.highlight(this.props.highlightedReference);
   }
 
@@ -82,7 +82,8 @@ Document.propTypes = {
   className: PropTypes.string,
   onClick: PropTypes.func,
   executeOnClickHandler: PropTypes.bool,
-  disableTextSelection: PropTypes.bool
+  disableTextSelection: PropTypes.bool,
+  forceSimulateSelection: PropTypes.bool
 };
 
 export default Document;

--- a/app/react/Viewer/components/SourceDocument.js
+++ b/app/react/Viewer/components/SourceDocument.js
@@ -15,7 +15,9 @@ const mapStateToProps = ({documentViewer}) => {
     className: 'sourceDocument',
     highlightedReference: uiState.highlightedReference,
     executeOnClickHandler: !!documentViewer.targetDoc.get('_id'),
-    disableTextSelection: documentViewer.uiState.get('panel') === 'viewMetadataPanel'
+    disableTextSelection: documentViewer.uiState.get('panel') === 'viewMetadataPanel',
+    forceSimulateSelection: documentViewer.uiState.get('panel') === 'targetReferencePanel'
+      || documentViewer.uiState.get('panel') === 'referencePanel'
   };
 };
 

--- a/app/react/Viewer/components/specs/Document.spec.js
+++ b/app/react/Viewer/components/specs/Document.spec.js
@@ -165,6 +165,7 @@ describe('Document', () => {
       props.selection = {selection: 'selection'};
       props.highlightedReference = 'highlightedReference';
       props.references = [{reference: 'reference'}];
+      props.forceSimulateSelection = 'forceSimulateSelection';
       render();
       instance.text = Text(instance.pagesContainer);
       spyOn(instance.text, 'getSelection').and.returnValue('serializedRange');
@@ -182,7 +183,7 @@ describe('Document', () => {
       it('should simulateSelection', () => {
         instance.componentDidUpdate();
 
-        expect(instance.text.simulateSelection).toHaveBeenCalledWith({selection: 'selection'});
+        expect(instance.text.simulateSelection).toHaveBeenCalledWith({selection: 'selection'}, 'forceSimulateSelection');
       });
 
       it('should render the references', () => {

--- a/app/react/Viewer/components/specs/SourceDocument.spec.js
+++ b/app/react/Viewer/components/specs/SourceDocument.spec.js
@@ -40,6 +40,23 @@ describe('SourceDocument', function () {
     expect(props.highlightedReference).toBe('highlightedReference');
   });
 
+  it('should forceSimulateSelection when showing panels referencePanel or targetReferencePanel', () => {
+    state.documentViewer.uiState = state.documentViewer.uiState.set('panel', 'referencePanel');
+    render();
+    let props = component.props();
+    expect(props.forceSimulateSelection).toBe(true);
+
+    state.documentViewer.uiState = state.documentViewer.uiState.set('panel', 'targetReferencePanel');
+    render();
+    props = component.props();
+    expect(props.forceSimulateSelection).toBe(true);
+
+    state.documentViewer.uiState = state.documentViewer.uiState.set('panel', 'otherPanel');
+    render();
+    props = component.props();
+    expect(props.forceSimulateSelection).toBe(false);
+  });
+
   it('should pass executeOnClickHandler true if target document is loaded', () => {
     state.documentViewer.targetDoc = Immutable.fromJS({_id: 'id'});
     render();

--- a/app/react/Viewer/scss/document.scss
+++ b/app/react/Viewer/scss/document.scss
@@ -26,7 +26,7 @@
   }
 
   .fake-selection {
-    background: $c-primary-light;
+    background: #E0ED55;
   }
 
   h1, h2, h3, h4, h5, h6 {

--- a/app/react/Viewer/utils/Text.js
+++ b/app/react/Viewer/utils/Text.js
@@ -32,9 +32,9 @@ export default function (container) {
       this.highlightedReference = referenceId;
     },
 
-    simulateSelection(range) {
+    simulateSelection(range, force) {
       this.removeSimulatedSelection();
-      if (!range || this.selected()) {
+      if (!range || this.selected() && !force) {
         return;
       }
 
@@ -53,7 +53,7 @@ export default function (container) {
     },
 
     isSelectionOnContainer() {
-      let node = window.getSelection().parentNode;
+      let node = window.getSelection().baseNode;
       while (node && node !== this.container && node.nodeName !== 'BODY') {
         node = node.parentNode;
       }

--- a/app/react/Viewer/utils/Text.js
+++ b/app/react/Viewer/utils/Text.js
@@ -34,7 +34,7 @@ export default function (container) {
 
     simulateSelection(range) {
       this.removeSimulatedSelection();
-      if (!range) {
+      if (!range || this.selected()) {
         return;
       }
 
@@ -42,11 +42,11 @@ export default function (container) {
       let elementWrapper = document.createElement('span');
       elementWrapper.classList.add('fake-selection');
       this.fakeSelection = wrapper.wrap(elementWrapper, restoredRange);
-      this.removeSelection();
     },
 
     removeSimulatedSelection() {
       if (this.fakeSelection) {
+        this.removeSelection();
         this.fakeSelection.unwrap();
         this.fakeSelection = null;
       }

--- a/app/react/Viewer/utils/Text.js
+++ b/app/react/Viewer/utils/Text.js
@@ -52,8 +52,17 @@ export default function (container) {
       }
     },
 
+    isSelectionOnContainer() {
+      let node = window.getSelection().parentNode;
+      while (node && node !== this.container && node.nodeName !== 'BODY') {
+        node = node.parentNode;
+      }
+
+      return node === this.container;
+    },
+
     removeSelection() {
-      if (!this.selected()) {
+      if (!this.selected() || !this.isSelectionOnContainer()) {
         return;
       }
       if (window.getSelection) {

--- a/app/react/Viewer/utils/specs/Text.spec.js
+++ b/app/react/Viewer/utils/specs/Text.spec.js
@@ -34,40 +34,58 @@ describe('Text', () => {
   });
 
   describe('simulateSelection', () => {
-    it('should wrap the range with a span.fake-selection', () => {
-      spyOn(wrapper, 'wrap').and.returnValue('fakeSelection');
-      spyOn(TextRange, 'restore').and.returnValue('restoredRange');
-      spyOn(text, 'removeSelection');
-      spyOn(text, 'removeSimulatedSelection');
+    describe('when there is no selection', () => {
+      it('should wrap the range with a span.fake-selection', () => {
+        spyOn(wrapper, 'wrap').and.returnValue('fakeSelection');
+        spyOn(TextRange, 'restore').and.returnValue('restoredRange');
+        spyOn(text, 'selected').and.returnValue(false);
+        spyOn(text, 'removeSimulatedSelection');
 
-      text.simulateSelection('range');
+        text.simulateSelection('range');
 
-      let elementWrapper = document.createElement('span');
-      elementWrapper.classList.add('fake-selection');
+        let elementWrapper = document.createElement('span');
+        elementWrapper.classList.add('fake-selection');
 
-      expect(TextRange.restore).toHaveBeenCalledWith('range', document);
-      expect(wrapper.wrap).toHaveBeenCalledWith(elementWrapper, 'restoredRange');
-      expect(text.fakeSelection).toBe('fakeSelection');
-      expect(text.removeSelection).toHaveBeenCalled();
-      expect(text.removeSimulatedSelection).toHaveBeenCalled();
+        expect(TextRange.restore).toHaveBeenCalledWith('range', document);
+        expect(wrapper.wrap).toHaveBeenCalledWith(elementWrapper, 'restoredRange');
+        expect(text.fakeSelection).toBe('fakeSelection');
+        expect(text.removeSimulatedSelection).toHaveBeenCalled();
+      });
     });
 
     describe('when selection passed is null', () => {
-      it('should remove current fakeSelection', () => {
+      it('should only remove current fakeSelection', () => {
         spyOn(text, 'removeSimulatedSelection');
+        spyOn(wrapper, 'wrap');
         text.simulateSelection(null);
 
         expect(text.removeSimulatedSelection).toHaveBeenCalled();
+        expect(wrapper.wrap).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when there is text selected', () => {
+      it('should only remove current fakeSelection', () => {
+        spyOn(text, 'removeSimulatedSelection');
+        spyOn(wrapper, 'wrap');
+        spyOn(text, 'selected').and.returnValue(true);
+
+        text.simulateSelection({});
+
+        expect(text.removeSimulatedSelection).toHaveBeenCalled();
+        expect(wrapper.wrap).not.toHaveBeenCalled();
       });
     });
   });
 
   describe('removeSimulatedSelection', () => {
-    it('should unwrap fake selection and set fakeSelection to null', () => {
+    it('should unwrap fake selection, fakeSelection to null and remove real selection', () => {
       let unwrap = jasmine.createSpy('unwrap');
+      spyOn(text, 'removeSelection');
       text.fakeSelection = {unwrap};
       text.removeSimulatedSelection();
 
+      expect(text.removeSelection).toHaveBeenCalled();
       expect(unwrap).toHaveBeenCalled();
       expect(text.fakeSelection).toBe(null);
     });


### PR DESCRIPTION
solves: #49 
now the fake selection spans are only rendered when the real selection is removed, for instance, when opening the create references panel, so the user can copy the text selected.