### PR TITLE
Fix edit-metadata font

### DIFF
--- a/app/react/App/scss/modules/_search.scss
+++ b/app/react/App/scss/modules/_search.scss
@@ -261,7 +261,7 @@
     width: 100%;
     font-weight: 300;
     font-style: normal;
-    font-family: $f-mono;
+    font-family: $f-special;
     margin-bottom: 0;
     color: $c-grey-dark;
     line-height: inherit;


### PR DESCRIPTION
**hotfix** When editing metadata, the font-family for titles differs from the viewing metadata ones.

PR check list:

- [ ] Client test
- [ ] Server test
- [ ] End-to-end test
- [ ] Pass code linter to client and server
- [ ] Database views added ?
- [ ] Update READ.me ?

QA check list:

- [ ] Smoke test the functionality described in the issue
- [ ] Smoke test potential collaterals
- [ ] UI responsiveness
- [ ] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.
