### PR TITLE
Fix updtelogs without mongoid

### DIFF
--- a/app/api/migrations/migrations/24-fix_updatelogs_again/index.js
+++ b/app/api/migrations/migrations/24-fix_updatelogs_again/index.js
@@ -1,0 +1,12 @@
+export default {
+  delta: 24,
+
+  name: 'fix_udaptelogs_again',
+
+  description: 'delete update logs without mongoId',
+
+  async up(db) {
+    process.stdout.write(`${this.name}...\r\n`);
+    await db.collection('updatelogs').removeMany({ mongoId: { $exists: false } });
+  },
+};

--- a/app/api/migrations/migrations/24-fix_updatelogs_again/specs/24-fix_udaptelogs.spec.js
+++ b/app/api/migrations/migrations/24-fix_updatelogs_again/specs/24-fix_udaptelogs.spec.js
@@ -1,0 +1,37 @@
+import testingDB from 'api/utils/testing_db';
+import migration from '../index.js';
+import fixtures from './fixtures.js';
+
+describe('migration fix_udaptelogs', () => {
+  beforeEach(async () => {
+    spyOn(process.stdout, 'write');
+    await testingDB.clearAllAndLoad(fixtures);
+  });
+
+  afterAll(async () => {
+    await testingDB.disconnect();
+  });
+
+  it('should have a delta number', () => {
+    expect(migration.delta).toBe(24);
+  });
+
+  it('should remove all updatelogs without mongoId', async () => {
+    await migration.up(testingDB.mongodb);
+    const updatelogs = await testingDB.mongodb
+      .collection('updatelogs')
+      .find()
+      .toArray();
+
+    expect(updatelogs).toEqual([
+      expect.objectContaining({
+        mongoId: expect.anything(),
+        namespace: 'entities',
+      }),
+      expect.objectContaining({
+        mongoId: expect.anything(),
+        namespace: 'entities',
+      }),
+    ]);
+  });
+});

--- a/app/api/migrations/migrations/24-fix_updatelogs_again/specs/fixtures.js
+++ b/app/api/migrations/migrations/24-fix_updatelogs_again/specs/fixtures.js
@@ -1,0 +1,20 @@
+import db from 'api/utils/testing_db';
+
+export default {
+  updatelogs: [
+    {
+      mongoId: db.id(),
+      namespace: 'entities',
+    },
+    {
+      mongoId: db.id(),
+      namespace: 'entities',
+    },
+    {
+      namespace: 'entities',
+    },
+    {
+      namespace: 'entities',
+    },
+  ],
+};

--- a/app/api/odm/model.ts
+++ b/app/api/odm/model.ts
@@ -31,14 +31,6 @@ class UpdateLogHelper {
   }
 
   upsertLogOne(doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
-    // temporary prevent creating updateLogs without mongoid, log error
-    if (!doc._id) {
-      errorLog.error(
-        `ERROR, Update Log received a doc without _id:\n ${JSON.stringify(doc, null, ' ')}`
-      );
-      return next();
-    }
-    //
     const logData = { namespace: this.collectionName, mongoId: doc._id };
     return asyncPost(async () => {
       await updatelogsModel.findOneAndUpdate(
@@ -53,7 +45,7 @@ class UpdateLogHelper {
     await updatelogsModel.updateMany(
       { mongoId: { $in: affectedIds }, namespace: this.collectionName },
       { $set: { timestamp: Date.now(), deleted } },
-      { upsert: true, lean: true }
+      { lean: true }
     );
   }
 }

--- a/app/api/odm/model.ts
+++ b/app/api/odm/model.ts
@@ -1,5 +1,4 @@
 import mongoose from 'mongoose';
-import errorLog from 'api/log/errorLog';
 
 import { model as updatelogsModel } from 'api/updatelogs';
 


### PR DESCRIPTION
in this PR the bug on updatelogs without mongoId its properly fixed, i had to do again migration 23 as migration 24 to remove any other entries with null mongoId created during this period, this was possible even with the guard condition because happened on delete calling updateMany:
https://github.com/huridocs/uwazi/blob/e7bd217dc688e968bbab5422f2c2e0f77fc15f06/app/api/odm/model.ts#L52-L58

whenever an empty array of affectedIds is passed this method, this actually creates an entry with only the $set object properties, this is because of the **upsert: true** that actually makes no sense in this query as it is supposed to update only, i also think this behaviour makes no sense on mongo itself, probably missing some bigger context, anyway this was the cause.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
