### PR TITLE
yarn migrate script now works on prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "restore-db": "./database/restore_db.sh",
     "fixtures": "./uwazi-fixtures/restore.sh",
     "add-migration": "./node_modules/.bin/plop --plopfile ./app/api/migrations/plopfile.js migration",
-    "migrate": "node --max-http-header-size 20000 run.js ./app/api/migrations/migrate.ts",
+    "migrate": "node --max-http-header-size 20000 run.js ./app/api/migrations/migrate",
     "test-debug": "node --max-http-header-size 20000 --inspect ./node_modules/.bin/jest --watch --no-cache -i",
     "test": "node --max-http-header-size 20000 ./node_modules/.bin/jest",
     "e2e": "jest --projects nightmare/jest.e2e.config.js -i --verbose true",


### PR DESCRIPTION
migrate was not working on production, because the script specifies, migrate.TS, this is not true on prod build, all files are .JS after transpilation
 
PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
