### PR TITLE
utils delete files ignores error when its a file not found

### DIFF
--- a/app/api/utils/files.js
+++ b/app/api/utils/files.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 function deleteFile(file) {
   return new Promise((resolve, reject) => {
     fs.unlink(file, (err) => {
-      if (err) {
+      if (err && err.code !== 'ENOENT') {
         reject(err);
       }
       resolve();
@@ -12,7 +12,7 @@ function deleteFile(file) {
 }
 
 function deleteFiles(files) {
-  return Promise.all(files.map((file) => deleteFile(file)));
+  return Promise.all(files.map(file => deleteFile(file)));
 }
 
-export {deleteFiles, deleteFile};
+export { deleteFiles, deleteFile };

--- a/app/api/utils/specs/files.spec.js
+++ b/app/api/utils/specs/files.spec.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import { deleteFiles } from '../files';
+
+describe('files', () => {
+  beforeEach(() => {
+    fs.writeFileSync(`${__dirname}/file1`);
+    fs.writeFileSync(`${__dirname}/file2`);
+  });
+
+  describe('deleteFiles', () => {
+    it('should delete all files passed', async () => {
+      await deleteFiles([`${__dirname}/file1`, `${__dirname}/file2`]);
+      expect(fs.existsSync(`${__dirname}/file1`)).toBe(false);
+      expect(fs.existsSync(`${__dirname}/file2`)).toBe(false);
+    });
+
+    it('should not fail when trying to delete a non existent file', async () => {
+      await deleteFiles([`${__dirname}/file0`, `${__dirname}/file1`, `${__dirname}/file2`]);
+      expect(fs.existsSync(`${__dirname}/file1`)).toBe(false);
+      expect(fs.existsSync(`${__dirname}/file2`)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes issue #1968 

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
