### PR TITLE
ThesaurisForm now does not render if the thesauri is not yet loaded to prevent bad validations

### DIFF
--- a/app/react/Thesauris/NewThesauri.js
+++ b/app/react/Thesauris/NewThesauri.js
@@ -19,6 +19,6 @@ export default class NewThesauri extends RouteHandler {
   }
 
   render() {
-    return <ThesauriForm />;
+    return <ThesauriForm new={true} />;
   }
 }

--- a/app/react/Thesauris/components/ThesauriForm.js
+++ b/app/react/Thesauris/components/ThesauriForm.js
@@ -95,7 +95,8 @@ ThesauriForm.propTypes = {
   removeValue: PropTypes.func,
   thesauris: PropTypes.object,
   thesauri: PropTypes.object,
-  state: PropTypes.object
+  state: PropTypes.object,
+  new: PropTypes.bool
 };
 
 export function mapStateToProps(state) {

--- a/app/react/Thesauris/components/ThesauriForm.js
+++ b/app/react/Thesauris/components/ThesauriForm.js
@@ -17,7 +17,6 @@ export class ThesauriForm extends Component {
   validation(thesauris, id) {
     return {
       name: {
-        required: (val) => val.trim() !== '',
         duplicated: (val) => {
           return !thesauris.find((thesauri) => {
             return thesauri._id !== id && thesauri.name.trim().toLowerCase() === val.trim().toLowerCase();
@@ -28,6 +27,12 @@ export class ThesauriForm extends Component {
   }
 
   render() {
+    let isNew = this.props.new;
+    let id = this.props.thesauri._id;
+    if (!isNew && !id) {
+      return false;
+    }
+
     return (
       <div className="row thesauri">
           <Form
@@ -102,7 +107,7 @@ export function mapStateToProps(state) {
 }
 
 function bindActions(dispatch) {
-  return bindActionCreators({saveThesauri, addValue, removeValue, resetForm: formActions.reset}, dispatch);
+  return bindActionCreators({saveThesauri, addValue, removeValue, resetForm: formActions.reset, validate: formActions.validate}, dispatch);
 }
 
 let form = connect(mapStateToProps, bindActions)(ThesauriForm);

--- a/app/react/Thesauris/specs/NewThesauri.spec.js
+++ b/app/react/Thesauris/specs/NewThesauri.spec.js
@@ -6,7 +6,7 @@ import NewThesauri from 'app/Thesauris/NewThesauri';
 import ThesauriForm from 'app/Thesauris/components/ThesauriForm';
 import {APIURL} from 'app/config.js';
 
-describe('NewThesauri', () => {
+fdescribe('NewThesauri', () => {
   let component;
   let instance;
   let context;
@@ -22,8 +22,9 @@ describe('NewThesauri', () => {
     .mock(APIURL + 'thesauris', 'GET', {body: JSON.stringify({rows: thesauris})});
   });
 
-  it('should render a ThesauriForm', () => {
+  it('should render a ThesauriForm with new=true', () => {
     expect(component.find(ThesauriForm).length).toBe(1);
+    expect(component.find(ThesauriForm).props().new).toBe(true);
   });
 
   describe('static requestState()', () => {

--- a/app/react/Thesauris/specs/NewThesauri.spec.js
+++ b/app/react/Thesauris/specs/NewThesauri.spec.js
@@ -6,7 +6,7 @@ import NewThesauri from 'app/Thesauris/NewThesauri';
 import ThesauriForm from 'app/Thesauris/components/ThesauriForm';
 import {APIURL} from 'app/config.js';
 
-fdescribe('NewThesauri', () => {
+describe('NewThesauri', () => {
   let component;
   let instance;
   let context;


### PR DESCRIPTION
Fixes issue #274 

PR check list:

- [x] Client test
- [x] Server test
- [ ] End-to-end test
- [x] Pass code linter to client and server
- [ ] Database views added ?

QA check list:

- [x] Smoke test the functionality described in the issue
- [x] Smoke test potential collaterals
- [ ] UI responsiveness
- [ ] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.

…o prevent bad validations