### PR TITLE
Returning empty object when there is no settings on the DB

### DIFF
--- a/app/api/settings/settings.js
+++ b/app/api/settings/settings.js
@@ -5,7 +5,11 @@ export default {
   get() {
     return request.get(`${dbUrl}/_design/settings/_view/all`)
     .then((result) => {
-      return result.json.rows[0].value;
+      if (result.json.rows.length) {
+        return result.json.rows[0].value;
+      }
+
+      return {};
     });
   },
 

--- a/app/api/settings/specs/settings.spec.js
+++ b/app/api/settings/specs/settings.spec.js
@@ -22,7 +22,7 @@ describe('settings', () => {
     });
 
     describe('if there is no settings on the DB', () => {
-      it('should return an empy object', (done) => {
+      it('should return an empty object', (done) => {
         database.reset_testing_database()
         .then(() => database.import({}))
         .then(() => settings.get())

--- a/app/api/settings/specs/settings.spec.js
+++ b/app/api/settings/specs/settings.spec.js
@@ -3,7 +3,7 @@ import database from 'api/utils/database.js';
 import fixtures from './fixtures.js';
 import {catchErrors} from 'api/utils/jasmineHelpers';
 
-describe('relationtypes', () => {
+describe('settings', () => {
 
   beforeEach((done) => {
     database.reset_testing_database()
@@ -19,6 +19,18 @@ describe('relationtypes', () => {
         expect(result.site_name).toBe('Uwazi');
         done();
       }).catch(catchErrors(done));
+    });
+
+    describe('if there is no settings on the DB', () => {
+      it('should return an empy object', (done) => {
+        database.reset_testing_database()
+        .then(() => database.import({}))
+        .then(() => settings.get())
+        .then((result) => {
+          expect(result).toEqual({});
+          done();
+        }).catch(catchErrors(done));
+      });
     });
   });
 


### PR DESCRIPTION
When there is no settings in the DB, the model returns an empty object to prevent errors