### PR TITLE
Fix logLevel for webpack-dev-middleware

### DIFF
--- a/webpack/webpack.config.hot.js
+++ b/webpack/webpack.config.hot.js
@@ -7,6 +7,10 @@ const config = require('./config')();
 const rootPath = `${__dirname}/../`;
 const RtlCssPlugin = require("rtlcss-webpack-plugin");
 
+config['infrastructureLogging'] = {
+    level: 'error',
+}
+
 config.plugins = config.plugins.filter(plugin => !(plugin instanceof RtlCssPlugin));
 config.plugins = config.plugins.concat([
   new webpack.HotModuleReplacementPlugin(),

--- a/webpack/webpack.server.js
+++ b/webpack/webpack.server.js
@@ -18,7 +18,6 @@ const compiler = webpack(webpackConfig);
 
 
 app.use(require('webpack-dev-middleware')(compiler, {
-  logLevel: 'error',
   publicPath: webpackConfig.output.publicPath,
   headers: { 'Access-Control-Allow-Origin': '*' }
 }));


### PR DESCRIPTION
`yarn hot` command broke on `webpack-dev-middleware` dependency update due to deprecated property on options.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
