### PR TITLE
properly print error when not instanceof Error

### DIFF
--- a/database/reindex_elastic.js
+++ b/database/reindex_elastic.js
@@ -97,9 +97,8 @@ const processErrors = async err => {
   if (err instanceof IndexError) {
     process.stdout.write('\r\nWarning! Errors found during reindex.\r\n');
   } else {
-    errorLog.error(
-      `Uncaught Reindex error.\r\n${JSON.stringify(err, '', '\r')}\r\nWill exit with (1)\r\n`
-    );
+    const errorMsg = err instanceof Error ? err.message : JSON.stringify(err, null, ' ');
+    errorLog.error(`Uncaught Reindex error.\r\n${errorMsg}\r\nWill exit with (1)\r\n`);
     await endScriptProcedures();
     throw err;
   }


### PR DESCRIPTION
Fixes previous merge #3057.

this errors that are not instance of Error come from JSONRequest:
https://github.com/huridocs/uwazi/blob/49e93aed0aa0062cf0378380c5d4a0f621825752/app/shared/JSONRequest.js#L98-L109
at some point i think we should rethink this for consistency, but for now a condition on the error print its enough.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
