### PR TITLE
Added link to documentations in nav menu.

### DIFF
--- a/app/react/Settings/components/SettingsNavigation.js
+++ b/app/react/Settings/components/SettingsNavigation.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import { I18NLink, t } from 'app/I18N';
+import { I18NLink, t, Translate } from 'app/I18N';
 import { NeedAuthorization } from 'app/Auth';
+import { Icon } from 'app/UI';
 
 export class SettingsNavigation extends Component {
   render() {
@@ -89,10 +90,10 @@ export class SettingsNavigation extends Component {
             </div>
           </div>
         </NeedAuthorization>
-        <NeedAuthorization roles={['admin']}>
-          <div className="panel panel-default">
-            <div className="panel-heading">{t('System', 'Tools')}</div>
-            <div className="list-group">
+        <div className="panel panel-default">
+          <div className="panel-heading">{t('System', 'Tools')}</div>
+          <div className="list-group">
+            <NeedAuthorization roles={['admin']}>
               <I18NLink
                 to="settings/activitylog"
                 activeClassName="active"
@@ -100,9 +101,19 @@ export class SettingsNavigation extends Component {
               >
                 {t('System', 'Activity log')}
               </I18NLink>
-            </div>
+            </NeedAuthorization>
+            <a
+              className="list-group-item"
+              href="http://uwazi.readthedocs.io/en/latest/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span>
+                <Translate>Documentation</Translate> <Icon icon="external-link-alt" />
+              </span>
+            </a>
           </div>
-        </NeedAuthorization>
+        </div>
       </div>
     );
   }

--- a/app/react/Settings/components/SettingsNavigation.js
+++ b/app/react/Settings/components/SettingsNavigation.js
@@ -110,7 +110,7 @@ export class SettingsNavigation extends Component {
             </NeedAuthorization>
             <a
               className="list-group-item"
-              href="http://uwazi.readthedocs.io/en/latest/"
+              href="https://uwazi.readthedocs.io/en/latest/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/app/react/Settings/components/SettingsNavigation.js
+++ b/app/react/Settings/components/SettingsNavigation.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { I18NLink, t, Translate } from 'app/I18N';
+import { I18NLink, Translate } from 'app/I18N';
 import { NeedAuthorization } from 'app/Auth';
 import { Icon } from 'app/UI';
 
@@ -8,14 +8,14 @@ export class SettingsNavigation extends Component {
     return (
       <div>
         <div className="panel panel-default">
-          <div className="panel-heading">{t('System', 'Settings')}</div>
+          <div className="panel-heading"><Translate>Settings</Translate></div>
           <div className="list-group">
             <I18NLink to="settings/account" activeClassName="active" className="list-group-item">
-              {t('System', 'Account')}
+              <Translate>Account</Translate>
             </I18NLink>
             <NeedAuthorization>
               <I18NLink to="settings/users" activeClassName="active" className="list-group-item">
-                {t('System', 'Users')}
+                <Translate>Users</Translate>
               </I18NLink>
             </NeedAuthorization>
             <NeedAuthorization>
@@ -24,17 +24,17 @@ export class SettingsNavigation extends Component {
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Collection')}
+                <Translate>Collection</Translate>
               </I18NLink>
             </NeedAuthorization>
             <NeedAuthorization>
               <I18NLink to="settings/navlinks" activeClassName="active" className="list-group-item">
-                {t('System', 'Menu')}
+                <Translate>Menu</Translate>
               </I18NLink>
             </NeedAuthorization>
             <NeedAuthorization>
               <I18NLink to="settings/pages" activeClassName="active" className="list-group-item">
-                {t('System', 'Pages')}
+                <Translate>Pages</Translate>
               </I18NLink>
             </NeedAuthorization>
             <NeedAuthorization>
@@ -43,7 +43,7 @@ export class SettingsNavigation extends Component {
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Languages')}
+                <Translate>Languages</Translate>
               </I18NLink>
             </NeedAuthorization>
             <NeedAuthorization>
@@ -52,46 +52,46 @@ export class SettingsNavigation extends Component {
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Translations')}
+                <Translate>Translations</Translate>
               </I18NLink>
             </NeedAuthorization>
             <NeedAuthorization>
               <I18NLink to="settings/filters" activeClassName="active" className="list-group-item">
-                {t('System', 'Filters configuration')}
+                <Translate>Filters configuration</Translate>
               </I18NLink>
             </NeedAuthorization>
           </div>
         </div>
         <NeedAuthorization>
           <div className="panel panel-default">
-            <div className="panel-heading">{t('System', 'Metadata')}</div>
+            <div className="panel-heading"><Translate>Metadata</Translate></div>
             <div className="list-group">
               <I18NLink
                 to="settings/templates"
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Templates')}
+                <Translate>Templates</Translate>
               </I18NLink>
               <I18NLink
                 to="settings/dictionaries"
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Thesauri')}
+                <Translate>Thesauri</Translate>
               </I18NLink>
               <I18NLink
                 to="settings/connections"
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Relationship types')}
+                <Translate>Relationship types</Translate>
               </I18NLink>
             </div>
           </div>
         </NeedAuthorization>
         <div className="panel panel-default">
-          <div className="panel-heading">{t('System', 'Tools')}</div>
+          <div className="panel-heading"><Translate>Tools</Translate></div>
           <div className="list-group">
             <NeedAuthorization roles={['admin']}>
               <I18NLink
@@ -99,7 +99,7 @@ export class SettingsNavigation extends Component {
                 activeClassName="active"
                 className="list-group-item"
               >
-                {t('System', 'Activity log')}
+                <Translate>Activity log</Translate>
               </I18NLink>
             </NeedAuthorization>
             <a

--- a/app/react/Settings/components/SettingsNavigation.js
+++ b/app/react/Settings/components/SettingsNavigation.js
@@ -8,7 +8,9 @@ export class SettingsNavigation extends Component {
     return (
       <div>
         <div className="panel panel-default">
-          <div className="panel-heading"><Translate>Settings</Translate></div>
+          <div className="panel-heading">
+            <Translate>Settings</Translate>
+          </div>
           <div className="list-group">
             <I18NLink to="settings/account" activeClassName="active" className="list-group-item">
               <Translate>Account</Translate>
@@ -64,7 +66,9 @@ export class SettingsNavigation extends Component {
         </div>
         <NeedAuthorization>
           <div className="panel panel-default">
-            <div className="panel-heading"><Translate>Metadata</Translate></div>
+            <div className="panel-heading">
+              <Translate>Metadata</Translate>
+            </div>
             <div className="list-group">
               <I18NLink
                 to="settings/templates"
@@ -91,7 +95,9 @@ export class SettingsNavigation extends Component {
           </div>
         </NeedAuthorization>
         <div className="panel panel-default">
-          <div className="panel-heading"><Translate>Tools</Translate></div>
+          <div className="panel-heading">
+            <Translate>Tools</Translate>
+          </div>
           <div className="list-group">
             <NeedAuthorization roles={['admin']}>
               <I18NLink

--- a/app/react/UI/Icon/library.js
+++ b/app/react/UI/Icon/library.js
@@ -88,6 +88,7 @@ import { faEyeSlash } from '@fortawesome/free-solid-svg-icons/faEyeSlash';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
 import { faUserTimes } from '@fortawesome/free-solid-svg-icons/faUserTimes';
 import { faHandPaper } from '@fortawesome/free-solid-svg-icons/faHandPaper';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt';
 import { saveAndNext } from './save-and-next';
 import { exportCsv } from './export-csv';
 import { copyFrom } from './copy-from';
@@ -183,6 +184,7 @@ const icons = {
   faUsers,
   faUserTimes,
   faHandPaper,
+  faExternalLinkAlt,
   saveAndNext,
   exportCsv,
   copyFrom,


### PR DESCRIPTION
fixes #3370. Add an external link to the Uwazi documentation in the setting navigation bar. 

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
