### PR TITLE
gelocation label now is optional

### DIFF
--- a/app/api/entities/metadataValidators.js
+++ b/app/api/entities/metadataValidators.js
@@ -44,8 +44,7 @@ const isValidDateRange = value => {
 
 const isValidSelect = value => isString(value);
 
-const isValidGeolocation = value =>
-  isString(value.label) && isNumber(value.lat) && isNumber(value.lon);
+const isValidGeolocation = value => isNumber(value.lat) && isNumber(value.lon);
 
 const validateRequiredProperty = (property, value) => {
   if (property.required) {

--- a/app/api/entities/specs/entitySchema.spec.js
+++ b/app/api/entities/specs/entitySchema.spec.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /* eslint-disable max-lines,max-statements */
 
 import db from 'api/utils/testing_db';
@@ -409,10 +407,11 @@ describe('entity schema', () => {
         });
         it('should fail if label is not a string', async () => {
           entity.metadata.geolocation[0].value.label = 10;
-          await expectError(
-            customErrorMessages[propertyTypes.geolocation],
-            ".metadata['geolocation']"
-          );
+          await expectError('should be string', ".metadata['geolocation'][0].value");
+        });
+        it('should not fail if label is not present', async () => {
+          entity.metadata.geolocation[0].value.label = undefined;
+          await testValid();
         });
         it('should fail if lat or lon is missing', async () => {
           entity.metadata.geolocation = [{ value: { lon: 80, label: '' } }];

--- a/app/shared/types/entitySchema.js
+++ b/app/shared/types/entitySchema.js
@@ -1,5 +1,3 @@
-/** @format */
-
 import Ajv from 'ajv';
 import templatesModel from 'api/templates/templatesModel';
 import { isUndefined, isNull } from 'util';


### PR DESCRIPTION
validation for gelocation fields assume label should be a string, this fails when the label does not exist. most instances have this type of data where geolocation does not have a string.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
