### PR TITLE
moved dynamic import babel plugin to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/plugin-transform-react-constant-elements": "7.5.0",
     "@babel/plugin-transform-react-inline-elements": "7.2.0",
     "@babel/plugin-transform-typeof-symbol": "7.2.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "7.4.4",
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "^7.6.0",
@@ -188,7 +189,6 @@
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",
-    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/polyfill": "7.4.4",
     "@types/enzyme": "3.1.10",
     "@types/enzyme-adapter-react-16": "1.0.2",


### PR DESCRIPTION
this is a hotfix for an error on deploying production, when migrate is launched babel-dynamic-import-plugin is not available because its set as dev dependency, i think this is correct but right now i do not have a better solution for this and it is not critical.
