### PR TITLE
Graceful shutdown on SIGINT signal

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -183,4 +183,21 @@ DB.connect(config.DBHOST, dbAuth).then(async () => {
       console.info(uwaziMessage);
     }
   });
+
+  process.on('SIGINT', () => {
+    process.stdout.write('SIGNIT signal received.\r\n');
+    http.close(error => {
+      process.stdout.write('Gracefully closing express connections\r\n');
+      if (error) {
+        process.stderr.write(error.toString());
+        process.exit(1);
+      }
+
+      DB.disconnect().then(() => {
+        process.stdout.write('Disconnected from database\r\n');
+        process.stdout.write('Server closed succesfully\r\n');
+        process.exit(0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
related to: #4150

When we restart our service, a SIGINT signal is sent.  Listening to that signal allows us to do a graceful shutdown:
- Stop accepting new requests.
- Finish all the ongoing requests.
- Clean up DB connections.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
