### PR TITLE
Trying to disable transiations for copy-from e2e

### DIFF
--- a/e2e/helpers/disableTransitions.ts
+++ b/e2e/helpers/disableTransitions.ts
@@ -1,7 +1,8 @@
 /*global page*/
 
 export default async () => {
-  await page.addStyleTag({ content : `
+  await page.addStyleTag({
+    content: `
       *,
       *::after,
       *::before {
@@ -11,5 +12,6 @@ export default async () => {
           animation-duration: 0s !important;
           animation-play-state: paused !important;
           caret-color: transparent !important;
-      }`});
+      }`,
+  });
 };

--- a/e2e/helpers/disableTransitions.ts
+++ b/e2e/helpers/disableTransitions.ts
@@ -1,0 +1,15 @@
+/*global page*/
+
+export default async () => {
+  await page.addStyleTag({ content : `
+      *,
+      *::after,
+      *::before {
+          transition-delay: 0s !important;
+          transition-duration: 0s !important;
+          animation-delay: -0.0001s !important;
+          animation-duration: 0s !important;
+          animation-play-state: paused !important;
+          caret-color: transparent !important;
+      }`});
+};

--- a/e2e/suites/copy-from.test.ts
+++ b/e2e/suites/copy-from.test.ts
@@ -3,6 +3,7 @@
 import { adminLogin, logout } from '../helpers/login';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
+import disableTransitions from '../helpers/disableTransitions';
 import { host } from '../config';
 
 describe('Copy from', () => {
@@ -10,6 +11,7 @@ describe('Copy from', () => {
     await insertFixtures();
     await proxyMock();
     await adminLogin();
+    await disableTransitions();
     await page.goto(`${host}/library`);
   });
 

--- a/e2e/suites/default-library-view.test.ts
+++ b/e2e/suites/default-library-view.test.ts
@@ -4,12 +4,14 @@ import { host } from '../config';
 import { adminLogin, logout } from '../helpers/login';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
+import disableTransitions from '../helpers/disableTransitions';
 
 describe('Entities', () => {
   beforeAll(async () => {
     await insertFixtures();
     await proxyMock();
     await adminLogin();
+    await disableTransitions();
   });
 
   it('Should set the default library view to Table', async () => {

--- a/e2e/suites/entity.test.ts
+++ b/e2e/suites/entity.test.ts
@@ -3,12 +3,14 @@
 import { adminLogin, logout } from '../helpers/login';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
+import disableTransitions from '../helpers/disableTransitions';
 
 describe('Entities', () => {
   beforeAll(async () => {
     await insertFixtures();
     await proxyMock();
     await adminLogin();
+    await disableTransitions();
   });
 
   it('Should create new entity', async () => {

--- a/e2e/suites/graphs.test.ts
+++ b/e2e/suites/graphs.test.ts
@@ -6,6 +6,7 @@ import { adminLogin, logout } from '../helpers/login';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
 import { displayGraph } from '../helpers/graphs';
+import disableTransitions from '../helpers/disableTransitions';
 
 const localSelectors = {
   pageContentsInput:
@@ -24,6 +25,7 @@ describe('Graphs in Page', () => {
     await insertFixtures();
     await proxyMock();
     await adminLogin();
+    await disableTransitions();
   });
 
   it('should create a basic page', async () => {

--- a/e2e/suites/login.test.ts
+++ b/e2e/suites/login.test.ts
@@ -4,11 +4,13 @@ import { host } from '../config';
 import { adminLogin, logout } from '../helpers/login';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
+import disableTransitions from '../helpers/disableTransitions';
 
 describe('Login', () => {
   beforeAll(async () => {
     await insertFixtures();
     await proxyMock();
+    await disableTransitions();
   });
 
   it('Should login as admin', async () => {

--- a/e2e/suites/tableView.test.ts
+++ b/e2e/suites/tableView.test.ts
@@ -4,12 +4,14 @@ import { host } from '../config';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
 import { adminLogin, logout } from '../helpers/login';
+import disableTransitions from '../helpers/disableTransitions';
 
 describe('Table view', () => {
   beforeAll(async () => {
     await insertFixtures();
     await proxyMock();
     await adminLogin();
+    await disableTransitions();
   });
 
   it('Should go to the table view', async () => {


### PR DESCRIPTION
Disables CSS transitions during e2e testing to speed up tests and reduce the chances of hidden elements.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
