### PR TITLE
Prevent save duplicated templates

### DIFF
--- a/app/api/templates/specs/templates.spec.js
+++ b/app/api/templates/specs/templates.spec.js
@@ -150,10 +150,24 @@ describe('templates', () => {
       });
     });
 
+    describe('when the template name exists', () => {
+      it('should return the error', (done) => {
+        let template = {name: 'template_test'};
+        templates.save(template)
+        .then(() => {
+          done.fail('should return an error');
+        })
+        .catch((error) => {
+          expect(error.json).toBe('duplicated_entry');
+          done();
+        });
+      });
+    });
+
     describe('when there is a db error', () => {
       it('should return the error', (done) => {
         spyOn(documents, 'updateMetadataProperties').and.returnValue(new Promise((resolve) => resolve()));
-        let badTemplate = {_id: 'c08ef2532f0bd008ac5174b45e033c93', _rev: 'bad_rev'};
+        let badTemplate = {_id: 'c08ef2532f0bd008ac5174b45e033c93', _rev: 'bad_rev', name: ''};
         templates.save(badTemplate)
         .then(() => {
           done.fail('should return an error');

--- a/app/react/Library/helpers/specs/libraryFilters.spec.js
+++ b/app/react/Library/helpers/specs/libraryFilters.spec.js
@@ -28,10 +28,10 @@ describe('library helper', () => {
         let filters = libraryFilters(templates, documentTypes, thesauris);
         expect(filters)
         .toEqual([
-                  {name: 'country', filter: true, type: 'select', content: 'abc1', options: ['thesauri values']},
-                  {name: 'date', filter: true, type: 'text'},
-                  {name: 'language', filter: true, type: 'text'}
-                ]);
+          {name: 'country', filter: true, type: 'select', content: 'abc1', options: ['thesauri values']},
+          {name: 'date', filter: true, type: 'text'},
+          {name: 'language', filter: true, type: 'text'}
+        ]);
       });
     });
 

--- a/app/react/Router.js
+++ b/app/react/Router.js
@@ -117,7 +117,7 @@ function handleRoute(res, renderProps, req) {
     })
     .catch(console.log);
   }
-  
+
   renderPage();
 }
 

--- a/app/react/Templates/EditTemplate.js
+++ b/app/react/Templates/EditTemplate.js
@@ -5,7 +5,7 @@ import templatesAPI from 'app/Templates/TemplatesAPI';
 import thesaurisAPI from 'app/Thesauris/ThesaurisAPI';
 import TemplateCreator from 'app/Templates/components/TemplateCreator';
 import {setTemplates} from 'app/Templates/actions/templatesActions';
-import {setThesauris} from 'app/Templates/actions/uiActions';
+import {setThesauris} from 'app/Thesauris/actions/thesaurisActions';
 import RouteHandler from 'app/App/RouteHandler';
 import ID from 'shared/uniqueID';
 
@@ -29,17 +29,18 @@ export default class EditTemplate extends RouteHandler {
       let template = Object.assign({}, templates.find((tmpl) => tmpl._id === templateId));
       return {
         template: {
-          data: prepareTemplate(template),
-          uiState: {thesauris, templates}
-        }
+          data: prepareTemplate(template)
+        },
+        thesauris,
+        templates
       };
     });
   }
 
-  setReduxState({template}) {
+  setReduxState({template, thesauris, templates}) {
     this.context.store.dispatch(formActions.load('template.data', template.data));
-    this.context.store.dispatch(setThesauris(template.uiState.thesauris));
-    this.context.store.dispatch(setTemplates(template.uiState.templates));
+    this.context.store.dispatch(setThesauris(thesauris));
+    this.context.store.dispatch(setTemplates(templates));
   }
 
   render() {

--- a/app/react/Templates/NewTemplate.js
+++ b/app/react/Templates/NewTemplate.js
@@ -1,9 +1,8 @@
 import React, {PropTypes} from 'react';
-import Immutable from 'immutable';
 
 import templatesAPI from 'app/Templates/TemplatesAPI';
 import thesaurisAPI from 'app/Thesauris/ThesaurisAPI';
-import {setThesauris} from 'app/Templates/actions/uiActions';
+import {setThesauris} from 'app/Thesauris/actions/thesaurisActions';
 import {setTemplates} from 'app/Templates/actions/templatesActions';
 import TemplateCreator from 'app/Templates/components/TemplateCreator';
 import RouteHandler from 'app/App/RouteHandler';
@@ -16,17 +15,13 @@ export default class NewTemplate extends RouteHandler {
       templatesAPI.get()
     ])
     .then(([thesauris, templates]) => {
-      return {
-        template: {
-          uiState: Immutable.fromJS({thesauris, templates})
-        }
-      };
+      return {thesauris, templates};
     });
   }
 
-  setReduxState({template}) {
-    this.context.store.dispatch(setThesauris(template.uiState.toJS().thesauris));
-    this.context.store.dispatch(setTemplates(template.uiState.toJS().templates));
+  setReduxState({thesauris, templates}) {
+    this.context.store.dispatch(setThesauris(thesauris));
+    this.context.store.dispatch(setTemplates(templates));
   }
 
   render() {

--- a/app/react/Templates/components/FilterSuggestions.js
+++ b/app/react/Templates/components/FilterSuggestions.js
@@ -60,13 +60,13 @@ export class FilterSuggestions extends Component {
   }
 
   getThesauriName(thesauriId) {
-    return this.props.uiState.toJS().thesauris.find((thesauri) => {
+    return this.props.thesauris.toJS().find((thesauri) => {
       return thesauri._id === thesauriId;
     }).name;
   }
 
   filterSuggestions(label, type, content, hasThesauri) {
-    return this.findSameLabelProperties(label, this.props.uiState.toJS().templates)
+    return this.findSameLabelProperties(label, this.props.templates.toJS())
     .map((propertyMatch, index) => {
       let typeConflict = propertyMatch.property.type !== type;
       let contentConflict = propertyMatch.property.content !== content;
@@ -116,13 +116,15 @@ FilterSuggestions.propTypes = {
   type: PropTypes.string,
   filter: PropTypes.any,
   data: PropTypes.object,
-  uiState: PropTypes.object,
+  templates: PropTypes.object,
+  thesauris: PropTypes.object,
   content: PropTypes.string
 };
 
 export function mapStateToProps(state) {
   return {
-    uiState: state.template.uiState,
+    templates: state.templates,
+    thesauris: state.thesauris,
     data: state.template.data
   };
 }

--- a/app/react/Templates/components/MetadataTemplate.js
+++ b/app/react/Templates/components/MetadataTemplate.js
@@ -27,13 +27,22 @@ export class MetadataTemplate extends Component {
               model="template.data"
               onSubmit={this.props.saveTemplate}
               className="metadataTemplate panel-default panel"
-              validators={validator(this.props.properties, this.props.setErrors)}
+              validators={validator(this.props.template.properties, this.props.templates.toJS(), this.props.template._id)}
             >
               <div className="metadataTemplate-heading panel-heading">
                 <div className={nameGroupClass}>
                   <FormField model="template.data.name">
                     <input placeholder="Template name" className="form-control"/>
                   </FormField>
+                  {(() => {
+                    if (this.props.formState.fields.name && this.props.formState.fields.name.errors.duplicated) {
+                      return <div className="validation-error">
+                                <i className="fa fa-exclamation-triangle"></i>
+                                &nbsp;
+                                Duplicated name
+                            </div>;
+                    }
+                  })()}
                 </div>
                 &nbsp;
                 <Link to="/metadata" className="btn btn-default"><i className="fa fa-arrow-left"></i> Back</Link>
@@ -44,13 +53,13 @@ export class MetadataTemplate extends Component {
               </div>
               {connectDropTarget(<ul className="metadataTemplate-list list-group">
                 {(() => {
-                  if (this.props.properties.length === 0) {
+                  if (this.props.template.properties.length === 0) {
                     return <div className="no-properties">
                             <i className="fa fa-clone"></i>Drag properties here to start
                           </div>;
                   }
                 })()}
-                {this.props.properties.map((config, index) => {
+                {this.props.template.properties.map((config, index) => {
                   return <MetadataProperty {...config} key={config.localID} index={index}/>;
                 })}
               </ul>)}
@@ -65,7 +74,8 @@ MetadataTemplate.propTypes = {
   saveTemplate: PropTypes.func,
   savingTemplate: PropTypes.bool,
   setErrors: PropTypes.func,
-  properties: PropTypes.array
+  template: PropTypes.object,
+  templates: PropTypes.object
 };
 
 const target = {
@@ -76,14 +86,14 @@ const target = {
   drop(props, monitor) {
     let item = monitor.getItem();
 
-    let propertyAlreadyAdded = props.properties[item.index];
+    let propertyAlreadyAdded = props.template.properties[item.index];
 
     if (propertyAlreadyAdded) {
       props.inserted(item.index);
       return;
     }
 
-    props.addProperty({label: item.label, type: item.type}, props.properties.length);
+    props.addProperty({label: item.label, type: item.type}, props.template.properties.length);
     return {name: 'container'};
   }
 };
@@ -94,11 +104,12 @@ let dropTarget = DropTarget('METADATA_OPTION', target, (connector) => ({
 
 export {dropTarget};
 
-const mapStateToProps = ({template}) => {
+const mapStateToProps = (state) => {
   return {
-    properties: template.data.properties,
-    savingTemplate: template.uiState.get('savingTemplate'),
-    formState: template.formState
+    template: state.template.data,
+    templates: state.templates,
+    savingTemplate: state.template.uiState.get('savingTemplate'),
+    formState: state.template.formState
   };
 };
 

--- a/app/react/Templates/components/ValidateTemplate.js
+++ b/app/react/Templates/components/ValidateTemplate.js
@@ -1,6 +1,11 @@
-function validateName() {
+function validateName(templates, id) {
   return {
-    required: (val) => val && val.trim() !== ''
+    required: (val) => val && val.trim() !== '',
+    duplicated: (val) => {
+      return !templates.find((template) => {
+        return template._id !== id && template.name.trim().toLowerCase() === val.trim().toLowerCase();
+      });
+    }
   };
 }
 
@@ -11,10 +16,10 @@ export function validateDuplicatedLabel(property, properties) {
   }, true);
 }
 
-export default function (properties) {
+export default function (properties, templates, id) {
   let validator = {
     '': {},
-    name: validateName()
+    name: validateName(templates, id)
   };
 
   properties.forEach((property, index) => {

--- a/app/react/Templates/components/specs/FilterSuggestions.spec.js
+++ b/app/react/Templates/components/specs/FilterSuggestions.spec.js
@@ -38,7 +38,8 @@ describe('FilterSuggestions', () => {
       filter: true,
       content,
       data: {name: 'Current template', _id: 'template1'},
-      uiState: Immutable.fromJS({thesauris, templates})
+      templates: Immutable.fromJS(templates),
+      thesauris: Immutable.fromJS(thesauris)
     };
 
     component = shallow(<FilterSuggestions {...props}/>);

--- a/app/react/Templates/components/specs/MetadataProperty.spec.js
+++ b/app/react/Templates/components/specs/MetadataProperty.spec.js
@@ -33,6 +33,7 @@ function sourceTargetTestContext(Target, Source, actions) {
           connectDragSource: identity,
           isDragging: false,
           uiState: Immutable.fromJS({}),
+          templates: Immutable.fromJS([]),
           formState: {fields: [], errors: {}}
         };
         let sourceProps = {
@@ -42,6 +43,7 @@ function sourceTargetTestContext(Target, Source, actions) {
           connectDragSource: identity,
           isDragging: false,
           uiState: Immutable.fromJS({}),
+          templates: Immutable.fromJS([]),
           formState: {fields: [], errors: {}}
         };
         return <div>
@@ -74,7 +76,8 @@ describe('MetadataProperty', () => {
         formState: {fields: [], errors: {}},
         removeProperty,
         editProperty,
-        uiState: Immutable.fromJS({editingProperty: ''})
+        uiState: Immutable.fromJS({editingProperty: ''}),
+        templates: Immutable.fromJS([])
       };
 
       component = shallow(<MetadataProperty {...props}/>);
@@ -133,6 +136,7 @@ describe('MetadataProperty', () => {
             uiState: Immutable.fromJS({templates: []}),
             formState: {fields: [], errors: {}}
           },
+          templates: Immutable.fromJS([]),
           modals: Immutable.fromJS({})
         };
       });

--- a/app/react/Templates/components/specs/MetadataTemplate.spec.js
+++ b/app/react/Templates/components/specs/MetadataTemplate.spec.js
@@ -19,8 +19,9 @@ function sourceTargetTestContext(Target, Source, actions) {
     class TestContextContainer extends Component {
       render() {
         const identity = x => x;
-        let properties = [{label: 'childTarget', localID: 'childId', inserting: true, type: 'text'}];
-        let targetProps = {properties: properties, connectDropTarget: identity, formState: {fields: {}, errors: {}}};
+        let template = {properties: [{label: 'childTarget', localID: 'childId', inserting: true, type: 'text'}], _id: 1};
+        let templates = Immutable.fromJS([]);
+        let targetProps = {template, templates, connectDropTarget: identity, formState: {fields: {}, errors: {}}};
         let sourceProps = {label: 'source', type: 'type', index: 2, localID: 'source', connectDragSource: identity,
           formState: {fields: {}, errors: {}}};
         return <div>
@@ -38,8 +39,9 @@ describe('MetadataTemplate', () => {
     let formModel = {name: '', properties: properties};
     props.properties = properties;
     let initialData = {
-      template: {data: formModel, uiState: Immutable.fromJS({templates: []})},
+      template: {data: formModel},
       form: {template: {}},
+      templates: Immutable.fromJS({templates: []}),
       modals: Immutable.fromJS({})
     };
     let store = createStore(
@@ -47,8 +49,11 @@ describe('MetadataTemplate', () => {
         combineReducers({
           data: modelReducer('template.data', formModel),
           formState: formReducer('template.data'),
-          uiState: () => initialData.template.uiState
+          uiState: () => {
+            return Immutable.fromJS({editProperty: ''});
+          }
         }),
+        templates: () => Immutable.fromJS([]),
         form: () => initialData.form,
         modals: () => initialData.modals
       }),
@@ -59,25 +64,24 @@ describe('MetadataTemplate', () => {
   }
 
   describe('render()', () => {
+    let props = {template: {properties: []}, connectDropTarget: (x) => x, formState: {fields: {}}, templates: Immutable.fromJS([])};
+
     it('should disable send button when saving the template', () => {
-      let props = {properties: [], connectDropTarget: (x) => x, formState: {fields: {}}};
       let component = shallow(<MetadataTemplate {...props} />);
       expect(component.find('button').props().disabled).toBe(false);
 
-      props = {savingTemplate: true, properties: [], connectDropTarget: (x) => x, formState: {fields: {}}};
+      props.savingTemplate = true;
       component = shallow(<MetadataTemplate {...props} />);
       expect(component.find('button').props().disabled).toBe(true);
     });
 
     it('should render the template name field', () => {
-      let props = {properties: [], connectDropTarget: (x) => x, formState: {fields: {}}};
       let component = shallow(<MetadataTemplate {...props} />);
       expect(component.find(FormField).node.props.model).toBe('template.data.name');
     });
 
     describe('when fields is empty', () => {
       it('should render a blank state', () => {
-        let props = {properties: [], connectDropTarget: (x) => x, formState: {fields: {}}};
         let component = shallow(<MetadataTemplate {...props} />);
         expect(component.find('.no-properties').length).toBe(1);
       });
@@ -85,8 +89,7 @@ describe('MetadataTemplate', () => {
 
     describe('when has fields', () => {
       it('should render all fields as MetadataProperty', () => {
-        let props = {properties: [{label: 'country', type: 'text'}, {label: 'author', type: 'text'}],
-          connectDropTarget: (x) => x, formState: {fields: {}}};
+        props.template.properties = [{label: 'country', type: 'text'}, {label: 'author', type: 'text'}];
         let component = shallow(<MetadataTemplate {...props} />);
         expect(component.find(MetadataProperty).length).toBe(2);
       });

--- a/app/react/Templates/specs/EditTemplate.spec.js
+++ b/app/react/Templates/specs/EditTemplate.spec.js
@@ -42,8 +42,8 @@ describe('EditTemplate', () => {
       EditTemplate.requestState({templateId: 'abc2'})
       .then((response) => {
         expect(response.template.data._id).toEqual('abc2');
-        expect(response.template.uiState.thesauris).toEqual(thesauris);
-        expect(response.template.uiState.templates.length).toBe(2);
+        expect(response.thesauris).toEqual(thesauris);
+        expect(response.templates.length).toBe(2);
         done();
       })
       .catch(done.fail);
@@ -62,7 +62,7 @@ describe('EditTemplate', () => {
   describe('setReduxState()', () => {
     it('should call setTemplates with templates passed', () => {
       spyOn(formActions, 'load').and.returnValue('TEMPLATE MODEL LOADED');
-      instance.setReduxState({template: {data: 'template_data', uiState: {thesauris: 'thesauris', templates: 'templates'}}});
+      instance.setReduxState({template: {data: 'template_data'}, thesauris: 'thesauris', templates: 'templates'});
       expect(formActions.load).toHaveBeenCalledWith('template.data', 'template_data');
       expect(context.store.dispatch).toHaveBeenCalledWith('TEMPLATE MODEL LOADED');
 

--- a/app/react/Templates/specs/NewTemplate.spec.js
+++ b/app/react/Templates/specs/NewTemplate.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Immutable from 'immutable';
 import {shallow} from 'enzyme';
 import backend from 'fetch-mock';
 
@@ -33,9 +32,8 @@ describe('NewTemplate', () => {
     it('should request the thesauris and templates to fit in the state', (done) => {
       NewTemplate.requestState()
       .then((response) => {
-        let state = response.template.uiState.toJS();
-        expect(state.thesauris).toEqual(thesauris);
-        expect(state.templates).toEqual(templates);
+        expect(response.thesauris).toEqual(thesauris);
+        expect(response.templates).toEqual(templates);
         done();
       })
       .catch(done.fail);
@@ -44,7 +42,7 @@ describe('NewTemplate', () => {
 
   describe('setReduxState()', () => {
     it('should call setThesauri with thesauri passed', () => {
-      instance.setReduxState({template: {uiState: Immutable.fromJS({thesauris: 'thesauris', templates: 'templates'})}});
+      instance.setReduxState({thesauris: 'thesauris', templates: 'templates'});
       expect(context.store.dispatch).toHaveBeenCalledWith({type: 'SET_THESAURIS', thesauris: 'thesauris'});
       expect(context.store.dispatch).toHaveBeenCalledWith({type: 'SET_TEMPLATES', templates: 'templates'});
     });

--- a/app/react/Thesauris/actions/specs/thesaurisActions.spec.js
+++ b/app/react/Thesauris/actions/specs/thesaurisActions.spec.js
@@ -12,7 +12,7 @@ describe('thesaurisActions', () => {
       let dispatch = jasmine.createSpy('dispatch');
       spyOn(formActions, 'load');
       actions.editThesauri(thesauri)(dispatch);
-    
+
       expect(formActions.load).toHaveBeenCalledWith('thesauri.data', thesauri);
     });
   });

--- a/app/react/Viewer/specs/referencesAPI.spec.js
+++ b/app/react/Viewer/specs/referencesAPI.spec.js
@@ -9,7 +9,7 @@ describe('referencesAPI', () => {
     backend.restore();
     backend
     .mock(APIURL + 'references?sourceDocument=sourceDocument', 'GET', {body: JSON.stringify({rows: arrayResponse})})
-    .mock(APIURL + 'references/count_by_relationtype?relationtypeId=abc1', 'GET', {body: "2"})
+    .mock(APIURL + 'references/count_by_relationtype?relationtypeId=abc1', 'GET', {body: '2'})
     .mock(APIURL + 'references?_id=id', 'DELETE', {body: JSON.stringify({backednResponse: 'testdelete'})})
     .mock(APIURL + 'references', 'POST', {body: JSON.stringify({backednResponse: 'test'})});
   });


### PR DESCRIPTION
Now backend returns an error when trying to save a template with a name that already exists, and client side validation

Solves #44 