### PR TITLE
noListener for db extra connections.

### DIFF
--- a/app/api/auth/routes.js
+++ b/app/api/auth/routes.js
@@ -25,7 +25,10 @@ export default app => {
     session({
       secret: app.get('env') === 'production' ? config.userSessionSecret : 'harvey&lola',
       store: new MongoStore({
-        mongooseConnection: DB.connectionForDB(config.SHARED_DB),
+        mongooseConnection: DB.connectionForDB(config.SHARED_DB, {
+          useCache: true,
+          noListener: false,
+        }),
       }),
       resave: false,
       saveUninitialized: false,

--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -12,6 +12,7 @@ const {
   ELASTICSEARCH_URL,
   DBHOST,
   SENTRY_API_DSN,
+  MONGO_CONNECTION_POOL_SIZE,
 } = process.env;
 
 const rootPath = ROOT_PATH || `${__dirname}/../../`;
@@ -26,6 +27,8 @@ export const config = {
   PORT: process.env.PORT || 3000,
 
   DBHOST: MONGO_URI || onlyDBHOST(),
+
+  mongo_connection_pool_size: Number(MONGO_CONNECTION_POOL_SIZE) || 5,
 
   rootPath,
 

--- a/app/api/odm/DB.ts
+++ b/app/api/odm/DB.ts
@@ -12,6 +12,7 @@ const DB = {
       ...auth,
       useUnifiedTopology: true,
       useNewUrlParser: true,
+      poolSize: config.mongo_connection_pool_size,
     });
 
     return this.getConnection();
@@ -21,8 +22,8 @@ const DB = {
     return mongoose.disconnect();
   },
 
-  connectionForDB(dbName: string) {
-    return this.getConnection().useDb(dbName, { useCache: true });
+  connectionForDB(dbName: string, options = { useCache: true, noListener: true }) {
+    return this.getConnection().useDb(dbName, options);
   },
 
   getConnection() {

--- a/app/api/odm/MultiTenantMongooseModel.ts
+++ b/app/api/odm/MultiTenantMongooseModel.ts
@@ -24,15 +24,10 @@ class MultiTenantMongooseModel<T> {
 
   dbForCurrentTenant() {
     const currentTenant = tenants.current();
-
-    if (!this.dbs[currentTenant.name]) {
-      this.dbs[currentTenant.name] = DB.connectionForDB(currentTenant.dbName).model<DataType<T>>(
-        this.collectionName,
-        this.schema
-      );
-    }
-
-    return this.dbs[currentTenant.name];
+    return DB.connectionForDB(currentTenant.dbName).model<DataType<T>>(
+      this.collectionName,
+      this.schema
+    );
   }
 
   findById(id: any, select?: any) {

--- a/app/api/odm/specs/DB.spec.ts
+++ b/app/api/odm/specs/DB.spec.ts
@@ -50,7 +50,7 @@ describe('DB', () => {
   });
 
   describe('newDB', () => {
-    it('should not instantiate new connections for same dbName', () => {
+    it('should not instantiate new connections for same dbName by default', () => {
       const dbConnection = DB.connectionForDB('newDB');
       expect(dbConnection).toBe(DB.connectionForDB('newDB'));
     });


### PR DESCRIPTION
extra db connection objects (tenant connections mostly) not going to be eventListeners of the original connection to prevent warning messages and potential memory leak.
