### PR TITLE
Update typescript to 4.0.8

### DIFF
--- a/app/api/odm/model.ts
+++ b/app/api/odm/model.ts
@@ -24,7 +24,7 @@ export type WithId<T> = _WithId<T>;
 export type EnforcedWithId<T> = WithId<mongoose.EnforceDocument<DataType<T>, {}>>;
 
 export type UwaziFilterQuery<T> = FilterQuery<T>;
-export type UwaziUpdateQuery<T> = UpdateQuery<Partial<T>>;
+export type UwaziUpdateQuery<T> = UpdateQuery<DataType<T>>;
 export type UwaziQueryOptions = QueryOptions;
 
 const generateID = mongoose.Types.ObjectId;
@@ -70,7 +70,7 @@ export class OdmModel<T> {
 
   async updateMany(
     conditions: UwaziFilterQuery<DataType<T>>,
-    doc: UpdateQuery<T>,
+    doc: UwaziUpdateQuery<T>,
     options: ModelUpdateOptions = {}
   ) {
     await this.logHelper.upsertLogMany(conditions);

--- a/app/api/pages/pages.ts
+++ b/app/api/pages/pages.ts
@@ -96,7 +96,7 @@ export default {
     const duplicate = async () => {
       const pages = await this.get({ language: defaultLanguage });
       const savePages = pages.map(async _page => {
-        const page = { ..._page, language };
+        const page: PageType = { ..._page, language };
         delete page._id;
         delete page.__v;
         return this.save(page);

--- a/app/react/Library/components/TableCell.tsx
+++ b/app/react/Library/components/TableCell.tsx
@@ -6,7 +6,7 @@ import { LinkSchema, MetadataObjectSchema, PropertySchema } from 'shared/types/c
 import MarkdownViewer from 'app/Markdown';
 
 export interface TableCellProps {
-  content: FormattedMetadataValue;
+  content?: FormattedMetadataValue;
   zoomLevel: number;
 }
 
@@ -14,7 +14,7 @@ export interface FormattedMetadataValue extends PropertySchema {
   value?: string | MetadataObjectSchema | MetadataObjectSchema[];
 }
 
-const formatProperty = (prop: FormattedMetadataValue) => {
+const formatProperty = (prop: FormattedMetadataValue | undefined) => {
   let result;
   if (!prop?.value) {
     return undefined;

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "svg-captcha": "^1.4.0",
     "swagger-jsdoc": "^6.1.0",
     "tiny-cookie": "^2.3.2",
-    "typescript": "3.9.10",
+    "typescript": "4.0.8",
     "url-join": "^4.0.1",
     "winston": "3.3.3",
     "world-countries": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14723,10 +14723,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.10:
-  version "3.9.10"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.8.tgz#5739105541db80a971fdbd0d56511d1a6f17d37f"
+  integrity sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.24:
   version "0.7.28"


### PR DESCRIPTION
Update typescript to 4.0.8.  Needed to be able to update socket.io to fix vulnerability checks

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
