### PR TITLE
FilterSuggestions do not throw an error when thesauri no longer exists

### DIFF
--- a/app/react/Templates/components/FilterSuggestions.js
+++ b/app/react/Templates/components/FilterSuggestions.js
@@ -56,9 +56,11 @@ export class FilterSuggestions extends Component {
   }
 
   getThesauriName(thesauriId) {
-    return this.props.thesauris.toJS().find((thesauri) => {
+    let _thesauri = this.props.thesauris.toJS().find((thesauri) => {
       return thesauri._id === thesauriId;
-    }).name;
+    }) || {};
+
+    return _thesauri.name;
   }
 
   filterSuggestions(label, type, content, hasThesauri) {

--- a/app/react/Templates/components/specs/FilterSuggestions.spec.js
+++ b/app/react/Templates/components/specs/FilterSuggestions.spec.js
@@ -78,4 +78,13 @@ describe('FilterSuggestions', () => {
       .toBe('Best SCI FI Authors');
     });
   });
+
+  describe('when content does not match with a thesauri (happening when opening property and the dictionary has been deleted)', () => {
+    it('should not show anything', () => {
+      renderComponent('authors', 'select', 'non existent thesauri');
+      let suggestion = component.find('tbody > tr').at(1);
+      expect(suggestion.text().trim())
+      .toBe('Template 2 Select Best SCI FI Authors');
+    });
+  });
 });


### PR DESCRIPTION
Fixes issue #995 

PR check list:

- [x] Client test
- [x] Server test
- [x] End-to-end test
- [x] Pass code linter to client and server
- [ ] Database views added ?
- [ ] Update READ.me ?

QA check list:

- [ ] Smoke test the functionality described in the issue
- [ ] Smoke test potential collaterals
- [ ] UI responsiveness
- [ ] Tested in a browser other than chrome
- [ ] Code review ?

NOTE: Make sure the build passes.
