### PR TITLE
Inline translation button is now always available

### DIFF
--- a/app/react/I18N/components/I18NMenu.js
+++ b/app/react/I18N/components/I18NMenu.js
@@ -30,6 +30,19 @@ export class I18NMenu extends Component {
     this.setState({ open: !this.state.open });
   }
 
+  inlineEditButton() {
+    return (
+      <NeedAuthorization roles={['admin', 'editor']}>
+        <button
+          className={this.props.i18nmode ? 'inlineEdit menuNav-btn btn btn-default active' : 'menuNav-btn btn btn-default'}
+          onClick={this.props.toggleInlineEdit}
+        >
+          <Icon icon="language" size="lg" />
+        </button>
+      </NeedAuthorization>
+    );
+  }
+
   render() {
     const languages = this.props.languages.toJS();
     let path = this.props.location.pathname;
@@ -39,19 +52,16 @@ export class I18NMenu extends Component {
     path = path.replace(regexp, '/');
 
     if (languages.length <= 1) {
-      return false;
+      return (
+        <ul className="menuNav-I18NMenu">
+          {this.inlineEditButton()}
+        </ul>
+      );
     }
 
     return (
       <ul className="menuNav-I18NMenu">
-        <NeedAuthorization roles={['admin', 'editor']}>
-          <button
-            className={this.props.i18nmode ? 'inlineEdit menuNav-btn btn btn-default active' : 'menuNav-btn btn btn-default'}
-            onClick={this.props.toggleInlineEdit}
-          >
-            <Icon icon="language" size="lg" />
-          </button>
-        </NeedAuthorization>
+        {this.inlineEditButton()}
         {(() => languages.map((lang) => {
             const url = `/${lang.key}${path}${path.match('document') ? '' : this.props.location.search}`;
             return (

--- a/app/react/I18N/components/specs/I18NMenu.spec.js
+++ b/app/react/I18N/components/specs/I18NMenu.spec.js
@@ -100,4 +100,12 @@ describe('I18NMenu', () => {
       expect(Cookie.set).toHaveBeenCalledWith('locale', 'en', { expires: 3650 });
     });
   });
+
+  describe('when there is only one language', () => {
+    it('should only render the inline translation button', () => {
+      props.languages = Immutable.fromJS([{ key: 'en', label: 'English', default: true }]);
+      render();
+      expect(component).toMatchSnapshot();
+    });
+  });
 });

--- a/app/react/I18N/components/specs/__snapshots__/I18NMenu.spec.js.snap
+++ b/app/react/I18N/components/specs/__snapshots__/I18NMenu.spec.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`I18NMenu when there is only one language should only render the inline translation button 1`] = `
+<ul
+  className="menuNav-I18NMenu"
+>
+  <Connect(NeedAuthorization)
+    roles={
+      Array [
+        "admin",
+        "editor",
+      ]
+    }
+  >
+    <button
+      className="menuNav-btn btn btn-default"
+      onClick={[Function]}
+    >
+      <Component
+        icon="language"
+        size="lg"
+      />
+    </button>
+  </Connect(NeedAuthorization)>
+</ul>
+`;


### PR DESCRIPTION
Fixes issue #1841 

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
