### PR TITLE
do not duplicate values when value has already a blank space on db

### DIFF
--- a/app/api/csv/specs/fixtures.js
+++ b/app/api/csv/specs/fixtures.js
@@ -46,7 +46,10 @@ export default {
     {
       _id: thesauri1Id,
       name: 'thesauri1',
-      values: [],
+      values: [{
+        label: ' value4 ',
+        id: db.id().toString(),
+      }],
     }
   ],
 

--- a/app/api/csv/specs/typeParsers.spec.js
+++ b/app/api/csv/specs/typeParsers.spec.js
@@ -69,7 +69,6 @@ describe('csvLoader typeParsers', () => {
       rawEntity = { date_prop: '2014 11 6' };
 
       expected = await typeParsers.date(rawEntity, templateProp);
-      // expect(moment.utc(expected, 'X').format('DD-MM-YYYY')).toEqual('06-11-2014');
 
       rawEntity = { date_prop: '1/1/1996 00:00:00' };
 
@@ -86,21 +85,23 @@ describe('csvLoader typeParsers', () => {
       const value2 = await typeParsers.select({ select_prop: 'value2' }, templateProp);
       const thesauri1 = await thesauris.getById(thesauri1Id);
 
-      expect(thesauri1.values[0].label).toBe('value');
-      expect(thesauri1.values[1].label).toBe('value2');
-      expect(value1).toBe(thesauri1.values[0].id);
-      expect(value2).toBe(thesauri1.values[1].id);
+      expect(thesauri1.values[1].label).toBe('value');
+      expect(thesauri1.values[2].label).toBe('value2');
+      expect(value1).toBe(thesauri1.values[1].id);
+      expect(value2).toBe(thesauri1.values[2].id);
     });
 
     it('should not create repeated values', async () => {
       const templateProp = { name: 'select_prop', content: thesauri1Id };
-      const rawEntity = { select_prop: 'value' };
 
-      await typeParsers.select(rawEntity, templateProp);
-      await typeParsers.select(rawEntity, templateProp);
+      await typeParsers.select({ select_prop: 'value4' }, templateProp);
+      await typeParsers.select({ select_prop: 'value ' }, templateProp);
+      await typeParsers.select({ select_prop: 'value' }, templateProp);
+      await typeParsers.select({ select_prop: ' value ' }, templateProp);
+      await typeParsers.select({ select_prop: 'value4' }, templateProp);
       const thesauri1 = await thesauris.getById(thesauri1Id);
 
-      expect(thesauri1.values.length).toBe(1);
+      expect(thesauri1.values.length).toBe(2);
     });
 
     it('should not create blank values', async () => {
@@ -110,7 +111,7 @@ describe('csvLoader typeParsers', () => {
       const value = await typeParsers.select(rawEntity, templateProp);
       const thesauri1 = await thesauris.getById(thesauri1Id);
 
-      expect(thesauri1.values.length).toBe(0);
+      expect(thesauri1.values.length).toBe(1);
       expect(value).toBe(null);
     });
   });
@@ -119,22 +120,28 @@ describe('csvLoader typeParsers', () => {
     let value1;
     let value2;
     let value3;
+    let value4;
     let thesauri1;
 
     const templateProp = { name: 'multiselect_prop', content: thesauri1Id };
 
     beforeAll(async () => {
       value1 = await typeParsers.multiselect(
-        { multiselect_prop: 'value1|value3|value3' },
+        { multiselect_prop: 'value4' },
         templateProp
       );
 
       value2 = await typeParsers.multiselect(
-        { multiselect_prop: 'value1|value2' },
+        { multiselect_prop: 'value1|value3| value3' },
         templateProp
       );
 
       value3 = await typeParsers.multiselect(
+        { multiselect_prop: 'value1| value2' },
+        templateProp
+      );
+
+      value4 = await typeParsers.multiselect(
         { multiselect_prop: 'value1|value2' },
         templateProp
       );
@@ -153,17 +160,19 @@ describe('csvLoader typeParsers', () => {
     });
 
     it('should create thesauri values and return an array of ids', async () => {
-      expect(thesauri1.values[0].label).toBe('value1');
-      expect(thesauri1.values[1].label).toBe('value3');
-      expect(thesauri1.values[2].label).toBe('value2');
+      expect(thesauri1.values[0].label).toBe(' value4 ');
+      expect(thesauri1.values[1].label).toBe('value1');
+      expect(thesauri1.values[2].label).toBe('value3');
+      expect(thesauri1.values[3].label).toBe('value2');
 
-      expect(value1).toEqual([thesauri1.values[0].id, thesauri1.values[1].id]);
-      expect(value2).toEqual([thesauri1.values[0].id, thesauri1.values[2].id]);
-      expect(value3).toEqual([thesauri1.values[0].id, thesauri1.values[2].id]);
+      expect(value1).toEqual([thesauri1.values[0].id]);
+      expect(value2).toEqual([thesauri1.values[1].id, thesauri1.values[2].id]);
+      expect(value3).toEqual([thesauri1.values[1].id, thesauri1.values[3].id]);
+      expect(value4).toEqual([thesauri1.values[1].id, thesauri1.values[3].id]);
     });
 
-    it('should not create blank values', async () => {
-      expect(thesauri1.values.length).toBe(3);
+    it('should not create blank values, or repeat values', async () => {
+      expect(thesauri1.values.length).toBe(4);
     });
   });
 
@@ -181,13 +190,17 @@ describe('csvLoader typeParsers', () => {
     beforeAll(async () => {
       spyOn(entities, 'indexEntities').and.returnValue(Promise.resolve());
 
+      await entities.save(
+        { title: '   value1  ', template: templateToRelateId },
+        { user: {}, language: 'en' }
+      );
       value1 = await typeParsers.relationship(
-        { relationship_prop: 'value1|value3|value3' },
+        { relationship_prop: 'value1|value3| value3' },
         templateProp
       );
 
       value2 = await typeParsers.relationship(
-        { relationship_prop: 'value1|value2' },
+        { relationship_prop: 'value1| value2' },
         templateProp
       );
 
@@ -210,7 +223,7 @@ describe('csvLoader typeParsers', () => {
     });
 
     it('should create entities and return the ids', async () => {
-      expect(entitiesRelated[0].title).toBe('value1');
+      expect(entitiesRelated[0].title).toBe('   value1  ');
       expect(entitiesRelated[1].title).toBe('value3');
       expect(entitiesRelated[2].title).toBe('value2');
 


### PR DESCRIPTION
fixes #2320

import script basic usage:

yarn import-csv will show help on how to use the script,

csv needs at least a title column, every other field is treated as metadata if configured in the instance, thesauri and template to relate to need to be also created in the instance.

example csv:

```
Title , text label  , select label, 

title1, text value 1, thesauri1   , 
title2, text value 2, thesauri2   , 
title3, text value 3, thesauri2   , 


```
