### PR TITLE
Document renders font styles

### DIFF
--- a/app/react/Viewer/components/Document.js
+++ b/app/react/Viewer/components/Document.js
@@ -81,6 +81,7 @@ export class Document extends Component {
           </div>
         </div>
         <style type="text/css" dangerouslySetInnerHTML={{__html: docHTML.css}}></style>
+        <style type="text/css" dangerouslySetInnerHTML={{__html: docHTML.fonts}}></style>
       </div>
     );
   }


### PR DESCRIPTION
Fixes issue #31 
Fonts are actually converting right when running on linux (on mac the conversions produce large font files, like 1mb or more per font). this task includes generating new fixtures with properly converted documents.

PR check list:

- [x] Client test
- [x] Server test
- [x] End-to-end test
- [x] Pass code linter to client and server
- [x] Database views added ?

QA check list:

- [x] Smoke test the functionality described in the issue
- [x] Smoke test potential collaterals
- [x] UI responsiveness
- [x] Tested in a browser other than chrome
- [x] Code review ?

NOTE: Make sure the build passes.

