### PR TITLE
Don't track @types dependencies on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@types/*"
     allow:
       - dependency-type: "development"
     open-pull-requests-limit: 3


### PR DESCRIPTION
@types updates can make our check types steps to fail due to discrepancies with the main dependency.  Ignoring them  and updating the @types whenever a dependency is updated can be a good solution.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
