### PR TITLE
Remove custom handler on API's Sentry integration

### DIFF
--- a/app/react/App/Root.js
+++ b/app/react/App/Root.js
@@ -94,7 +94,7 @@ class Root extends Component {
       <html lang={language}>
         {headTag(head, CSS, reduxData)}
         <body>
-          <div id="root" dangerouslySetInnerHTML={{ __html: content }} /> 
+          <div id="root" dangerouslySetInnerHTML={{ __html: content }} />
           <script
             //eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{

--- a/app/react/App/Root.js
+++ b/app/react/App/Root.js
@@ -1,3 +1,4 @@
+import { config } from 'api/config';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import serialize from 'serialize-javascript';
@@ -93,7 +94,13 @@ class Root extends Component {
       <html lang={language}>
         {headTag(head, CSS, reduxData)}
         <body>
-          <div id="root" dangerouslySetInnerHTML={{ __html: content }} />
+          <div id="root" dangerouslySetInnerHTML={{ __html: content }} /> 
+          <script
+            //eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: `window.UWAZI_ENVIRONMENT = "${config.ENVIRONMENT}"`,
+            }}
+          />
           {process.env.SENTRY_APP_DSN && (
             <script
               //eslint-disable-next-line react/no-danger

--- a/app/react/index.js
+++ b/app/react/index.js
@@ -13,6 +13,7 @@ import './App/sockets';
 
 if (window.SENTRY_APP_DSN) {
   Sentry.init({
+    environment: window.UWAZI_ENVIRONMENT,
     dsn: window.SENTRY_APP_DSN,
     integrations: [new BrowserTracing()],
     tracesSampleRate: 0.1,

--- a/app/server.js
+++ b/app/server.js
@@ -19,7 +19,6 @@ import { DistributedLoop } from 'api/services/tasksmanager/DistributedLoop';
 
 import { appContextMiddleware } from 'api/utils/appContextMiddleware';
 import { requestIdMiddleware } from 'api/utils/requestIdMiddleware';
-import Error from 'api/utils/Error';
 import uwaziMessage from '../message';
 import apiRoutes from './api/api';
 import privateInstanceMiddleware from './api/auth/privateInstanceMiddleware';
@@ -71,7 +70,7 @@ app.use(metricsMiddleware);
 if (config.sentry.dsn) {
   Sentry.init({
     dsn: config.sentry.dsn,
-    env: config.ENVIRONMENT,
+    environment: config.ENVIRONMENT,
     integrations: [
       new Sentry.Integrations.Http({ tracing: true }),
       new Tracing.Integrations.Express({ app }),

--- a/app/server.js
+++ b/app/server.js
@@ -146,13 +146,7 @@ DB.connect(config.DBHOST, dbAuth).then(async () => {
   apiRoutes(app, http);
   serverRenderingRoutes(app);
   if (config.sentry.dsn) {
-    app.use(
-      Sentry.Handlers.errorHandler({
-        shouldHandleError(error) {
-          return error instanceof Error || error.code >= 500;
-        },
-      })
-    );
+    app.use(Sentry.Handlers.errorHandler());
   }
   app.use(errorHandlingMiddleware);
 

--- a/app/server.js
+++ b/app/server.js
@@ -145,7 +145,13 @@ DB.connect(config.DBHOST, dbAuth).then(async () => {
   apiRoutes(app, http);
   serverRenderingRoutes(app);
   if (config.sentry.dsn) {
-    app.use(Sentry.Handlers.errorHandler());
+    app.use(
+      Sentry.Handlers.errorHandler({
+        shouldHandleError(error) {
+          return error instanceof Error || error.code >= 500;
+        },
+      })
+    );
   }
   app.use(errorHandlingMiddleware);
 


### PR DESCRIPTION
To be able to track all errors on Sentry.