### PR TITLE
Emptying a date filter  no longer sends a filter with a null as value

### DIFF
--- a/app/react/Forms/components/DatePicker.js
+++ b/app/react/Forms/components/DatePicker.js
@@ -17,6 +17,7 @@ export default class DatePicker extends Component {
   componentWillReceiveProps(newProps) {
     if (newProps.value) {
       this.setState({value: moment.utc(newProps.value, 'X')});
+      return;
     }
   }
 

--- a/app/react/Library/actions/libraryActions.js
+++ b/app/react/Library/actions/libraryActions.js
@@ -102,8 +102,9 @@ export function filterIsEmpty(value) {
     return true;
   }
 
-  if (typeof value === 'object' && !Object.keys(value).length) {
-    return true;
+  if (typeof value === 'object') {
+    const hasValue = Object.keys(value).reduce((result, key) => result || Boolean(value[key]), false);
+    return !hasValue;
   }
 
   return false;

--- a/app/react/Library/actions/specs/libraryActions.spec.js
+++ b/app/react/Library/actions/specs/libraryActions.spec.js
@@ -164,10 +164,11 @@ describe('libraryActions', () => {
           searchTerm: 'batman',
           filters: {
             author: 'batman',
-            date: 'dateValue',
+            date: {from: null},
             select: 'selectValue',
             multiselect: {values: []},
-            nested: 'nestedValue'
+            nested: 'nestedValue',
+            object: {}
           }
         };
 
@@ -179,7 +180,7 @@ describe('libraryActions', () => {
         actions.searchDocuments({search, filters}, storeKey, limit)(dispatch, getState);
 
         expect(getState).not.toHaveBeenCalled();
-        expect(browserHistory.push).toHaveBeenCalledWith(`/library/?view=chart&q=(filters:(author:batman,date:dateValue,nested:nestedValue,select:selectValue),limit:limit,searchTerm:batman,types:!(decision))`); //eslint-disable-line
+        expect(browserHistory.push).toHaveBeenCalledWith(`/library/?view=chart&q=(filters:(author:batman,nested:nestedValue,select:selectValue),limit:limit,searchTerm:batman,types:!(decision))`); //eslint-disable-line
       });
 
       it('should set the storeKey selectedSorting if user has selected a custom sorting', () => {


### PR DESCRIPTION
Fixes issue #1288 

PR check list:

- [x] Rebase current DEV branch
- [x] Client test
- [x] Server test
- [x] End-to-end test
- [x] Pass code linter to client and server
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA check list:

- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review

NOTE: Make sure the build passes.
