### PR TITLE
Get entity by

### DIFF
--- a/app/api/entities/entities.js
+++ b/app/api/entities/entities.js
@@ -66,7 +66,8 @@ function updateEntity(entity, _template) {
 function createEntity(doc, languages, sharedId) {
   const docs = languages.map((lang) => {
     const langDoc = Object.assign({}, doc);
-    if (!lang.default) {
+    const avoidIdDuplication = docs._id && !lang.default;
+    if (avoidIdDuplication) {
       delete langDoc._id;
     }
     langDoc.language = lang.key;

--- a/app/api/entities/entities.js
+++ b/app/api/entities/entities.js
@@ -66,10 +66,17 @@ function updateEntity(entity, _template) {
 function createEntity(doc, languages, sharedId) {
   const docs = languages.map((lang) => {
     const langDoc = Object.assign({}, doc);
+    if (!lang.default) {
+      delete langDoc._id;
+    }
+
     langDoc.language = lang.key;
     langDoc.sharedId = sharedId;
+
+
     return langDoc;
   });
+
   return model.save(docs);
 }
 

--- a/app/api/entities/entities.js
+++ b/app/api/entities/entities.js
@@ -69,11 +69,8 @@ function createEntity(doc, languages, sharedId) {
     if (!lang.default) {
       delete langDoc._id;
     }
-
     langDoc.language = lang.key;
     langDoc.sharedId = sharedId;
-
-
     return langDoc;
   });
 

--- a/app/api/entities/entities.js
+++ b/app/api/entities/entities.js
@@ -66,7 +66,7 @@ function updateEntity(entity, _template) {
 function createEntity(doc, languages, sharedId) {
   const docs = languages.map((lang) => {
     const langDoc = Object.assign({}, doc);
-    const avoidIdDuplication = docs._id && !lang.default;
+    const avoidIdDuplication = doc._id && !lang.default;
     if (avoidIdDuplication) {
       delete langDoc._id;
     }

--- a/app/api/entities/routes.js
+++ b/app/api/entities/routes.js
@@ -88,6 +88,18 @@ export default (app) => {
       .catch(next);
     });
 
+  app.get('/api/entities/byid',
+    validation.validateRequest(Joi.object().keys({
+      _id: Joi.string().required(),
+    }).required(), 'query'),
+    (req, res, next) => {
+      entities.get({ _id: req._id })
+      .then((_entities) => {
+        res.json({ rows: _entities });
+      })
+      .catch(next);
+    });
+
   app.delete('/api/entities',
     needsAuthorization(['admin', 'editor']),
     validation.validateRequest(Joi.object().keys({

--- a/app/api/entities/routes.js
+++ b/app/api/entities/routes.js
@@ -95,6 +95,11 @@ export default (app) => {
     (req, res, next) => {
       entities.get({ _id: req.query._id })
       .then((_entities) => {
+        if (_entities.length === 0) {
+          res.status(404);
+          res.json({});
+          return;
+        }
         res.json(_entities[0]);
       })
       .catch(next);

--- a/app/api/entities/routes.js
+++ b/app/api/entities/routes.js
@@ -88,14 +88,14 @@ export default (app) => {
       .catch(next);
     });
 
-  app.get('/api/entities/byid',
+  app.get('/api/entities/by_id',
     validation.validateRequest(Joi.object().keys({
       _id: Joi.string().required(),
     }).required(), 'query'),
     (req, res, next) => {
-      entities.get({ _id: req._id })
+      entities.get({ _id: req.query._id })
       .then((_entities) => {
-        res.json({ rows: _entities });
+        res.json(_entities[0]);
       })
       .catch(next);
     });

--- a/app/api/entities/routes.js
+++ b/app/api/entities/routes.js
@@ -75,8 +75,8 @@ export default (app) => {
       const { omitRelationships, ...query } = req.query;
       const action = omitRelationships ? 'get' : 'getWithRelationships';
       const published = req.user ? {} : { published: true };
-      const language = req.language ? {language: req.language} : {};
-      entities[action]({ ...query, ...published, ...language}, {}, 1)
+      const language = req.language ? { language: req.language } : {};
+      entities[action]({ ...query, ...published, ...language }, {}, 1)
       .then((_entities) => {
         if (!_entities.length) {
           res.status(404);

--- a/app/api/entities/specs/__snapshots__/routes.spec.js.snap
+++ b/app/api/entities/specs/__snapshots__/routes.spec.js.snap
@@ -51,13 +51,16 @@ Object {
 exports[`entities GET should have a validation schema 1`] = `
 Object {
   "children": Object {
+    "_id": Object {
+      "invalids": Array [
+        "",
+      ],
+      "type": "string",
+    },
     "omitRelationships": Object {
       "type": "any",
     },
     "sharedId": Object {
-      "flags": Object {
-        "presence": "required",
-      },
       "invalids": Array [
         "",
       ],

--- a/app/api/entities/specs/entities.spec.js
+++ b/app/api/entities/specs/entities.spec.js
@@ -76,6 +76,18 @@ describe('entities', () => {
       expect(createdDocumentEn.creationDate).toEqual(universalTime);
     });
 
+    it('should create a new entity for each language when passing an _id', async () => {
+      const universalTime = 1;
+      spyOn(date, 'currentUTC').and.returnValue(universalTime);
+      const doc = { _id: '123456789012345678901234', title: 'Batman begins', language: 'es' };
+      const user = { _id: db.id() };
+
+      const { createdDocumentEs, createdDocumentEn } = await saveDoc(doc, user);
+
+      expect(createdDocumentEs._id.toString()).toBe('123456789012345678901234');
+      expect(createdDocumentEn._id.toString()).not.toBe('123456789012345678901234');
+    });
+
     it('should create a new entity, preserving template if passed', async () => {
       const doc = { title: 'The Dark Knight', template: templateId };
       const user = { _id: db.id() };

--- a/app/api/entities/specs/fixtures.js
+++ b/app/api/entities/specs/fixtures.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import db from 'api/utils/testing_db';
 
+
 const batmanFinishesId = db.id();
 const syncPropertiesEntityId = db.id();
 const templateId = db.id();
@@ -19,6 +20,7 @@ const hub5 = db.id();
 
 const docId1 = db.id();
 const docId2 = db.id();
+const unpublishedDocId = db.id('123456789012345678901234');
 
 export default {
   entities: [
@@ -44,7 +46,7 @@ export default {
     },
     { _id: docId1, sharedId: 'shared', type: 'entity', language: 'es', title: 'Penguin almost done', creationDate: 1, published: true, file: { filename: '8202c463d6158af8065022d9b5014ccb.pdf' }, attachments: [{ filename: '8202c463d6158af8065022d9b5014ccc.pdf' }], fullText: { 1: 'text' } },
     { _id: docId2, sharedId: 'shared', type: 'entity', language: 'pt', title: 'Penguin almost done', creationDate: 1, published: true, metadata: { text: 'test' }, file: { filename: '8202c463d6158af8065022d9b5014cc1.pdf' } },
-    { _id: db.id(), sharedId: 'other', type: 'entity', template: templateId, language: 'en', title: 'Unpublished entity', published: false, metadata: { property1: 'value1' } },
+    { _id: unpublishedDocId, sharedId: 'other', type: 'entity', template: templateId, language: 'en', title: 'Unpublished entity', published: false, metadata: { property1: 'value1' } },
     //select/multiselect/date sync
     { _id: syncPropertiesEntityId, template: templateId, sharedId: 'shared1', type: 'entity', language: 'en', title: 'EN', published: true, metadata: { property1: 'text' }, file: { filename: 'nonexistent.pdf' } },
     { _id: db.id(), template: templateId, sharedId: 'shared1', type: 'entity', language: 'es', title: 'ES', creationDate: 1, published: true, metadata: { property1: 'text' }, file: { filename: 'nonexistent.pdf' }, fullText: { 1: 'text' } },
@@ -133,4 +135,5 @@ export {
   templateWithEntityAsThesauri,
   docId1,
   docId2,
+  unpublishedDocId,
 };

--- a/app/api/entities/specs/routes.spec.js
+++ b/app/api/entities/specs/routes.spec.js
@@ -157,13 +157,13 @@ describe('entities', () => {
     });
 
     it('should return document by id', async () => {
-      const expectedEntity = [{ _id: '123456789012345678901234' }];
-      spyOn(entities, 'get').and.returnValue(Promise.resolve(expectedEntity));
+      const expectedEntity = { _id: '123456789012345678901234', title: 'title' };
+      spyOn(entities, 'get').and.returnValue(Promise.resolve([expectedEntity]));
 
-      const response = await routes.get('/api/entities/byid', {_id: '123456789012345678901234'});
+      const response = await routes.get('/api/entities/by_id', { query: {_id: '123456789012345678901234'} });
 
-      expect(entities.get).toHaveBeenCalledWith({_id: '123456789012345678901234'});
-      expect(response).toEqual({ rows: expectedEntity });
+      expect(entities.get).toHaveBeenCalledWith({ _id: '123456789012345678901234' });
+      expect(response).toEqual(expectedEntity);
     });
 
     it('should allow not fetching the relationships', async () => {

--- a/app/api/entities/specs/routes.spec.js
+++ b/app/api/entities/specs/routes.spec.js
@@ -314,20 +314,17 @@ describe('entities', () => {
     });
   });
 
-  // describe('/api/entities/get_raw_page', () => {
-  //   it('should return formattedPlainTextPages page requested', (done) => {
-  //     spyOn(entities, 'countByTemplate').and.returnValue(new Promise(resolve => resolve(2)));
-  //     const req = { query: { templateId: 'templateId' } };
+  describe('/api/entities/get_raw_page', () => {
+    it('should return formattedPlainTextPages page requested', async () => {
+      spyOn(entities, 'countByTemplate').and.returnValue(new Promise(resolve => resolve(2)));
+      const req = { query: { templateId: 'templateId' } };
 
-  //     routes.get('/api/entities/count_by_template', req)
-  //     .then((response) => {
-  //       expect(entities.countByTemplate).toHaveBeenCalledWith('templateId');
-  //       expect(response).toEqual(2);
-  //       done();
-  //     })
-  //     .catch(catchErrors(done));
-  //   });
-  // });
+      const response = await routes.get('/api/entities/count_by_template', req);
+
+      expect(entities.countByTemplate).toHaveBeenCalledWith('templateId');
+      expect(response).toEqual(2);
+    });
+  });
 
   describe('/api/entities/count_by_template', () => {
     it('should have a validation schema', () => {

--- a/app/api/entities/specs/routes.spec.js
+++ b/app/api/entities/specs/routes.spec.js
@@ -166,6 +166,14 @@ describe('entities', () => {
       expect(response).toEqual(expectedEntity);
     });
 
+    it('should return 404 when document by id not found', async () => {
+      spyOn(entities, 'get').and.returnValue(Promise.resolve([]));
+
+      const response = await routes.get('/api/entities/by_id', { query: {_id: '123456789012345678901234'} });
+
+      expect(response.status).toEqual(404);
+    });
+
     it('should allow not fetching the relationships', async () => {
       const expectedEntity = { sharedId: 'sharedId', published: true };
 

--- a/app/api/entities/specs/routes.spec.js
+++ b/app/api/entities/specs/routes.spec.js
@@ -160,7 +160,7 @@ describe('entities', () => {
       const expectedEntity = { _id: '123456789012345678901234', title: 'title' };
       spyOn(entities, 'get').and.returnValue(Promise.resolve([expectedEntity]));
 
-      const response = await routes.get('/api/entities/by_id', { query: {_id: '123456789012345678901234'} });
+      const response = await routes.get('/api/entities/by_id', { query: { _id: '123456789012345678901234' } });
 
       expect(entities.get).toHaveBeenCalledWith({ _id: '123456789012345678901234' });
       expect(response).toEqual(expectedEntity);
@@ -169,7 +169,7 @@ describe('entities', () => {
     it('should return 404 when document by id not found', async () => {
       spyOn(entities, 'get').and.returnValue(Promise.resolve([]));
 
-      const response = await routes.get('/api/entities/by_id', { query: {_id: '123456789012345678901234'} });
+      const response = await routes.get('/api/entities/by_id', { query: { _id: '123456789012345678901234' } });
 
       expect(response.status).toEqual(404);
     });

--- a/app/api/entities/specs/routes.spec.js
+++ b/app/api/entities/specs/routes.spec.js
@@ -156,6 +156,16 @@ describe('entities', () => {
       .catch(catchErrors(done));
     });
 
+    it('should return document by id', async () => {
+      const expectedEntity = [{ _id: '123456789012345678901234' }];
+      spyOn(entities, 'get').and.returnValue(Promise.resolve(expectedEntity));
+
+      const response = await routes.get('/api/entities/byid', {_id: '123456789012345678901234'});
+
+      expect(entities.get).toHaveBeenCalledWith({_id: '123456789012345678901234'});
+      expect(response).toEqual({ rows: expectedEntity });
+    });
+
     it('should allow not fetching the relationships', async () => {
       const expectedEntity = { sharedId: 'sharedId', published: true };
 


### PR DESCRIPTION
To check if an entity exists, the endpoint 'get entities' now accepts queries like {_id:'34344353453'}. This is useful for avoiding duplications by the Crawler uploads