### PR TITLE
Post api entities rework

### DIFF
--- a/app/api/entities/entities.js
+++ b/app/api/entities/entities.js
@@ -48,28 +48,28 @@ async function denormalizeMetadata(metadata, entity, template, thesauriByKey) {
           return elem;
         }
         if (prop.content && ['select', 'multiselect'].includes(prop.type)) {
-          const dict = thesauriByKey
+          const thesaurus = thesauriByKey
             ? thesauriByKey[prop.content]
             : await dictionariesModel.getById(prop.content);
-          if (dict) {
+          if (thesaurus) {
             const context = getContext(translation, prop.content);
-            const flattenValues = dict.values.reduce(
+            const flattenValues = thesaurus.values.reduce(
               (result, dv) =>
                 dv.values
                   ? result.concat(dv.values.map(v => ({ ...v, parent: dv })))
                   : result.concat([dv]),
               []
             );
-            const dictElem = flattenValues.find(v => v.id === elem.value);
+            const thesaurusValue = flattenValues.find(v => v.id === elem.value);
 
-            if (dictElem && dictElem.label) {
-              elem.label = translate(context, dictElem.label, dictElem.label);
+            if (thesaurusValue && thesaurusValue.label) {
+              elem.label = translate(context, thesaurusValue.label, thesaurusValue.label);
             }
 
-            if (dictElem && dictElem.parent) {
+            if (thesaurusValue && thesaurusValue.parent) {
               elem.parent = {
-                value: dictElem.parent.id,
-                label: translate(context, dictElem.parent.label, dictElem.parent.label),
+                value: thesaurusValue.parent.id,
+                label: translate(context, thesaurusValue.parent.label, thesaurusValue.parent.label),
               };
             }
           }

--- a/app/api/entities/entities.js
+++ b/app/api/entities/entities.js
@@ -26,7 +26,7 @@ import { denormalizeRelated } from './denormalize';
 import { saveSelections } from './metadataExtraction/saveSelections';
 
 /** Repopulate metadata object .label from thesauri and relationships. */
-async function denormalizeMetadata(metadata, entity, template, dictionariesByKey) {
+async function denormalizeMetadata(metadata, entity, template, thesauriByKey) {
   if (!metadata) {
     return metadata;
   }
@@ -48,8 +48,8 @@ async function denormalizeMetadata(metadata, entity, template, dictionariesByKey
           return elem;
         }
         if (prop.content && ['select', 'multiselect'].includes(prop.type)) {
-          const dict = dictionariesByKey
-            ? dictionariesByKey[prop.content]
+          const dict = thesauriByKey
+            ? thesauriByKey[prop.content]
             : await dictionariesModel.getById(prop.content);
           if (dict) {
             const context = getContext(translation, prop.content);
@@ -151,9 +151,9 @@ async function updateEntity(entity, _template, unrestricted = false) {
   const currentDoc = docLanguages.find(d => d._id.toString() === entity._id.toString());
   const saveFunc = !unrestricted ? model.save : model.saveUnrestricted;
 
-  const dictionaryIds = template.properties.map(p => p.content).filter(p => p);
-  const dictionaries = await dictionariesModel.get({ _id: { $in: dictionaryIds } });
-  const dictionariesByKey = Object.fromEntries(dictionaries.map(d => [d._id, d]));
+  const thesauriIds = template.properties.map(p => p.content).filter(p => p);
+  const thesauri = await dictionariesModel.get({ _id: { $in: thesauriIds } });
+  const thesauriByKey = Object.fromEntries(thesauri.map(d => [d._id, d]));
 
   return Promise.all(
     docLanguages.map(async d => {
@@ -167,7 +167,7 @@ async function updateEntity(entity, _template, unrestricted = false) {
             entity.metadata,
             entity,
             template,
-            dictionariesByKey
+            thesauriByKey
           );
         }
 
@@ -176,7 +176,7 @@ async function updateEntity(entity, _template, unrestricted = false) {
             entity.suggestedMetadata,
             entity,
             template,
-            dictionariesByKey
+            thesauriByKey
           );
         }
 
@@ -201,7 +201,7 @@ async function updateEntity(entity, _template, unrestricted = false) {
             toSave[metadataParent],
             toSave,
             template,
-            dictionariesByKey
+            thesauriByKey
           );
         }
       }, Promise.resolve());


### PR DESCRIPTION
related to #4356 

Improved the number of queries on entity save (post to api/entities), by pre-loading thesauri.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
