### PR TITLE
Improve api error handling

### DIFF
--- a/app/api/entities/routes.js
+++ b/app/api/entities/routes.js
@@ -16,9 +16,7 @@ export default (app) => {
     .then((templateTransformed) => {
       req.io.sockets.emit('thesauriChange', templateTransformed);
     })
-    .catch(error => {
-      res.json({error});
-    });
+    .catch(res.error);
   });
 
   app.post('/api/entities/multipleupdate', needsAuthorization, (req, res) => {
@@ -26,38 +24,36 @@ export default (app) => {
     .then(docs => {
       res.json(docs.map((doc) => doc.sharedId));
     })
-    .catch(error => {
-      res.json({error});
-    });
+    .catch(res.error);
   });
 
   app.get('/api/entities/count_by_template', (req, res) => {
     return entities.countByTemplate(req.query.templateId)
     .then(response => res.json(response))
-    .catch(error => res.json({error}));
+    .catch(res.error);
   });
 
   app.get('/api/entities/uploads', needsAuthorization, (req, res) => {
     entities.getUploadsByUser(req.user)
     .then(response => res.json(response))
-    .catch(error => res.json({error}));
+    .catch(res.error);
   });
 
   app.get('/api/entities', (req, res) => {
     entities.getById(req.query._id, req.language)
     .then(response => res.json({rows: [response]}))
-    .catch(error => res.json({error}));
+    .catch(res.error);
   });
 
   app.delete('/api/entities', needsAuthorization, (req, res) => {
     entities.delete(req.query.sharedId)
     .then(response => res.json(response))
-    .catch(error => res.json({error}));
+    .catch(res.error);
   });
 
   app.delete('/api/entities/multiple', needsAuthorization, (req, res) => {
     entities.deleteMultiple(JSON.parse(req.query.sharedIds))
     .then(response => res.json(response))
-    .catch(error => res.json({error}));
+    .catch(res.error);
   });
 };

--- a/app/api/utils/error_handling_middleware.js
+++ b/app/api/utils/error_handling_middleware.js
@@ -1,0 +1,16 @@
+export default function (req, res, next) {
+  res.error = function (error) {
+    let result = error;
+    if (error instanceof Error) {
+      result = error.stack.split('\n');
+    }
+
+    if (error.code) {
+      result = error.message;
+    }
+
+    res.status(error.code || 500);
+    res.json({error: result});
+  };
+  next();
+}

--- a/app/api/utils/instrumentRoutes.js
+++ b/app/api/utils/instrumentRoutes.js
@@ -21,6 +21,9 @@ let executeRoute = (method, routePath, req = {}, res, app) => {
       resolve(response);
     });
 
+    res.error = (error) => {
+      res.json({error});
+    };
 
     if (!args[1]) {
       return reject('route function has not been defined !');

--- a/app/api/utils/specs/error_handling_middleware.spec.js
+++ b/app/api/utils/specs/error_handling_middleware.spec.js
@@ -1,0 +1,37 @@
+import middleware from '../error_handling_middleware.js';
+
+describe('Error handling middleware', function () {
+  let next;
+  let res;
+  const req = {};
+
+  beforeEach(() => {
+    next = jasmine.createSpy('next');
+    res = {json: jasmine.createSpy('json'), status: jasmine.createSpy('status')};
+  });
+
+  it('should call next', () => {
+    middleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  describe('when error is instanceof Error (unhandled)', () => {
+    it('should respond the error stack trace splited', () => {
+      middleware(req, res, next);
+      const error = new Error('error');
+      res.error(error);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({error: error.stack.split('\n')});
+    });
+  });
+
+  describe('when error is uwazi error (handled object with message and code)', () => {
+    it('should respond the error message with the status', () => {
+      middleware(req, res, next);
+      const error = {message: 'error', code: 'code'};
+      res.error(error);
+      expect(res.status).toHaveBeenCalledWith('code');
+      expect(res.json).toHaveBeenCalledWith({error: 'error'});
+    });
+  });
+});

--- a/server.js
+++ b/server.js
@@ -11,7 +11,9 @@ var path = require('path');
 var compression = require('compression');
 const app = express();
 var http = require('http').Server(app);
+var error_handling_middleware = require('./app/api/utils/error_handling_middleware.js');
 
+app.use(error_handling_middleware);
 app.use(compression());
 app.use(express.static(path.resolve(__dirname, 'dist')));
 app.use('/uploaded_documents', express.static(path.resolve(__dirname, 'uploaded_documents')));


### PR DESCRIPTION
added error method to response object to use it on routes, the idea is to have the error handling centralized so we can decide later what we will do with different errors, now it responds with error to the client,  formatting correctly if its an unhandled error or a handled one.

PR check list:

- [x] Client test
- [x] Server test
- [x] End-to-end test
- [x] Pass code linter to client and server
- [ ] Database views added ?
- [ ] Update READ.me ?

QA check list:

- [ ] Smoke test the functionality described in the issue
- [ ] Smoke test potential collaterals
- [ ] UI responsiveness
- [ ] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.
