### PR TITLE
when metadata thesauri does not match any value, the ui shows blank a…

### DIFF
--- a/app/react/Documents/helpers.js
+++ b/app/react/Documents/helpers.js
@@ -11,9 +11,14 @@ export default {
     let metadata = template.properties.map((property) => {
       let value = doc.metadata[property.name];
       if (property.type === 'select' && value) {
-        value = thesauris.find(t => t._id === property.content).values.find(v => {
+        let thesauri = thesauris.find(t => t._id === property.content).values.find(v => {
           return v.id.toString() === value.toString();
-        }).label;
+        });
+
+        value = '';
+        if (thesauri) {
+          value = thesauri.label;
+        }
       }
 
       if (property.type === 'date' && value) {

--- a/app/react/Documents/specs/helpers.spec.js
+++ b/app/react/Documents/specs/helpers.spec.js
@@ -8,6 +8,7 @@ describe('document helpers', () => {
     {_id: '2', name: 'template name', properties: [
       {name: 'author', type: 'text', label: 'authorLabel'},
       {name: 'country', type: 'select', content: 'abc1', label: 'countryLabel'},
+      {name: 'badThesauri', type: 'select', content: 'abc1', label: 'badThesauri'},
       {name: 'language', type: 'text', label: 'languageLabel'},
       {name: 'date', type: 'date', label: 'dateLabel'}
     ]},
@@ -22,6 +23,7 @@ describe('document helpers', () => {
   let doc = {title: 'doc title', template: '2', metadata: {
     author: 'authorValue',
     country: 'thesauriId',
+    badThesauri: 'bad',
     language: 'languageValue',
     date: '1469729080'
   }};
@@ -35,6 +37,7 @@ describe('document helpers', () => {
         metadata: [
           {label: 'authorLabel', value: 'authorValue'},
           {label: 'countryLabel', value: 'countryValue'},
+          {label: 'badThesauri', value: ''},
           {label: 'languageLabel', value: 'languageValue'},
           {label: 'dateLabel', value: 'Jul 28, 2016'}
         ]


### PR DESCRIPTION
Fixes issue #271

PR check list:

- [x] Client test
- [x] Server test
- [x] End-to-end test
- [x] Pass code linter to client and server
- [ ] Database views added ?

QA check list:

- [x] Smoke test the functionality described in the issue
- [x] Smoke test potential collaterals
- [ ] UI responsiveness
- [ ] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.

…nd do not throw any error