### PR TITLE
Date filters as string proof of concept

### DIFF
--- a/app/api/search/search.js
+++ b/app/api/search/search.js
@@ -1,4 +1,5 @@
 import errorLog from 'api/log/errorLog';
+import date from 'api/utils/date';
 import { comonFilters, defaultFilters, allUniqueProperties, textFields } from 'shared/comonProperties';
 import { detect as detectLanguage } from 'shared/languages';
 import translate, { getLocaleTranslation, getContext } from 'shared/translate';
@@ -18,6 +19,7 @@ function processFiltes(filters, properties) {
   return Object.keys(filters || {}).map((propertyName) => {
     const property = properties.find(p => p.name === propertyName);
     let { type } = property;
+    const value = filters[property.name];
     if (property.type === 'date' || property.type === 'multidate' || property.type === 'numeric') {
       type = 'range';
     }
@@ -27,7 +29,12 @@ function processFiltes(filters, properties) {
     if (property.type === 'multidaterange' || property.type === 'daterange') {
       type = 'nestedrange';
     }
-    return Object.assign(property, { value: filters[property.name], type });
+
+    if (['multidaterange', 'daterange', 'date', 'multidate'].includes(property.type)) {
+      value.from = date.descriptionToTimestamp(value.from);
+      value.to = date.descriptionToTimestamp(value.to);
+    }
+    return Object.assign(property, { value, type });
   });
 }
 

--- a/app/api/search/specs/__snapshots__/searchDatesFilters.spec.js.snap
+++ b/app/api/search/specs/__snapshots__/searchDatesFilters.spec.js.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dates filters search should request all unpublished entities or documents for the user 1`] = `
+Object {
+  "range": Object {
+    "metadata.date": Object {
+      "gte": "timestamp!",
+      "lte": "timestamp!",
+    },
+  },
+}
+`;
+
+exports[`dates filters search should request all unpublished entities or documents for the user 2`] = `
+Object {
+  "range": Object {
+    "metadata.multidate": Object {
+      "gte": "timestamp!",
+      "lte": "timestamp!",
+    },
+  },
+}
+`;
+
+exports[`dates filters search should request all unpublished entities or documents for the user 3`] = `
+Object {
+  "nested": Object {
+    "path": "metadata.daterange",
+    "query": Object {
+      "bool": Object {
+        "should": Array [
+          Object {
+            "range": Object {
+              "metadata.daterange.from": Object {
+                "gte": "timestamp!",
+                "lte": "timestamp!",
+              },
+            },
+          },
+          Object {
+            "range": Object {
+              "metadata.daterange.to": Object {
+                "gte": "timestamp!",
+                "lte": "timestamp!",
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`dates filters search should request all unpublished entities or documents for the user 4`] = `
+Object {
+  "nested": Object {
+    "path": "metadata.multidaterange",
+    "query": Object {
+      "bool": Object {
+        "should": Array [
+          Object {
+            "range": Object {
+              "metadata.multidaterange.from": Object {
+                "gte": "timestamp!",
+                "lte": "timestamp!",
+              },
+            },
+          },
+          Object {
+            "range": Object {
+              "metadata.multidaterange.to": Object {
+                "gte": "timestamp!",
+                "lte": "timestamp!",
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+`;

--- a/app/api/search/specs/fixtures_elastic.js
+++ b/app/api/search/specs/fixtures_elastic.js
@@ -22,11 +22,7 @@ export default {
       template: template1,
       language: 'en',
       title: 'Batman finishes en',
-      fullText: {
-        1: 'english[[12]]',
-        2: 'document[[2]]',
-        3: 'english[[123]]',
-      },
+      fullText: { 1: 'english[[12]]', 2: 'document[[2]]', 3: 'english[[123]]' },
       published: true,
       user: userId
     },
@@ -157,6 +153,10 @@ export default {
       _id: template1,
       properties: [
         { name: 'status_relationship_filter', type: 'relationshipfilter', relationType },
+        { name: 'date', type: 'date', filter: true },
+        { name: 'multidate', type: 'multidate', filter: true },
+        { name: 'daterange', type: 'daterange', filter: true },
+        { name: 'multidaterange', type: 'multidaterange', filter: true },
       ]
     },
     { _id: template2, properties: [] },

--- a/app/api/search/specs/searchDatesFilters.spec.js
+++ b/app/api/search/specs/searchDatesFilters.spec.js
@@ -1,0 +1,43 @@
+import db from 'api/utils/testing_db';
+import instanceElasticTesting from 'api/utils/elastic_testing';
+import date from 'api/utils/date';
+
+import elasticFixtures, { ids } from './fixtures_elastic';
+import elastic from '../elastic';
+import search from '../search';
+
+describe('dates filters search', () => {
+  const elasticTesting = instanceElasticTesting('search_dates_index_test');
+
+  beforeAll(async () => {
+    await db.clearAllAndLoad(elasticFixtures);
+    await elasticTesting.reindex();
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+  });
+
+  it('should request all unpublished entities or documents for the user', async () => {
+    spyOn(date, 'descriptionToTimestamp').and.returnValue('timestamp!');
+    spyOn(elastic, 'search').and.returnValue(Promise.resolve({ hits: { hits: [] }, aggregations: { all: {} } }));
+
+    await search.search(
+      {
+        types: [ids.template1],
+        filters: {
+          date: { to: 'dateto', from: 'datefrom' },
+          multidate: { to: 'dateto', from: 'datefrom' },
+          daterange: { to: 'dateto', from: 'datefrom' },
+          multidaterange: { to: 'dateto', from: 'datefrom' },
+        }
+      },
+      'en'
+    );
+
+    expect(elastic.search.calls.argsFor(0)[0].body.query.bool.filter[3]).toMatchSnapshot();
+    expect(elastic.search.calls.argsFor(0)[0].body.query.bool.filter[4]).toMatchSnapshot();
+    expect(elastic.search.calls.argsFor(0)[0].body.query.bool.filter[5]).toMatchSnapshot();
+    expect(elastic.search.calls.argsFor(0)[0].body.query.bool.filter[6]).toMatchSnapshot();
+  });
+});

--- a/app/api/utils/date.js
+++ b/app/api/utils/date.js
@@ -9,7 +9,7 @@ export default {
     return new Date(`${date} UTC`).getTime() / 1000;
   },
 
-  naturalLanguageToTimestamp(date) {
+  descriptionToTimestamp(date) {
     if (date === 'last-day-last-month') {
       return moment.utc().subtract(1, 'months').endOf('month').unix();
     }

--- a/app/api/utils/date.js
+++ b/app/api/utils/date.js
@@ -7,5 +7,17 @@ export default {
 
   stringDateToUTCTimestamp(date) {
     return new Date(`${date} UTC`).getTime() / 1000;
+  },
+
+  naturalLanguageToTimestamp(date) {
+    if (date === 'last-day-last-month') {
+      return moment.utc().subtract(1, 'months').endOf('month').unix();
+    }
+
+    if (date === 'first-day-last-month') {
+      return moment.utc().subtract(1, 'months').startOf('month').unix();
+    }
+
+    return date;
   }
 };

--- a/app/api/utils/specs/date.spec.js
+++ b/app/api/utils/specs/date.spec.js
@@ -1,0 +1,26 @@
+import moment from 'moment';
+
+import date from '../date';
+
+describe('date helper', () => {
+  describe('naturalLanguageToTimestamp', () => {
+    it('should return date if it is already a timestamp', () => {
+      const timestamp = moment().unix();
+      expect(date.naturalLanguageToTimestamp(timestamp)).toBe(timestamp);
+    });
+
+    it('transform "first-day-last-month" to timestamp', () => {
+      spyOn(Date, 'now').and.returnValue(moment('2018-07-04'));
+
+      expect(date.naturalLanguageToTimestamp('first-day-last-month'))
+      .toBe(moment.utc('2018-06-01').unix());
+    });
+
+    it('transform "last-day-last-month" to timestamp', () => {
+      spyOn(Date, 'now').and.returnValue(moment('2018-07-04'));
+
+      expect(date.naturalLanguageToTimestamp('last-day-last-month'))
+      .toBe(moment.utc('2018-06-30T23:59:59').unix());
+    });
+  });
+});

--- a/app/api/utils/specs/date.spec.js
+++ b/app/api/utils/specs/date.spec.js
@@ -3,23 +3,23 @@ import moment from 'moment';
 import date from '../date';
 
 describe('date helper', () => {
-  describe('naturalLanguageToTimestamp', () => {
+  describe('descriptionToTimestamp', () => {
     it('should return date if it is already a timestamp', () => {
       const timestamp = moment().unix();
-      expect(date.naturalLanguageToTimestamp(timestamp)).toBe(timestamp);
+      expect(date.descriptionToTimestamp(timestamp)).toBe(timestamp);
     });
 
     it('transform "first-day-last-month" to timestamp', () => {
       spyOn(Date, 'now').and.returnValue(moment('2018-07-04'));
 
-      expect(date.naturalLanguageToTimestamp('first-day-last-month'))
+      expect(date.descriptionToTimestamp('first-day-last-month'))
       .toBe(moment.utc('2018-06-01').unix());
     });
 
     it('transform "last-day-last-month" to timestamp', () => {
       spyOn(Date, 'now').and.returnValue(moment('2018-07-04'));
 
-      expect(date.naturalLanguageToTimestamp('last-day-last-month'))
+      expect(date.descriptionToTimestamp('last-day-last-month'))
       .toBe(moment.utc('2018-06-30T23:59:59').unix());
     });
   });


### PR DESCRIPTION
for now only implemented: 'last-day-last-month' and 'first-day-last-month'

example: ?q=(filters:(initial_date:(from:first-day-last-month,to:last-day-last-month)))

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
