### PR TITLE
index thesauri values, improve render performance

### DIFF
--- a/app/react/Metadata/containers/FormatMetadata.js
+++ b/app/react/Metadata/containers/FormatMetadata.js
@@ -2,12 +2,12 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import selectors from '../selectors';
+import { metadataSelectors } from '../selectors';
 import Metadata from '../components/Metadata';
 
 const FormatMetadata = ({ additionalMetadata, sortedProperty, entity, relationships, ...props }) => (
   <Metadata
-    metadata={additionalMetadata.concat(selectors.formatMetadata(props, entity, sortedProperty, relationships))}
+    metadata={additionalMetadata.concat(metadataSelectors.formatMetadata(props, entity, sortedProperty, relationships))}
     compact={!!sortedProperty}
     {...props}
   />

--- a/app/react/Metadata/containers/specs/FormatMetadata.spec.js
+++ b/app/react/Metadata/containers/specs/FormatMetadata.spec.js
@@ -3,11 +3,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import FormatMetadata from '../FormatMetadata';
-import selectors from '../../selectors';
+import { metadataSelectors } from '../../selectors';
 
 describe('FormatMetadata', () => {
   it('should render Metadata component passing the formatted metadata', () => {
-    spyOn(selectors, 'formatMetadata').and.returnValue([{ formated: 'metadata' }]);
+    spyOn(metadataSelectors, 'formatMetadata').and.returnValue([{ formated: 'metadata' }]);
     const props = {
       templates: [],
       thesauris: [],
@@ -19,7 +19,7 @@ describe('FormatMetadata', () => {
   });
 
   it('should unshift additional metadata if passed', () => {
-    spyOn(selectors, 'formatMetadata').and.returnValue([{ formated: 'metadata' }]);
+    spyOn(metadataSelectors, 'formatMetadata').and.returnValue([{ formated: 'metadata' }]);
     const props = {
       templates: [],
       thesauris: [],

--- a/app/react/Metadata/helpers/formater.js
+++ b/app/react/Metadata/helpers/formater.js
@@ -5,24 +5,7 @@ import { store } from 'app/store';
 import nestedProperties from 'app/Templates/components/ViolatedArticlesNestedProperties';
 import t from 'app/I18N/t';
 
-const getOption = (thesauri, id) => {
-  let option;
-  thesauri.get('values').forEach((value) => {
-    if (value.get('id') === id) {
-      option = value;
-    }
-
-    if (value.get('values')) {
-      value.get('values').forEach((subValue) => {
-        if (subValue.get('id') === id) {
-          option = subValue;
-        }
-      });
-    }
-  });
-
-  return option;
-};
+const getOption = (thesauri, id) => thesauri.get('values').get(id);
 
 const addSortedProperty = (templates, sortedProperty) => templates.reduce((_property, template) => {
   if (!template.get('properties')) {

--- a/app/react/Metadata/helpers/specs/fixtures.js
+++ b/app/react/Metadata/helpers/specs/fixtures.js
@@ -16,7 +16,7 @@ export const doc = {
     daterange: { from: 10, to: 1000000 },
     multidaterange: [{ from: 10, to: 1000000 }, { from: 2000000, to: 3000000 }],
     markdown: 'markdown content',
-    select: 'value3',
+    select: 'value5',
     image: 'imageURL',
     media: 'mediaURL',
     relationship1: ['value1', 'value2'],

--- a/app/react/Metadata/helpers/specs/formater.spec.js
+++ b/app/react/Metadata/helpers/specs/formater.spec.js
@@ -1,7 +1,8 @@
 /* eslint-disable max-statements */
 import Immutable from 'immutable';
 
-import metadataSelectors from '../../selectors';
+import { metadataSelectors } from '../../selectors';
+
 import formater from '../formater';
 import { doc, templates, thesauris, relationships } from './fixtures';
 
@@ -44,10 +45,10 @@ describe('metadata formater', () => {
     let nested;
 
     beforeAll(() => {
-      data = formater.prepareMetadata(doc, templates, thesauris, relationships);
+      data = formater.prepareMetadata(doc, templates, metadataSelectors.indexedThesaurus({ thesauris }), relationships);
       [text, date, multiselect, multidate, daterange, multidaterange, markdown,
-       select, image, preview, media, relationship1, relationship2, relationship3, relationship4,
-       geolocation, nested] =
+        select, image, preview, media, relationship1, relationship2, relationship3, relationship4,
+        geolocation, nested] =
         data.metadata;
     });
 
@@ -106,7 +107,7 @@ describe('metadata formater', () => {
     });
 
     it('should process select type', () => {
-      assessBasicProperties(select, ['Select', 'select', 'templateID', 'Value 3']);
+      assessBasicProperties(select, ['Select', 'select', 'templateID', 'Value 5']);
     });
 
     it('should process bound relationship types', () => {
@@ -286,7 +287,7 @@ describe('metadata formater', () => {
       const state = { templates, thesauris };
       const metadata = metadataSelectors.formatMetadata(state, doc, null, relationships);
       expect(metadata).toBe('metadataFormated');
-      expect(formater.prepareMetadata).toHaveBeenCalledWith(doc, templates, thesauris, relationships);
+      expect(formater.prepareMetadata).toHaveBeenCalledWith(doc, templates, metadataSelectors.indexedThesaurus(state), relationships);
     });
 
     describe('when passing sortProperty', () => {
@@ -295,7 +296,7 @@ describe('metadata formater', () => {
         const state = { templates, thesauris };
         const metadata = metadataSelectors.formatMetadata(state, doc, 'sortProperty', relationships);
         expect(metadata).toBe('metadataFormated');
-        expect(formater.prepareMetadataForCard).toHaveBeenCalledWith(doc, templates, thesauris, 'sortProperty');
+        expect(formater.prepareMetadataForCard).toHaveBeenCalledWith(doc, templates, metadataSelectors.indexedThesaurus(state), 'sortProperty');
       });
     });
   });

--- a/app/react/Metadata/selectors.js
+++ b/app/react/Metadata/selectors.js
@@ -1,10 +1,24 @@
 import { createSelector } from 'reselect';
 
+import Immutable from 'immutable';
 import formater from './helpers/formater';
+
+const indexValues = t =>
+  t.set('values', t.get('values').reduce((indexed, value) => {
+    if (value.get('values')) {
+      return indexed.merge(indexValues(value).get('values'));
+    }
+    return indexed.set(value.get('id'), value);
+  }, new Immutable.Map({})));
+
+const indexedThesaurus = createSelector(
+  s => s.thesauris,
+  thesaurus => thesaurus.map(t => indexValues(t))
+);
 
 const formatMetadata = createSelector(
   s => s.templates,
-  s => s.thesauris,
+  indexedThesaurus,
   (s, doc, sortProperty, references) => ({ doc, sortProperty, references }),
   (templates, thesauris, { doc, sortProperty, references }) => {
     if (sortProperty) {
@@ -14,4 +28,9 @@ const formatMetadata = createSelector(
   }
 );
 
-export default { formatMetadata };
+const metadataSelectors = {
+  formatMetadata,
+  indexedThesaurus
+};
+
+export { metadataSelectors };


### PR DESCRIPTION
patched a a performmance bug when rendering multiple values of a relationship with lots of entries

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
