### PR TITLE
Naive implementation of opportunistic OCR

### DIFF
--- a/app/api/upload/PDF.js
+++ b/app/api/upload/PDF.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { spawn } from 'child-process-promise';
 import errorLog from 'api/log/errorLog';
+import debugLog from 'api/log/debugLog';
 
 export default class PDF extends EventEmitter {
   constructor(filepath) {
@@ -15,9 +16,37 @@ export default class PDF extends EventEmitter {
     return path.join(path.dirname(this.filepath), documentId);
   }
 
+  async attemptOcr() {
+    try {
+      // check that both tesseract and convert exist system-wide
+      const res1 = await spawn('tesseract', ['--version'], { capture: ['stdout', 'stderr'] });
+      debugLog.debug(res1.stdout);
+      const res2 = await spawn('convert', ['--version'], { capture: ['stdout', 'stderr'] });
+      debugLog.debug(res1.stdout);
+      debugLog.debug('Tesseract and imagemagick found, continuing with OCR processing');
+
+      // convert PDF to TIFF first
+      await spawn('convert', ['-density', '300', this.filepath, '-depth', '8',
+        '-strip', '-background', 'white', '-alpha', 'off', '/tmp/tmp.tiff']);
+      // run OCR
+      const res = await spawn('tesseract', ['/tmp/tmp.tiff', '-', '-c', 'debug_file=/dev/null', '-l', 'eng'], { capture: ['stdout', 'stderr'] });
+      return result.stdout.split('\f').slice(0, -1);
+    } catch (e) {
+      if (e.errno === 'ENOENT') {
+        debugLog.debug('Tesseract not found, skipping OCR processing');
+      }
+      return null;
+    };
+
+  }
+
   async extractText() {
-    const result = await spawn('pdftotext', [this.filepath, '-'], { capture: ['stdout', 'stderr'] });
-    const pages = result.stdout.split('\f').slice(0, -1);
+    let pages = await this.attemptOcr();
+    if (pages === null) {
+      const result = await spawn('pdftotext', [this.filepath, '-'], { capture: ['stdout', 'stderr'] });
+      pages = result.stdout.split('\f').slice(0, -1);
+    }
+
     return {
       fullText: pages.reduce((memo, page, index) => ({ ...memo, [index + 1]: page.replace(/(\S+)(\s?)/g, `$1[[${index + 1}]]$2`) }), {}),
       totalPages: pages.length


### PR DESCRIPTION
This PR is a work in progress that attemps to provide OCR processing for incoming PDF files, under the assumption that `tesseract` and `imagemagick` are installed system-wide.

Some initial thoughts / questions:
- Should OCR happen upon file upload? This might be a time consuming process.
- Should intermediate TIFF file be placed in `/tmp` (which is usually a `tmpfs` in-memory filesystem? Note that it can grow quite large in case of large input files.
- Where would be the best place to do sanity tests for the existance of tesseract and imagemagick? (Preferably one time during startup or during first OCR invocation)
- Are we comfortable with directly spawning the processes as implemented?
- Are there any UI considerations?
- Should OCR always take precedence over `pdftotext`?
- ImageMagick might not be the best tool, given that it is considered unsecure for processing PDFs (https://bugs.archlinux.org/task/60580)

Would love to hear thoughts on how to proceed.

<hr>

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
