### PR TITLE
Fix app top padding

### DIFF
--- a/app/react/App/scss/fixes.scss
+++ b/app/react/App/scss/fixes.scss
@@ -2,14 +2,6 @@
 @import "../../App/scss/config/_materials.scss";
 @import "../../App/scss/config/_typography.scss";
 
-#app {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  padding-top: 54px;
-  overflow: hidden;
-}
-
 header {
   width: 100%;
 }

--- a/app/react/App/scss/layout/_app.scss
+++ b/app/react/App/scss/layout/_app.scss
@@ -1,0 +1,9 @@
+#app {
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 100vh;
+  padding-top: $header-height;
+  overflow: hidden;
+}

--- a/app/react/App/scss/styles.scss
+++ b/app/react/App/scss/styles.scss
@@ -13,6 +13,7 @@
 @import "elements/draggable";
 @import "elements/dropdown";
 
+@import "layout/app";
 @import "layout/header";
 @import "layout/content";
 @import "layout/footer";


### PR DESCRIPTION
The `#app` padding-top wasn't aligned with the header:

![screen shot 2017-02-15 at 19 13 24](https://cloud.githubusercontent.com/assets/6364153/22988572/df1e87b4-f3b2-11e6-8702-573b7d91d6d2.png)

PR check list:

- [x] Client test
- [ ] Server test
- [ ] End-to-end test
- [x] Pass code linter to client and server
- [ ] Database views added ?

QA check list:

- [ ] Smoke test the functionality described in the issue
- [ ] Smoke test potential collaterals
- [x] UI responsiveness
- [x] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.
