### PR TITLE
escape chars matching titles on import relations

### DIFF
--- a/app/api/csv/specs/typeParsers.spec.js
+++ b/app/api/csv/specs/typeParsers.spec.js
@@ -89,20 +89,20 @@ describe('csvLoader typeParsers', () => {
     beforeAll(async () => {
       spyOn(entities, 'indexEntities').and.returnValue(Promise.resolve());
 
-      await model.save({ title: '   value1  ', template: templateToRelateId, sharedId: '123', language: 'en' });
-      await model.save({ title: '   value1  ', template: templateToRelateId, sharedId: '123', language: 'es' });
+      await model.save({ title: '   valu(e)1  ', template: templateToRelateId, sharedId: '123', language: 'en' });
+      await model.save({ title: '   valu(e)1  ', template: templateToRelateId, sharedId: '123', language: 'es' });
       value1 = await typeParsers.relationship(
-        { relationship_prop: 'value1|value3| value3' },
+        { relationship_prop: 'valu(e)1|value3| value3' },
         templateProp
       );
 
       value2 = await typeParsers.relationship(
-        { relationship_prop: 'value1| value2' },
+        { relationship_prop: 'valu(e)1| value2' },
         templateProp
       );
 
       value3 = await typeParsers.relationship(
-        { relationship_prop: 'value1|value2' },
+        { relationship_prop: 'valu(e)1|value2' },
         templateProp
       );
 
@@ -120,7 +120,7 @@ describe('csvLoader typeParsers', () => {
     });
 
     it('should create entities and return the ids', async () => {
-      expect(entitiesRelated[0].title).toBe('   value1  ');
+      expect(entitiesRelated[0].title).toBe('   valu(e)1  ');
       expect(entitiesRelated[1].title).toBe('value3');
       expect(entitiesRelated[2].title).toBe('value2');
 

--- a/app/api/csv/typeParsers.js
+++ b/app/api/csv/typeParsers.js
@@ -7,6 +7,8 @@ import geolocation from './typeParsers/geolocation.js';
 import multiselect from './typeParsers/multiselect.js';
 import select from './typeParsers/select.js';
 
+const escapeRegExpCharacters = string => string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
 export default {
   geolocation,
 
@@ -50,7 +52,7 @@ export default {
     .filter(emptyString)
     .filter(unique);
 
-    const current = await entities.get({ title: { $in: values.map(v => new RegExp(`\\s?${v}\\s?`, 'i')) } });
+    const current = await entities.get({ title: { $in: values.map(v => new RegExp(`\\s?${escapeRegExpCharacters(v)}\\s?`, 'i')) } });
     const newValues = values.filter(v => !current.map(c => c.title.trim()).includes(v));
 
     await newValues.reduce(
@@ -69,7 +71,7 @@ export default {
       Promise.resolve([])
     );
 
-    const toRelateEntities = await entities.get({ title: { $in: values.map(v => new RegExp(`\\s?${v}\\s?`, 'i')) } });
+    const toRelateEntities = await entities.get({ title: { $in: values.map(v => new RegExp(`\\s?${escapeRegExpCharacters(v)}\\s?`, 'i')) } });
     return toRelateEntities.map(e => e.sharedId).filter((id, index, ids) => ids.indexOf(id) === index);
   },
 };


### PR DESCRIPTION
When matching by title on import if the relationship has characters like "({[" etc the match fails, this PR escapes all the special regexp characters to avoid this.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
