### PR TITLE
Display error when saving data while server is down

### DIFF
--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -16,7 +16,7 @@ const doneLoading = (data) => {
   return data;
 };
 
-const isOtherApiError = error => error.status && ![500, 404, 401].includes(error.status);
+const isNonUsualApiError = error => error.status && ![500, 404, 401].includes(error.status);
 
 const handleErrorStatus = (error) => {
   if (error.status === 401) {
@@ -25,7 +25,7 @@ const handleErrorStatus = (error) => {
     browserHistory.replace('/404');
   } else if (error.status === 500) {
     store.dispatch(notify('An error has occurred', 'danger'));
-  } else if (isOtherApiError(error)) {
+  } else if (isNonUsualApiError(error)) {
     store.dispatch(notify(error.json.error, 'danger'));
   } else if (error instanceof TypeError) {
     store.dispatch(notify('Could not reach server. Please try again later.', 'danger'));

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -38,8 +38,12 @@ const handleError = (e, endpoint) => {
     store.dispatch(notify('An error has occurred', 'danger'));
   }
 
-  if (![500, 404, 401].includes(error.status)) {
+  if (error.status && ![500, 404, 401].includes(error.status)) {
     store.dispatch(notify(error.json.error, 'danger'));
+  }
+
+  if (/failed to fetch/i.test(error.message)) {
+    store.dispatch(notify('Could not reach server. Please try again later.', 'danger'));
   }
 
   return Promise.reject(error);

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -16,6 +16,8 @@ const doneLoading = (data) => {
   return data;
 };
 
+const isOtherApiError = error => error.status && ![500, 404, 401].includes(error.status);
+
 const handleErrorStatus = (error) => {
   if (error.status === 401) {
     browserHistory.replace('/login');
@@ -23,7 +25,7 @@ const handleErrorStatus = (error) => {
     browserHistory.replace('/404');
   } else if (error.status === 500) {
     store.dispatch(notify('An error has occurred', 'danger'));
-  } else if (error.status && ![500, 404, 401].includes(error.status)) {
+  } else if (isOtherApiError(error)) {
     store.dispatch(notify(error.json.error, 'danger'));
   } else if (error instanceof TypeError) {
     store.dispatch(notify('Could not reach server. Please try again later.', 'danger'));

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -33,7 +33,7 @@ const handleErrorStatus = (error) => {
     store.dispatch(notify(error.json.error, 'danger'));
   }
 
-  if (/failed to fetch/i.test(error.message)) {
+  if (error instanceof TypeError) {
     store.dispatch(notify('Could not reach server. Please try again later.', 'danger'));
   }
 };
@@ -49,7 +49,6 @@ const handleError = (e, endpoint) => {
   doneLoading();
 
   handleErrorStatus(error);
-
   return Promise.reject(error);
 };
 

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -19,22 +19,16 @@ const doneLoading = (data) => {
 const handleErrorStatus = (error) => {
   if (error.status === 401) {
     browserHistory.replace('/login');
-  }
-
-  if (error.status === 404) {
+  } else if (error.status === 404) {
     browserHistory.replace('/404');
-  }
-
-  if (error.status === 500) {
+  } else if (error.status === 500) {
     store.dispatch(notify('An error has occurred', 'danger'));
-  }
-
-  if (error.status && ![500, 404, 401].includes(error.status)) {
+  } else if (error.status && ![500, 404, 401].includes(error.status)) {
     store.dispatch(notify(error.json.error, 'danger'));
-  }
-
-  if (error instanceof TypeError) {
+  } else if (error instanceof TypeError) {
     store.dispatch(notify('Could not reach server. Please try again later.', 'danger'));
+  } else {
+    store.dispatch(notify('An error has occurred', 'danger'));
   }
 };
 

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -16,16 +16,7 @@ const doneLoading = (data) => {
   return data;
 };
 
-const handleError = (e, endpoint) => {
-  const error = e;
-  error.endpoint = endpoint;
-
-  if (!isClient) {
-    return Promise.reject(error);
-  }
-
-  doneLoading();
-
+const handleErrorStatus = (error) => {
   if (error.status === 401) {
     browserHistory.replace('/login');
   }
@@ -45,6 +36,19 @@ const handleError = (e, endpoint) => {
   if (/failed to fetch/i.test(error.message)) {
     store.dispatch(notify('Could not reach server. Please try again later.', 'danger'));
   }
+};
+
+const handleError = (e, endpoint) => {
+  const error = e;
+  error.endpoint = endpoint;
+
+  if (!isClient) {
+    return Promise.reject(error);
+  }
+
+  doneLoading();
+
+  handleErrorStatus(error);
 
   return Promise.reject(error);
 };

--- a/app/react/utils/specs/api.spec.js
+++ b/app/react/utils/specs/api.spec.js
@@ -20,7 +20,10 @@ describe('api', () => {
     .delete(`${APIURL}test_delete?data=delete`, JSON.stringify({ method: 'DELETE' }))
     .get(`${APIURL}unauthorised`, { status: 401, body: {} })
     .get(`${APIURL}notfound`, { status: 404, body: {} })
-    .get(`${APIURL}error_url`, { status: 500, body: {} });
+    .get(`${APIURL}error_url`, { status: 500, body: {} })
+    .get(`${APIURL}network_error`, {
+      throws: new TypeError('Failed to fetch')
+    });
   });
 
   afterEach(() => backend.restore());
@@ -106,6 +109,21 @@ describe('api', () => {
           expect(browserHistory.replace).toHaveBeenCalledWith('/404');
           done();
         });
+      });
+    });
+
+    describe('fetch error', () => {
+      it('should notify that server is unreachable', async () => {
+        spyOn(store, 'dispatch');
+        spyOn(notifyActions, 'notify').and.returnValue('notify action');
+        try {
+          await api.get('network_error');
+          fail('should throw error');
+        } catch (e) {
+          expect(store.dispatch).toHaveBeenCalledWith('notify action');
+          expect(notifyActions.notify)
+          .toHaveBeenCalledWith('Could not reach server. Please try again later.', 'danger');
+        }
       });
     });
 

--- a/app/react/utils/specs/api.spec.js
+++ b/app/react/utils/specs/api.spec.js
@@ -12,6 +12,8 @@ describe('api', () => {
   beforeEach(() => {
     spyOn(loadingBar, 'start');
     spyOn(loadingBar, 'done');
+    spyOn(store, 'dispatch');
+    spyOn(notifyActions, 'notify').and.returnValue('notify action');
     backend.restore();
     backend
     .get(`${APIURL}test_get`, JSON.stringify({ method: 'GET' }))
@@ -91,31 +93,31 @@ describe('api', () => {
 
   describe('error handling', () => {
     describe('401', () => {
-      it('should redirect to login', (done) => {
+      it('should redirect to login', async () => {
         spyOn(browserHistory, 'replace');
-        api.get('unauthorised')
-        .catch(() => {
+        try {
+          await api.get('unauthorised');
+          fail('should throw error');
+        } catch (e) {
           expect(browserHistory.replace).toHaveBeenCalledWith('/login');
-          done();
-        });
+        }
       });
     });
 
     describe('404', () => {
-      it('should redirect to login', (done) => {
+      it('should redirect to login', async () => {
         spyOn(browserHistory, 'replace');
-        api.get('notfound')
-        .catch(() => {
+        try {
+          await api.get('notfound');
+          fail('should throw error');
+        } catch (e) {
           expect(browserHistory.replace).toHaveBeenCalledWith('/404');
-          done();
-        });
+        }
       });
     });
 
     describe('fetch error', () => {
       it('should notify that server is unreachable', async () => {
-        spyOn(store, 'dispatch');
-        spyOn(notifyActions, 'notify').and.returnValue('notify action');
         try {
           await api.get('network_error');
           fail('should throw error');
@@ -127,23 +129,23 @@ describe('api', () => {
       });
     });
 
-    it('should notify the user', (done) => {
-      spyOn(store, 'dispatch');
-      spyOn(notifyActions, 'notify').and.returnValue('notify action');
-      api.get('error_url')
-      .catch(() => {
+    it('should notify the user', async () => {
+      try {
+        await api.get('error_url');
+        fail('should throw error');
+      } catch (e) {
         expect(store.dispatch).toHaveBeenCalledWith('notify action');
         expect(notifyActions.notify).toHaveBeenCalledWith('An error has occurred', 'danger');
-        done();
-      });
+      }
     });
 
-    it('should end the loading bar', (done) => {
-      api.get('error_url')
-      .catch(() => {
+    it('should end the loading bar', async () => {
+      try {
+        await api.get('error_url');
+        fail('should throw error');
+      } catch (e) {
         expect(loadingBar.done).toHaveBeenCalled();
-        done();
-      });
+      }
     });
   });
 });

--- a/app/react/utils/specs/api.spec.js
+++ b/app/react/utils/specs/api.spec.js
@@ -26,7 +26,8 @@ describe('api', () => {
     .get(`${APIURL}error_url`, { status: 500, body: {} })
     .get(`${APIURL}network_error`, {
       throws: new TypeError('Failed to fetch')
-    });
+    })
+    .get(`${APIURL}unknown_error`, { throws: new Error('some error') });
   });
 
   afterEach(() => backend.restore());
@@ -118,12 +119,22 @@ describe('api', () => {
       });
     });
 
-    describe('fetch error', () => {
+    describe('network error', () => {
       it('should notify that server is unreachable', async () => {
         await testErrorHandling('network_error', () => {
           expect(store.dispatch).toHaveBeenCalledWith('notify action');
           expect(notifyActions.notify)
           .toHaveBeenCalledWith('Could not reach server. Please try again later.', 'danger');
+        });
+      });
+    });
+
+    describe('unknown error', () => {
+      it('should show generic error message', async () => {
+        await testErrorHandling('unknown_error', () => {
+          expect(store.dispatch).toHaveBeenCalledWith('notify action');
+          expect(notifyActions.notify)
+          .toHaveBeenCalledWith('An error has occurred', 'danger');
         });
       });
     });

--- a/app/react/utils/specs/api.spec.js
+++ b/app/react/utils/specs/api.spec.js
@@ -103,6 +103,11 @@ describe('api', () => {
       }
     }
 
+    function testNotificationDisplayed(message, type = 'danger') {
+      expect(store.dispatch).toHaveBeenCalledWith('notify action');
+      expect(notifyActions.notify).toHaveBeenCalledWith(message, type);
+    }
+
     describe('401', () => {
       it('should redirect to login', async () => {
         await testErrorHandling('unauthorised', () => {
@@ -122,9 +127,7 @@ describe('api', () => {
     describe('network error', () => {
       it('should notify that server is unreachable', async () => {
         await testErrorHandling('network_error', () => {
-          expect(store.dispatch).toHaveBeenCalledWith('notify action');
-          expect(notifyActions.notify)
-          .toHaveBeenCalledWith('Could not reach server. Please try again later.', 'danger');
+          testNotificationDisplayed('Could not reach server. Please try again later.');
         });
       });
     });
@@ -132,17 +135,14 @@ describe('api', () => {
     describe('unknown error', () => {
       it('should show generic error message', async () => {
         await testErrorHandling('unknown_error', () => {
-          expect(store.dispatch).toHaveBeenCalledWith('notify action');
-          expect(notifyActions.notify)
-          .toHaveBeenCalledWith('An error has occurred', 'danger');
+          testNotificationDisplayed('An error has occurred');
         });
       });
     });
 
     it('should notify the user', async () => {
       await testErrorHandling('error_url', () => {
-        expect(store.dispatch).toHaveBeenCalledWith('notify action');
-        expect(notifyActions.notify).toHaveBeenCalledWith('An error has occurred', 'danger');
+        testNotificationDisplayed('An error has occurred');
       });
     });
 


### PR DESCRIPTION
fixes #2503

Displays a "Could not reach server. Please try again later." When a request fails when due failed to connection to the server (the server could be unreachable, or the client could be offline).

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
