### PR TITLE
[HOTFIX] formatMessage takes into account current tenant

### DIFF
--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -23,6 +23,7 @@ export const config = {
   multiTenant: process.env.MULTI_TENANT || false,
   clusterMode: CLUSTER_MODE,
   defaultTenant: <Tenant>{
+    name: 'default',
     dbName: process.env.DATABASE_NAME || 'uwazi_development',
     indexName: process.env.INDEX_NAME || 'uwazi_development',
     uploadedDocuments: UPLOADS_FOLDER || `${rootPath}/uploaded_documents/`,

--- a/app/api/log/errorLog.js
+++ b/app/api/log/errorLog.js
@@ -15,18 +15,19 @@ const createFileTransport = () =>
     format: winston.format.combine(winston.format.timestamp(), formatter),
   });
 
-const consoleTransport = new winston.transports.Console({
-  handleExceptions: true,
-  level: 'error',
-  format: winston.format.combine(winston.format.timestamp(), formatter),
-});
+const createConsoleTransport = () =>
+  new winston.transports.Console({
+    handleExceptions: true,
+    level: 'error',
+    format: winston.format.combine(winston.format.timestamp(), formatter),
+  });
 
 export const createErrorLog = () => {
   DATABASE_NAME = process.env.DATABASE_NAME ? process.env.DATABASE_NAME : 'localhost';
   LOGS_DIR = process.env.LOGS_DIR ? process.env.LOGS_DIR : './log';
 
   const logger = winston.createLogger({
-    transports: [createFileTransport(), consoleTransport],
+    transports: [createFileTransport(), createConsoleTransport()],
   });
 
   logger.closeGraylog = (cb = () => {}) => {

--- a/app/api/log/formatMessage.js
+++ b/app/api/log/formatMessage.js
@@ -1,7 +1,14 @@
+import { tenants } from 'api/tenants';
+import { config } from 'api/config';
+
 export default function formatMessage(info, instanceName) {
   const message = info.message && info.message.join ? info.message.join('\n') : info.message;
 
-  const result = `${info.timestamp} [${instanceName}] ${message}`;
+  let tenantName = instanceName;
+  if (info.shouldBeMultiTenantContext) {
+    const tenant = tenants.current();
+    tenantName = tenant.name === config.defaultTenant.name ? instanceName : tenant.name;
+  }
 
-  return result;
+  return `${info.timestamp} [${tenantName}] ${message}`;
 }

--- a/app/api/log/specs/GrayLogTransport.spec.js
+++ b/app/api/log/specs/GrayLogTransport.spec.js
@@ -1,3 +1,4 @@
+import { tenants } from 'api/tenants';
 import GrayLogTransport from '../GrayLogTransport';
 
 describe('GrayLogTransport', () => {
@@ -10,13 +11,16 @@ describe('GrayLogTransport', () => {
     expect(aTransport.graylog.constructor.name).toBe('graylog');
   });
 
-  it('should pass log call to graylog2 instance', () => {
+  it('should pass log call to graylog2 instance', async () => {
     const aTransport = new GrayLogTransport({
       instance_name: 'some_name',
     });
 
     spyOn(aTransport.graylog, 'log');
-    aTransport.log('message', () => {});
+
+    await tenants.run(async () => {
+      aTransport.log('message', () => {});
+    });
 
     expect(aTransport.graylog.log).toHaveBeenCalled();
   });

--- a/app/api/socketio/setupSockets.ts
+++ b/app/api/socketio/setupSockets.ts
@@ -27,7 +27,7 @@ const setupSockets = (server: Server, app: Application) => {
   const io: SocketIoServer = socketIo(server);
 
   io.on('connection', socket => {
-    socket.join(socket.request.headers.tenant || tenants.defaultTenantName);
+    socket.join(socket.request.headers.tenant || config.defaultTenant.name);
   });
 
   io.emitToCurrentTenant = (event, ...args) => {

--- a/app/api/socketio/specs/socketClusterMode.spec.ts
+++ b/app/api/socketio/specs/socketClusterMode.spec.ts
@@ -92,15 +92,21 @@ describe('socket middlewares setup', () => {
     return events;
   };
 
-  const requestTestRoute = async (tenant: string = '') =>
-    request(server)
-      .get('/api/test')
-      .set('tenant', tenant)
-      .expect(response => {
-        if (response.status !== 200) {
-          throw new Error(response.text);
-        }
+  const requestTestRoute = async (tenant?: string) => {
+    const req = request(server).get('/api/test');
+
+    if (tenant) {
+      req.set('tenant', tenant).catch(e => {
+        throw e;
       });
+    }
+
+    return req.expect(response => {
+      if (response.status !== 200) {
+        throw new Error(response.text);
+      }
+    });
+  };
 
   describe('when performing a request to tenant1', () => {
     it('should only emit socket events to tenant1 sockets', async () => {

--- a/app/api/tenants/index.ts
+++ b/app/api/tenants/index.ts
@@ -1,0 +1,1 @@
+export { tenants } from './tenantContext';

--- a/app/api/tenants/tenantContext.ts
+++ b/app/api/tenants/tenantContext.ts
@@ -16,13 +16,11 @@ export type Tenant = {
 class Tenants {
   storage = new AsyncLocalStorage<string>();
 
-  defaultTenantName = 'default';
-
   tenants: { [k: string]: Tenant };
 
   constructor() {
     this.tenants = {
-      [this.defaultTenantName]: { name: this.defaultTenantName, ...config.defaultTenant },
+      [config.defaultTenant.name]: config.defaultTenant,
     };
   }
 
@@ -42,9 +40,12 @@ class Tenants {
     });
   }
 
-  async run(cb: () => Promise<void>, tenantName?: string): Promise<void> {
+  async run(
+    cb: () => Promise<void>,
+    tenantName: string = config.defaultTenant.name
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.storage.run(tenantName || this.defaultTenantName, () => {
+      this.storage.run(tenantName, () => {
         cb()
           .then(resolve)
           .catch(reject);

--- a/app/api/utils/handleError.js
+++ b/app/api/utils/handleError.js
@@ -79,7 +79,7 @@ const prettifyError = (error, { req = {}, uncaught = false } = {}) => {
   return result;
 };
 
-export default (_error, { req = {}, uncaught = false } = {}) => {
+export default (_error, { req = undefined, uncaught = false } = {}) => {
   const error = _error || new Error('undefined error occurred');
   const responseToClientError = error.json;
 
@@ -89,8 +89,13 @@ export default (_error, { req = {}, uncaught = false } = {}) => {
 
   const result = prettifyError(error, { req, uncaught });
 
+  let errorOptions = {};
+  if (req) {
+    errorOptions.shouldBeMultiTenantContext = true;
+  }
+
   if (result.code === 500) {
-    errorLog.error(result.prettyMessage);
+    errorLog.error(result.prettyMessage, errorOptions);
   } else if (result.code === 400) {
     debugLog.debug(result.prettyMessage);
   }

--- a/app/api/utils/specs/error_handling_middleware.spec.js
+++ b/app/api/utils/specs/error_handling_middleware.spec.js
@@ -27,7 +27,9 @@ describe('Error handling middleware', () => {
     req.originalUrl = 'url';
     middleware(error, req, res, next);
 
-    expect(errorLog.error).toHaveBeenCalledWith('\nurl: url\nerror');
+    expect(errorLog.error).toHaveBeenCalledWith('\nurl: url\nerror', {
+      shouldBeMultiTenantContext: true,
+    });
   });
 
   it('should log the error body', () => {
@@ -35,12 +37,13 @@ describe('Error handling middleware', () => {
     req.body = { param: 'value', param2: 'value2' };
     middleware(error, req, res, next);
     expect(errorLog.error).toHaveBeenCalledWith(
-      `\nbody: ${JSON.stringify(req.body, null, ' ')}\nerror`
+      `\nbody: ${JSON.stringify(req.body, null, ' ')}\nerror`,
+      { shouldBeMultiTenantContext: true }
     );
 
     req.body = {};
     middleware(error, req, res, next);
-    expect(errorLog.error).toHaveBeenCalledWith('\nerror');
+    expect(errorLog.error).toHaveBeenCalledWith('\nerror', { shouldBeMultiTenantContext: true });
   });
 
   it('should log the error query', () => {
@@ -49,7 +52,8 @@ describe('Error handling middleware', () => {
     middleware(error, req, res, next);
 
     expect(errorLog.error).toHaveBeenCalledWith(
-      `\nquery: ${JSON.stringify(req.query, null, ' ')}\nerror`
+      `\nquery: ${JSON.stringify(req.query, null, ' ')}\nerror`,
+      { shouldBeMultiTenantContext: true }
     );
   });
 });

--- a/app/api/utils/specs/handleError.spec.js
+++ b/app/api/utils/specs/handleError.spec.js
@@ -23,7 +23,7 @@ describe('handleError', () => {
       const error = new Error('error');
       handleError(error);
 
-      expect(errorLog.error).toHaveBeenCalledWith(`\n${error.stack}`);
+      expect(errorLog.error).toHaveBeenCalledWith(`\n${error.stack}`, {});
     });
   });
 
@@ -38,7 +38,7 @@ describe('handleError', () => {
       expect(errorLog.error).not.toHaveBeenCalled();
 
       handleError(createError('test error'));
-      expect(errorLog.error).toHaveBeenCalledWith('\ntest error');
+      expect(errorLog.error).toHaveBeenCalledWith('\ntest error', {});
     });
   });
 

--- a/app/server.js
+++ b/app/server.js
@@ -45,7 +45,6 @@ const uncaughtError = error => {
 
 process.on('unhandledRejection', uncaughtError);
 process.on('uncaughtException', uncaughtError);
-http.on('error', handleError);
 
 const oneYear = 31557600;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "main": "server.js",
   "repository": {


### PR DESCRIPTION
Error formatter now uses tenant name to identify the error, when tenant name is "default" then the current DB name is used for backwards compatibility.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
