### PR TITLE
Reset button in filters form now also resets the search input

### DIFF
--- a/app/react/Library/actions/filterActions.js
+++ b/app/react/Library/actions/filterActions.js
@@ -59,7 +59,8 @@ export function filterDocumentTypes(documentTypes) {
 
 export function resetFilters() {
   return function (dispatch, getState) {
-    dispatch(formActions.change('search.filters', {}));
+    dispatch(formActions.reset('search'));
+    dispatch(formActions.setInitial('search'));
     dispatch({type: types.SET_LIBRARY_FILTERS, documentTypes: [], libraryFilters: []});
     libraryActions.searchDocuments(getState().search)(dispatch, getState);
   };

--- a/app/react/Library/actions/specs/filterActions.spec.js
+++ b/app/react/Library/actions/specs/filterActions.spec.js
@@ -38,6 +38,8 @@ describe('filterActions', () => {
     spyOn(libraryHelper, 'populateOptions').and.returnValue(libraryFilters);
     dispatch = jasmine.createSpy('dispatch');
     spyOn(formActions, 'change').and.returnValue('FILTERS_UPDATED');
+    spyOn(formActions, 'reset').and.returnValue('FILTERS_RESET');
+    spyOn(formActions, 'setInitial').and.returnValue('FILTERS_SET_INITIAL');
     getState = jasmine.createSpy('getState').and.returnValue(store);
   });
 
@@ -84,8 +86,10 @@ describe('filterActions', () => {
   describe('resetFilters', () => {
     it('should set all filters to an empty string', () => {
       actions.resetFilters()(dispatch, getState);
-      expect(formActions.change).toHaveBeenCalledWith('search.filters', {});
-      expect(dispatch).toHaveBeenCalledWith('FILTERS_UPDATED');
+      expect(formActions.reset).toHaveBeenCalledWith('search');
+      expect(formActions.setInitial).toHaveBeenCalledWith('search');
+      expect(dispatch).toHaveBeenCalledWith('FILTERS_RESET');
+      expect(dispatch).toHaveBeenCalledWith('FILTERS_SET_INITIAL');
     });
 
     it('should deactivate all the properties and documentTypes', () => {


### PR DESCRIPTION
Fixes issue #723 

PR check list:

- [x] Client test
- [x] Server test
- [x] End-to-end test
- [x] Pass code linter to client and server
- [ ] Database views added ?

QA check list:

- [ ] Smoke test the functionality described in the issue
- [ ] Smoke test potential collaterals
- [ ] UI responsiveness
- [ ] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.
