### PR TITLE
Throw 404 error when downloading an attachment file that doesn't exist

### DIFF
--- a/app/api/attachments/routes.js
+++ b/app/api/attachments/routes.js
@@ -69,6 +69,9 @@ export default (app) => {
         throw createError('entitiy does not exist', 404);
       }
       const file = response.attachments.find(a => a.filename === req.query.file);
+      if (!file) {
+        throw createError('file not found', 404);
+      }
       const newName = path.basename(file.originalname, path.extname(file.originalname)) + path.extname(file.filename);
       res.download(path.join(attachmentsPath, file.filename), sanitize(newName));
     })

--- a/app/api/attachments/specs/routes.spec.js
+++ b/app/api/attachments/specs/routes.spec.js
@@ -50,6 +50,16 @@ describe('Attachments Routes', () => {
   });
 
   describe('/download', () => {
+    function expect404Error(req, res, done) {
+      routes.get('/api/attachments/download', req, res)
+      .then(() => {
+        done.fail('should fail');
+      })
+      .catch((error) => {
+        expect(error.code).toBe(404);
+        done();
+      });
+    }
     it('should download the document with the title as file name (replacing extension with file ext)', (done) => {
       const req = { query: { _id: entityId, file: 'match.doc' } };
       const res = {};
@@ -74,14 +84,7 @@ describe('Attachments Routes', () => {
       const res = {};
       paths.attachmentsPath = `${__dirname}/uploads`;
 
-      routes.get('/api/attachments/download', req, res)
-      .then(() => {
-        done.fail('should fail when entity does not exists');
-      })
-      .catch((error) => {
-        expect(error.code).toBe(404);
-        done();
-      });
+      expect404Error(req, res, done);
     });
 
     it('should fail when attachment does not exist', (done) => {
@@ -89,14 +92,7 @@ describe('Attachments Routes', () => {
       const res = {};
       paths.attachmentsPath = `${__dirname}/uploads`;
 
-      routes.get('/api/attachments/download', req, res)
-      .then(() => {
-        done.fail('should fail when attachment does not exist');
-      })
-      .catch((error) => {
-        expect(error.code).toBe(404);
-        done();
-      });
+      expect404Error(req, res, done);
     });
   });
 

--- a/app/api/attachments/specs/routes.spec.js
+++ b/app/api/attachments/specs/routes.spec.js
@@ -83,6 +83,21 @@ describe('Attachments Routes', () => {
         done();
       });
     });
+
+    it('should fail when attachment does not exist', (done) => {
+      const req = { query: { _id: entityId, file: 'nonExisting.doc' } };
+      const res = {};
+      paths.attachmentsPath = `${__dirname}/uploads`;
+
+      routes.get('/api/attachments/download', req, res)
+      .then(() => {
+        done.fail('should fail when attachment does not exist');
+      })
+      .catch((error) => {
+        expect(error.code).toBe(404);
+        done();
+      });
+    });
   });
 
   describe('/upload', () => {


### PR DESCRIPTION
Fixes issue #1995 

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
