### PR TITLE
Add reindex flag to migrations

### DIFF
--- a/app/api/migrations/migrate.ts
+++ b/app/api/migrations/migrate.ts
@@ -29,8 +29,8 @@ export const run = async () => {
   errorLog.closeGraylog();
   await DB.disconnect();
 
-  const reindexNeed = migrations.some(migration => migration.reindex === true);
-  process.stdout.write(`{ reindex: ${reindexNeed} }`);
+  const reindexNeeded = migrations.some(migration => migration.reindex === true);
+  process.stdout.write(JSON.stringify({ reindex: reindexNeeded }));
 };
 
 run().catch(async e => {

--- a/app/api/migrations/migrationsModel.js
+++ b/app/api/migrations/migrationsModel.js
@@ -6,6 +6,7 @@ const entitySchema = new mongoose.Schema({
   name: String,
   description: String,
   migrationDate: { type: Date, default: Date.now },
+  reindex: Boolean,
 });
 
 const Model = instanceModel('migrations', entitySchema);

--- a/app/api/migrations/specs/migrate.spec.ts
+++ b/app/api/migrations/specs/migrate.spec.ts
@@ -1,0 +1,104 @@
+import testingDB from 'api/utils/testing_db';
+import { migrator } from 'api/migrations/migrator';
+import path from 'path';
+import { run } from 'api/migrations/migrate';
+import { Connection } from 'mongoose';
+import { DB } from 'api/odm';
+
+describe('migrate', () => {
+  let connection: Connection;
+  let stdoutSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    connection = await testingDB.connect();
+    jest.spyOn(DB, 'connectionForDB').mockReturnValue(connection);
+    jest.spyOn(DB, 'disconnect').mockResolvedValue(Promise.resolve());
+  });
+
+  afterAll(async () => {
+    await testingDB.disconnect();
+  });
+
+  describe('run', () => {
+    beforeEach(async () => {
+      await testingDB.clear();
+      migrator.migrationsDir = path.join(__dirname, 'testMigrations');
+      stdoutSpy = jest.spyOn(process.stdout, 'write');
+    });
+
+    afterEach(() => {
+      stdoutSpy.mockRestore();
+    });
+
+    it('should call migrator migrate', async () => {
+      const migrateSpy = jest.spyOn(migrator, 'migrate');
+
+      await run();
+
+      expect(migrateSpy).toBeCalledWith(connection.db);
+    });
+
+    it('prints result when migrations do not need reindex', async () => {
+      jest.spyOn(migrator, 'migrate').mockResolvedValue([
+        {
+          _id: '61e6b524f5de4b24d561391b',
+          delta: 1,
+          description: 'migration test 1',
+          migrationDate: '2022-01-18T12:40:04.618Z',
+          __v: 0,
+        },
+        {
+          _id: '61e6b524f5de4b24d5613920',
+          delta: 2,
+          description: 'migration test 2',
+          reindex: false,
+          migrationDate: '2022-01-18T12:40:04.645Z',
+          __v: 0,
+        },
+        {
+          _id: '61e6b524f5de4b24d5613924',
+          delta: 10,
+          description: 'migration test 10',
+          migrationDate: '2022-01-18T12:40:04.660Z',
+          __v: 0,
+        },
+      ]);
+
+      await run();
+
+      expect(stdoutSpy).toBeCalledWith('{"reindex":false}');
+    });
+
+    it('prints result when migrations need reindex', async () => {
+      jest.spyOn(migrator, 'migrate').mockResolvedValue([
+        {
+          _id: testingDB.id(),
+          delta: 1,
+          description: 'migration test 1',
+          migrationDate: '2022-01-18T12:40:04.618Z',
+          __v: 0,
+        },
+        {
+          _id: testingDB.id(),
+          delta: 2,
+          description: 'migration test 2',
+          reindex: true,
+          migrationDate: '2022-01-18T12:40:04.645Z',
+          __v: 0,
+        },
+        {
+          _id: testingDB.id(),
+          delta: 10,
+          description: 'migration test 10',
+          reindex: false,
+          migrationDate: '2022-01-18T12:40:04.660Z',
+          __v: 0,
+        },
+      ]);
+
+      await run();
+
+      expect(stdoutSpy).toBeCalledWith('{"reindex":true}');
+    });
+  });
+});

--- a/app/api/migrations/specs/migrator.spec.js
+++ b/app/api/migrations/specs/migrator.spec.js
@@ -53,7 +53,28 @@ describe('migrator', () => {
         .migrate(connection.db)
         .then(() => migrationsModel.get())
         .then(migrations => {
-          expect(migrations.map(m => m.delta)).toEqual([1, 2, 10]);
+          expect(
+            migrations.map(({ delta, description, reindex }) => ({
+              delta,
+              description,
+              reindex,
+            }))
+          ).toEqual([
+            {
+              delta: 1,
+              description: 'migration test 1',
+            },
+            {
+              delta: 2,
+              description: 'migration test 2',
+              reindex: true,
+            },
+            {
+              delta: 10,
+              description: 'migration test 10',
+              reindex: false,
+            },
+          ]);
           done();
         });
     });

--- a/app/api/migrations/specs/testMigrations/10-migrationTest/index.js
+++ b/app/api/migrations/specs/testMigrations/10-migrationTest/index.js
@@ -1,6 +1,7 @@
 export default {
   delta: 10,
   description: 'migration test 10',
+  reindex: false,
 
   up() {
     return new Promise(resolve => {

--- a/app/api/migrations/specs/testMigrations/2-migrationTest/index.js
+++ b/app/api/migrations/specs/testMigrations/2-migrationTest/index.js
@@ -1,8 +1,10 @@
 export default {
   delta: 2,
   description: 'migration test 2',
+  reindex: false,
 
   up() {
+    this.reindex = true;
     return new Promise(resolve => {
       setTimeout(resolve, 10);
     });

--- a/app/api/migrations/templates/migration.txt
+++ b/app/api/migrations/templates/migration.txt
@@ -5,6 +5,8 @@ export default {
 
   description: '{{ description }}',
 
+  reindex: false,
+
   async up() {
     process.stdout.write(`${this.name}...\r\n`);
     return Promise.reject(new Error('error! change this, recently created migration'));


### PR DESCRIPTION
fixes #4122
fixes #2872

Migrations will now be created with a property `reindex` set to `false` by  default.  A developer can check programatically whenever a reindex is needed or not and change that property's value.  If any of the pending migrations needs  a reindex, the `yarn migrate` command will output a JSON that will be handled by Ansible to decide if the `yarn reindex` command will be executed or not.  Here's an  example output:

<img width="905" alt="Screenshot 2022-01-19 at 11 18 30" src="https://user-images.githubusercontent.com/1397196/150111061-a1c25495-f30f-4827-99ea-8a1a19e45355.png">


PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
