### PR TITLE
Corrected regexps to only treat language-escaping when at the end of …

### DIFF
--- a/app/api/csv/entityRow.js
+++ b/app/api/csv/entityRow.js
@@ -10,13 +10,13 @@ const toSafeName = rawEntity =>
   );
 
 const notTranslated = languages => key =>
-  !key.match(new RegExp(`__${languages.join('|')}`));
+  !key.match(new RegExp(`__(${languages.join('|')})$`));
 
 const languagesTranslated = (row, availableLanguages, currentLanguage) =>
   availableLanguages
   .filter(languageCode =>
     Object.keys(row)
-    .filter(key => key.match(new RegExp(`__${languageCode}`)))
+    .filter(key => key.match(new RegExp(`__${languageCode}$`)))
     .map(key => row[key])
     .join('')
     .trim()
@@ -39,7 +39,7 @@ const extractEntity = (row, availableLanguages, currentLanguage) => {
     currentLanguage
   ).map(languageCode =>
     Object.keys(safeNamed)
-    .filter(key => key.match(new RegExp(`__${languageCode}`)))
+    .filter(key => key.match(new RegExp(`__${languageCode}$`)))
     .reduce(
       (entity, key) => {
         entity[key.split(`__${languageCode}`)[0]] = safeNamed[key]; //eslint-disable-line no-param-reassign

--- a/app/api/csv/specs/entityRow.spec.js
+++ b/app/api/csv/specs/entityRow.spec.js
@@ -4,13 +4,14 @@ describe('entityRow', () => {
   const languages = ['es', 'en', 'pt'];
   const currentLanguage = 'en';
 
-  it('should return entity for the current language', () => {
+  it('should return entity for the current language (not missinterpreting coincidences in letters as language escaping)', () => {
     const { rawEntity } = extractEntity({
       title__es: 'test_es',
       title__en: 'test_en',
+      not_portuguese_ptescaped_property: 'not portuguese'
     }, languages, currentLanguage);
 
-    expect(rawEntity).toEqual({ title: 'test_en', language: 'en' });
+    expect(rawEntity).toEqual({ title: 'test_en', not_portuguese_ptescaped_property: 'not portuguese', language: 'en' });
   });
 
   it('should return translations for languages that have it', () => {
@@ -47,5 +48,22 @@ describe('entityRow', () => {
       { title: 'test_es', language: 'es' },
       { text: 'text_pt', language: 'pt' },
     ]);
+  });
+
+  it('should not missinterpret middle-word coincidences with language matches', () => {
+    const { rawEntity, rawTranslations } = extractEntity({
+      title__es: 'test_es',
+      title__en: 'test_en',
+      some__entirely_new_property: 'has __en in name, but is not english',
+      a__pt_property: 'not portugese',
+    }, languages, 'es');
+
+    expect(rawEntity).toEqual(
+      { title: 'test_es', some__entirely_new_property: 'has __en in name, but is not english', a__pt_property: 'not portugese', language: 'es' }
+    );
+
+    expect(rawTranslations).toEqual(
+      [{ title: 'test_en', some__entirely_new_property: 'has __en in name, but is not english', a__pt_property: 'not portugese', language: 'en' }]
+    );
   });
 });


### PR DESCRIPTION
…the sentence and with two underscores even for second and onward languages.

fixes #2411

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
