### PR TITLE
Files to updatelogs migration

### DIFF
--- a/app/api/migrations/migrations/22-files-to-updatelogs/index.js
+++ b/app/api/migrations/migrations/22-files-to-updatelogs/index.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-await-in-loop, max-statements */
+export default {
+  delta: 22,
+
+  name: 'files-to-updatelogs',
+
+  description: 'update previously migrated files to updatelogs',
+
+  async up(db) {
+    process.stdout.write(`${this.name}...\r\n`);
+    const cursor = db.collection('files').find({});
+
+    let index = 1;
+
+    const [sync] = await db
+      .collection('syncs')
+      .find()
+      .toArray();
+
+    while (await cursor.hasNext()) {
+      const file = await cursor.next();
+      await db.collection('updatelogs').insertOne({
+        timestamp: sync ? sync.lastSync : 0,
+        namespace: 'files',
+        mongoId: file._id,
+        deleted: false,
+      });
+      process.stdout.write(` -> processed: ${index} \r`);
+      index += 1;
+    }
+  },
+};

--- a/app/api/migrations/migrations/22-files-to-updatelogs/index.js
+++ b/app/api/migrations/migrations/22-files-to-updatelogs/index.js
@@ -19,12 +19,21 @@ export default {
 
     while (await cursor.hasNext()) {
       const file = await cursor.next();
-      await db.collection('updatelogs').insertOne({
-        timestamp: sync ? sync.lastSync : 0,
-        namespace: 'files',
-        mongoId: file._id,
-        deleted: false,
-      });
+      const logExists = (
+        await db
+          .collection('updatelogs')
+          .find({ mongoId: file._id })
+          .toArray()
+      ).length;
+
+      if (!logExists) {
+        await db.collection('updatelogs').insertOne({
+          timestamp: sync ? sync.lastSync : 0,
+          namespace: 'files',
+          mongoId: file._id,
+          deleted: false,
+        });
+      }
       process.stdout.write(` -> processed: ${index} \r`);
       index += 1;
     }

--- a/app/api/migrations/migrations/22-files-to-updatelogs/specs/22-files-to-updatelogs.spec.js
+++ b/app/api/migrations/migrations/22-files-to-updatelogs/specs/22-files-to-updatelogs.spec.js
@@ -1,6 +1,6 @@
 import testingDB from 'api/utils/testing_db';
 import migration from '../index.js';
-import fixtures, { file1, file2 } from './fixtures.js';
+import fixtures, { file1, file2, file3 } from './fixtures.js';
 
 const query = (collectionName, queryObject = {}, select = {}) =>
   testingDB.mongodb
@@ -24,24 +24,29 @@ describe('migration files-to-updatelogs', () => {
 
   it('should create entries on updatelogs for all files', async () => {
     await migration.up(testingDB.mongodb);
-    const [file1log, file2log] = await query('updatelogs');
+    const fileLogs = await query('updatelogs');
 
-    expect(file1log).toEqual(
+    expect(fileLogs.length).toBe(3);
+    expect(fileLogs).toEqual([
+      expect.objectContaining({
+        timestamp: 50,
+        namespace: 'files',
+        mongoId: file3,
+        deleted: false,
+      }),
       expect.objectContaining({
         timestamp: 0,
         namespace: 'files',
         mongoId: file1,
         deleted: false,
-      })
-    );
-    expect(file2log).toEqual(
+      }),
       expect.objectContaining({
         timestamp: 0,
         namespace: 'files',
         mongoId: file2,
         deleted: false,
-      })
-    );
+      }),
+    ]);
   });
 
   describe('when it has lastSync', () => {
@@ -51,8 +56,13 @@ describe('migration files-to-updatelogs', () => {
       });
 
       await migration.up(testingDB.mongodb);
-      const [file1log, file2log] = await query('updatelogs');
+      const [file3log, file1log, file2log] = await query('updatelogs');
 
+      expect(file3log).toEqual(
+        expect.objectContaining({
+          timestamp: 50,
+        })
+      );
       expect(file1log).toEqual(
         expect.objectContaining({
           timestamp: 20,

--- a/app/api/migrations/migrations/22-files-to-updatelogs/specs/fixtures.js
+++ b/app/api/migrations/migrations/22-files-to-updatelogs/specs/fixtures.js
@@ -1,6 +1,6 @@
 import db from 'api/utils/testing_db';
 
-const [file1, file2] = [db.id(), db.id()];
+const [file1, file2, file3] = [db.id(), db.id(), db.id()];
 
 export default {
   files: [
@@ -10,7 +10,19 @@ export default {
     {
       _id: file2,
     },
+    {
+      _id: file3,
+    },
+  ],
+  updatelogs: [
+    {
+      _id: db.id(),
+      timestamp: 50,
+      namespace: 'files',
+      mongoId: file3,
+      deleted: false,
+    },
   ],
 };
 
-export { file1, file2 };
+export { file1, file2, file3 };

--- a/app/api/migrations/migrations/22-files-to-updatelogs/specs/fixtures.js
+++ b/app/api/migrations/migrations/22-files-to-updatelogs/specs/fixtures.js
@@ -1,0 +1,16 @@
+import db from 'api/utils/testing_db';
+
+const [file1, file2] = [db.id(), db.id()];
+
+export default {
+  files: [
+    {
+      _id: file1,
+    },
+    {
+      _id: file2,
+    },
+  ],
+};
+
+export { file1, file2 };

--- a/app/api/migrations/migrations/23-fix_udaptelogs/index.js
+++ b/app/api/migrations/migrations/23-fix_udaptelogs/index.js
@@ -1,0 +1,12 @@
+export default {
+  delta: 23,
+
+  name: 'fix_udaptelogs',
+
+  description: 'delete update logs without mongoId',
+
+  async up(db) {
+    process.stdout.write(`${this.name}...\r\n`);
+    await db.collection('updatelogs').removeMany({ mongoId: { $exists: false } });
+  },
+};

--- a/app/api/migrations/migrations/23-fix_udaptelogs/specs/23-fix_udaptelogs.spec.js
+++ b/app/api/migrations/migrations/23-fix_udaptelogs/specs/23-fix_udaptelogs.spec.js
@@ -1,0 +1,37 @@
+import testingDB from 'api/utils/testing_db';
+import migration from '../index.js';
+import fixtures from './fixtures.js';
+
+describe('migration fix_udaptelogs', () => {
+  beforeEach(async () => {
+    spyOn(process.stdout, 'write');
+    await testingDB.clearAllAndLoad(fixtures);
+  });
+
+  afterAll(async () => {
+    await testingDB.disconnect();
+  });
+
+  it('should have a delta number', () => {
+    expect(migration.delta).toBe(23);
+  });
+
+  it('should remove all updatelogs without mongoId', async () => {
+    await migration.up(testingDB.mongodb);
+    const updatelogs = await testingDB.mongodb
+      .collection('updatelogs')
+      .find()
+      .toArray();
+
+    expect(updatelogs).toEqual([
+      expect.objectContaining({
+        mongoId: expect.anything(),
+        namespace: 'entities',
+      }),
+      expect.objectContaining({
+        mongoId: expect.anything(),
+        namespace: 'entities',
+      }),
+    ]);
+  });
+});

--- a/app/api/migrations/migrations/23-fix_udaptelogs/specs/fixtures.js
+++ b/app/api/migrations/migrations/23-fix_udaptelogs/specs/fixtures.js
@@ -1,0 +1,20 @@
+import db from 'api/utils/testing_db';
+
+export default {
+  updatelogs: [
+    {
+      mongoId: db.id(),
+      namespace: 'entities',
+    },
+    {
+      mongoId: db.id(),
+      namespace: 'entities',
+    },
+    {
+      namespace: 'entities',
+    },
+    {
+      namespace: 'entities',
+    },
+  ],
+};

--- a/app/api/migrations/templates/migration.spec.txt
+++ b/app/api/migrations/templates/migration.spec.txt
@@ -1,23 +1,22 @@
-import { catchErrors } from 'api/utils/jasmineHelpers';
 import testingDB from 'api/utils/testing_db';
 import migration from '../index.js';
 import fixtures from './fixtures.js';
 
 describe('migration {{ name }}', () => {
-  beforeEach((done) => {
+  beforeEach(async () => {
     spyOn(process.stdout, 'write');
-    testingDB.clearAllAndLoad(fixtures).then(done).catch(catchErrors(done));
+    await testingDB.clearAllAndLoad(fixtures);
   });
 
-  afterAll((done) => {
-    testingDB.disconnect().then(done);
+  afterAll(async () => {
+    await testingDB.disconnect();
   });
 
   it('should have a delta number', () => {
     expect(migration.delta).toBe({{nextMigrationDelta}});
   });
 
-  it('should fail', (done) => {
-    migration.up().catch(catchErrors(done));
+  it('should fail', async () => {
+    await migration.up();
   });
 });

--- a/app/api/migrations/templates/migration.txt
+++ b/app/api/migrations/templates/migration.txt
@@ -5,8 +5,8 @@ export default {
 
   description: '{{ description }}',
 
-  up() {
+  async up() {
     process.stdout.write(`${this.name}...\r\n`);
-    return Promise.reject();
-  }
+    return Promise.reject(new Error('error! change this, recently created migration'));
+  },
 };

--- a/app/api/odm/model.ts
+++ b/app/api/odm/model.ts
@@ -1,6 +1,5 @@
-/** @format */
-
 import mongoose from 'mongoose';
+import errorLog from 'api/log/errorLog';
 
 import { model as updatelogsModel } from 'api/updatelogs';
 
@@ -32,8 +31,16 @@ class UpdateLogHelper {
   }
 
   upsertLogOne(doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
+    // temporary prevent creating updateLogs without mongoid, log error
+    if (!doc._id) {
+      errorLog.error(
+        `ERROR, Update Log received a doc without _id:\n ${JSON.stringify(doc, null, ' ')}`
+      );
+      return next();
+    }
+    //
     const logData = { namespace: this.collectionName, mongoId: doc._id };
-    asyncPost(async () => {
+    return asyncPost(async () => {
       await updatelogsModel.findOneAndUpdate(
         logData,
         { ...logData, timestamp: Date.now(), deleted: false },

--- a/app/api/updatelogs/updatelogsModel.ts
+++ b/app/api/updatelogs/updatelogsModel.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import mongoose from 'mongoose';
 
 const updateLogSchema = new mongoose.Schema({


### PR DESCRIPTION
this updates the updatelogs collection to include all files logs that were created on migration 21, this migrations do NOT need a reindex.

@RafaPolit this also includes now migration 23, and a errorLog to try to track an error happening and creating updatelogs without mongoId, we are assuming here that when this happens the document does not get created, all this migration does is remove those bugged updatelogs for the sync to coninue working.

fixes #2779

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
