### PR TITLE
Multitenant context refactor

### DIFF
--- a/app/api/socketio/specs/socketClusterMode.spec.ts
+++ b/app/api/socketio/specs/socketClusterMode.spec.ts
@@ -6,6 +6,7 @@ import { multitenantMiddleware } from 'api/utils/multitenantMiddleware';
 import { tenants, Tenant } from 'api/tenants/tenantContext';
 
 import { setupSockets } from '../setupSockets';
+import { appContextMiddleware } from 'api/utils/appContextMiddleware';
 
 const closeServer = async (httpServer: Server) =>
   new Promise(resolve => {
@@ -55,6 +56,7 @@ const app: Application = express();
 describe('socket middlewares setup', () => {
   beforeAll(async () => {
     server = await createServer(app, port);
+    app.use(appContextMiddleware);
     app.use(multitenantMiddleware);
     setupSockets(server, app);
 

--- a/app/api/sync/specs/uploadRoute.spec.ts
+++ b/app/api/sync/specs/uploadRoute.spec.ts
@@ -10,6 +10,7 @@ import { testingTenants } from 'api/utils/testingTenants';
 import { multitenantMiddleware } from 'api/utils/multitenantMiddleware';
 
 import syncRoutes from '../routes';
+import { appContextMiddleware } from 'api/utils/appContextMiddleware';
 
 jest.mock(
   '../../auth/authMiddleware.ts',
@@ -33,6 +34,7 @@ describe('sync', () => {
       await deleteFile(uploadsPath('testUpload.txt'));
 
       const app = express();
+      app.use(appContextMiddleware);
       app.use(multitenantMiddleware);
       syncRoutes(app);
 

--- a/app/api/tenants/tenantContext.ts
+++ b/app/api/tenants/tenantContext.ts
@@ -38,6 +38,13 @@ class Tenants {
     });
   }
 
+  /**
+   * This is a proxy to the context run method using only the tenant information.
+   * It is here for backwards compatibility after refactoring.
+   * @param cb The callback to run in the context
+   * @param tenantName Tenant name
+   */
+  // eslint-disable-next-line class-methods-use-this
   async run(
     cb: () => Promise<void>,
     tenantName: string = config.defaultTenant.name

--- a/app/api/utils/AppContext.ts
+++ b/app/api/utils/AppContext.ts
@@ -7,6 +7,12 @@ interface ContextData {
 class AppContext {
   private storage = new AsyncLocalStorage<ContextData>();
 
+  private getContextObject() {
+    const data = this.storage.getStore();
+    if (!data) throw new Error('Accessing nonexistent async context');
+    return data;
+  }
+
   async run(cb: () => Promise<void>, data: ContextData = {}): Promise<void> {
     return new Promise((resolve, reject) => {
       this.storage.run(data, () => {
@@ -18,13 +24,11 @@ class AppContext {
   }
 
   get(key: string) {
-    const data = this.storage.getStore();
-    return data && data[key];
+    return this.getContextObject()[key];
   }
 
   set(key: string, value: unknown) {
-    const data = this.storage.getStore();
-    if (data) data[key] = value;
+    this.getContextObject()[key] = value;
   }
 }
 

--- a/app/api/utils/AppContext.ts
+++ b/app/api/utils/AppContext.ts
@@ -1,0 +1,33 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+interface ContextData {
+  [k: string]: unknown;
+}
+
+class AppContext {
+  private storage = new AsyncLocalStorage<ContextData>();
+
+  async run(cb: () => Promise<void>, data: ContextData = {}): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.storage.run(data, () => {
+        cb()
+          .then(resolve)
+          .catch(reject);
+      });
+    });
+  }
+
+  get(key: string) {
+    const data = this.storage.getStore();
+    return data && data[key];
+  }
+
+  set(key: string, value: unknown) {
+    const data = this.storage.getStore();
+    if (data) data[key] = value;
+  }
+}
+
+const appContext = new AppContext();
+
+export { appContext };

--- a/app/api/utils/appContextMiddleware.ts
+++ b/app/api/utils/appContextMiddleware.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+import { appContext } from 'api/utils/AppContext';
+
+const appContextMiddleware = (_req: Request, _res: Response, next: NextFunction) => {
+  appContext
+    .run(async () => {
+      next();
+    })
+    .catch(next);
+};
+
+export { appContextMiddleware };

--- a/app/api/utils/multitenantMiddleware.ts
+++ b/app/api/utils/multitenantMiddleware.ts
@@ -1,12 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
-import { tenants } from 'api/tenants/tenantContext';
+import { appContext } from 'api/utils/AppContext';
+import { config } from 'api/config';
 
 const multitenantMiddleware = (req: Request, _res: Response, next: NextFunction) => {
-  tenants
-    .run(async () => {
-      next();
-    }, req.get('tenant'))
-    .catch(next);
+  appContext.set('tenant', req.get('tenant') || config.defaultTenant.name);
+  next();
 };
 
 export { multitenantMiddleware };

--- a/app/api/utils/specs/appContext.spec.ts
+++ b/app/api/utils/specs/appContext.spec.ts
@@ -47,4 +47,20 @@ describe('appContext', () => {
       );
     });
   });
+
+  describe('when outside a context', () => {
+    const error = new Error('Accessing nonexistent async context');
+
+    it('should throw on get', () => {
+      expect(() => {
+        appContext.get('somKey');
+      }).toThrow(error);
+    });
+
+    it('should throw on set', () => {
+      expect(() => {
+        appContext.set('somKey', 'someValue');
+      }).toThrow(error);
+    });
+  });
 });

--- a/app/api/utils/specs/appContext.spec.ts
+++ b/app/api/utils/specs/appContext.spec.ts
@@ -1,0 +1,50 @@
+import { appContext } from '../AppContext';
+
+describe('appContext', () => {
+  describe('when running the callback inside a context', () => {
+    it('it should access the given values', async () => {
+      await appContext.run(
+        async () => {
+          expect(appContext.get('key1')).toBe('value1');
+          expect(appContext.get('key2')).toBe('value2');
+        },
+        {
+          key1: 'value1',
+          key2: 'value2',
+        }
+      );
+    });
+
+    it('it should return undefined if accessing an unexising key', async () => {
+      await appContext.run(
+        async () => {
+          expect(appContext.get('non-existing')).toBe(undefined);
+        },
+        {
+          key: 'value',
+        }
+      );
+    });
+
+    it('it should set a new key', async () => {
+      await appContext.run(async () => {
+        expect(appContext.get('someKey')).toBe(undefined);
+        appContext.set('someKey', 'someValue');
+        expect(appContext.get('someKey')).toBe('someValue');
+      });
+    });
+
+    it('it should overwrite existing keys', async () => {
+      await appContext.run(
+        async () => {
+          expect(appContext.get('someKey')).toBe('previous');
+          appContext.set('someKey', 'someValue');
+          expect(appContext.get('someKey')).toBe('someValue');
+        },
+        {
+          someKey: 'previous',
+        }
+      );
+    });
+  });
+});

--- a/app/api/utils/specs/appContextMiddleware.spec.ts
+++ b/app/api/utils/specs/appContextMiddleware.spec.ts
@@ -1,0 +1,31 @@
+import request from 'supertest';
+import express, { Application, Request, Response, NextFunction } from 'express';
+import { appContextMiddleware } from '../appContextMiddleware';
+import { appContext } from '../AppContext';
+
+const testingRoutes = (app: Application) => {
+  app.get('/api/testGET', (_req, res, next) => {
+    res.json(appContext.get('someKey'));
+    next();
+  });
+};
+
+const helperMiddleware = (req: Request, _res: Response, next: NextFunction) => {
+  appContext.set('someKey', req.get('someHeader'));
+  next();
+};
+
+describe('multitenant middleware', () => {
+  it('should execute next middlewares inside an async context', async () => {
+    const app: Application = express();
+    app.use(appContextMiddleware);
+    app.use(helperMiddleware);
+    testingRoutes(app);
+
+    const response = await request(app)
+      .get('/api/testGET')
+      .set('someHeader', 'test');
+
+    expect(response.text).toBe(JSON.stringify('test'));
+  });
+});

--- a/app/api/utils/specs/appContextMiddleware.spec.ts
+++ b/app/api/utils/specs/appContextMiddleware.spec.ts
@@ -15,7 +15,7 @@ const helperMiddleware = (req: Request, _res: Response, next: NextFunction) => {
   next();
 };
 
-describe('multitenant middleware', () => {
+describe('appcontext middleware', () => {
   it('should execute next middlewares inside an async context', async () => {
     const app: Application = express();
     app.use(appContextMiddleware);

--- a/app/api/utils/specs/multitenantMiddleware.spec.ts
+++ b/app/api/utils/specs/multitenantMiddleware.spec.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import express, { Application } from 'express';
 import { tenants } from 'api/tenants/tenantContext';
 import { multitenantMiddleware } from '../multitenantMiddleware';
+import { appContextMiddleware } from '../appContextMiddleware';
 
 const testingRoutes = (app: Application) => {
   app.get('/api/testGET', (_req, res, next) => {
@@ -16,6 +17,7 @@ describe('multitenant middleware', () => {
     tenants.add({ name: 'test' });
 
     const app: Application = express();
+    app.use(appContextMiddleware);
     app.use(multitenantMiddleware);
     testingRoutes(app);
 

--- a/app/server.js
+++ b/app/server.js
@@ -10,6 +10,7 @@ import path from 'path';
 
 import { TaskProvider } from 'shared/tasks/tasks';
 
+import { appContextMiddleware } from 'api/utils/appContextMiddleware';
 import uwaziMessage from '../message';
 import apiRoutes from './api/api';
 import privateInstanceMiddleware from './api/auth/privateInstanceMiddleware';
@@ -29,7 +30,6 @@ import { tenants } from './api/tenants/tenantContext';
 import { multitenantMiddleware } from './api/utils/multitenantMiddleware';
 import { staticFilesMiddleware } from './api/utils/staticFilesMiddleware';
 import { customUploadsPath, uploadsPath } from './api/files/filesystem';
-import { appContextMiddleware } from 'api/utils/appContextMiddleware';
 
 mongoose.Promise = Promise;
 

--- a/app/server.js
+++ b/app/server.js
@@ -29,6 +29,7 @@ import { tenants } from './api/tenants/tenantContext';
 import { multitenantMiddleware } from './api/utils/multitenantMiddleware';
 import { staticFilesMiddleware } from './api/utils/staticFilesMiddleware';
 import { customUploadsPath, uploadsPath } from './api/files/filesystem';
+import { appContextMiddleware } from 'api/utils/appContextMiddleware';
 
 mongoose.Promise = Promise;
 
@@ -56,6 +57,8 @@ app.use(compression());
 app.use(express.static(path.resolve(__dirname, '../dist'), { maxage }));
 app.use('/public', express.static(config.publicAssets));
 app.use(/\/((?!remotepublic).)*/, bodyParser.json({ limit: '1mb' }));
+
+app.use(appContextMiddleware);
 
 //////
 // this middleware should go just before any other that accesses to db


### PR DESCRIPTION
This refactors separates the multitenant async context management into two different concerns:

- Multitenancy
- Async context management

This is needed in order to use the async context for other functionalities, e.g user permissions.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
