### PR TITLE
Stringify the error since not always contains a message

### DIFF
--- a/database/reindex_elastic.js
+++ b/database/reindex_elastic.js
@@ -97,7 +97,9 @@ const processErrors = async err => {
   if (err instanceof IndexError) {
     process.stdout.write('\r\nWarning! Errors found during reindex.\r\n');
   } else {
-    errorLog.error(`Uncaught Reindex error.\r\n${err.message}\r\nWill exit with (1)\r\n`);
+    errorLog.error(
+      `Uncaught Reindex error.\r\n${JSON.stringify(err, '', '\r')}\r\nWill exit with (1)\r\n`
+    );
     await endScriptProcedures();
     throw err;
   }


### PR DESCRIPTION
I found some situations where the exceptions do not contain a message but a reason. Since this particular error logging is very well bounded to the scope "uncaught elastic reindexing errors", I think is ok to treat it as a special case and just stringify the whole error object. Otherwise, I was getting an "undefined" message on index mapping misconfigurations.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
