### PR TITLE
Metadata extraction dashboard toggling

### DIFF
--- a/app/react/Settings/components/SettingsNavigation.tsx
+++ b/app/react/Settings/components/SettingsNavigation.tsx
@@ -63,7 +63,7 @@ const SettingsNavigation = () => (
             <Translate>Templates</Translate>
           </I18NLink>
         </NeedAuthorization>
-        <FeatureToggle feature="metadata-extraction">
+        <FeatureToggle feature="metadataExtraction.url">
           <NeedAuthorization roles={['admin']}>
             <I18NLink
               to="settings/metadata_extraction"

--- a/app/react/components/Elements/FeatureToggle.tsx
+++ b/app/react/components/Elements/FeatureToggle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
-import Immutable from 'immutable';
 
 export type ComponentPropTypes = {
   featureActivated: boolean;
@@ -21,9 +21,10 @@ FeatureToggle.defaultProps = {
 };
 
 function mapStateToProps({ settings }: any, ownProps: OwnPropTypes) {
-  const features = settings.collection.get('features') || Immutable.fromJS({});
+  const features = settings.collection.get('features');
+
   return {
-    featureActivated: features.get(ownProps.feature),
+    featureActivated: features ? Boolean(get(features.toJS(), ownProps.feature)) : false,
   };
 }
 

--- a/app/react/components/Elements/specs/FeatureToggle.spec.tsx
+++ b/app/react/components/Elements/specs/FeatureToggle.spec.tsx
@@ -57,4 +57,17 @@ describe('FeatureToggle', () => {
     const component = renderComponent(store, 'activatedFeature');
     expect(component).toMatchSnapshot();
   });
+
+  it('should work with string paths', () => {
+    store = mockStoreCreator({
+      settings: {
+        collection: Immutable.fromJS({
+          features: { featureGroup: { enabled: true } },
+        }),
+      },
+    });
+
+    const component = renderComponent(store, 'featureGroup.enabled');
+    expect(component.find('span').text()).toEqual('test');
+  });
 });


### PR DESCRIPTION
The dashboard used `settings > features > metadata-extraction` to appear on settings menu. Now it uses `settings > features > metadataExtraction > url`

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
