### PR TITLE
V2 - Entity view additional fixes

### DIFF
--- a/app/react/V2/Components/Metadata/Components/Geolocation.tsx
+++ b/app/react/V2/Components/Metadata/Components/Geolocation.tsx
@@ -52,10 +52,7 @@ const Geolocation = ({
     <MetadataCard>
       <dt>
         {isGroup ? (
-          <Translate
-            className={`${hideLabel ? 'sr-only' : 'font-bold text-gray-900'}`}
-            context={translationContext}
-          >
+          <Translate className={`${hideLabel ? 'sr-only' : 'font-bold text-gray-900'}`}>
             Grouped geolocation properties
           </Translate>
         ) : (

--- a/app/react/V2/Components/Metadata/Components/Markdown.tsx
+++ b/app/react/V2/Components/Metadata/Components/Markdown.tsx
@@ -13,22 +13,25 @@ type MarkdownProps = MetadataFieldProps & {
 
 const markdownParser = new MarkdownIt({ html: true });
 
+const sanitizeOptions = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    a: ['href', 'name', 'target'],
+    img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
+  },
+};
+
 const Markdown = ({ label, translationContext, values, hideLabel }: MarkdownProps) => {
-  const value = values?.[0]?.value || '';
+  const safeHtmlList = useMemo(
+    () =>
+      (values ?? [])
+        .map(v => sanitizeHtml(markdownParser.render(v.value || ''), sanitizeOptions))
+        .filter(html => html !== ''),
+    [values]
+  );
 
-  const safeHtml = useMemo(() => {
-    const html = markdownParser.render(value);
-    return sanitizeHtml(html, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-      allowedAttributes: {
-        ...sanitizeHtml.defaults.allowedAttributes,
-        a: ['href', 'name', 'target'],
-        img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
-      },
-    });
-  }, [value]);
-
-  if (safeHtml === '') {
+  if (safeHtmlList.length === 0) {
     return null;
   }
 
@@ -41,10 +44,11 @@ const Markdown = ({ label, translationContext, values, hideLabel }: MarkdownProp
           hideLabel={hideLabel}
         />
       </dt>
-      <dd>
-        {/* Allow inserting html since it's sanitized */}
-        {/* eslint-disable-next-line react/no-danger */}
-        <div className="no-tailwind" dangerouslySetInnerHTML={{ __html: safeHtml }} />
+      <dd className="flex flex-col gap-1">
+        {safeHtmlList.map((safeHtml, index) => (
+          // eslint-disable-next-line react/no-array-index-key, react/no-danger
+          <div key={index} className="no-tailwind" dangerouslySetInnerHTML={{ __html: safeHtml }} />
+        ))}
       </dd>
     </MetadataCard>
   );

--- a/app/react/V2/Components/Metadata/Components/Media.tsx
+++ b/app/react/V2/Components/Metadata/Components/Media.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import { PlayIcon } from '@heroicons/react/20/solid';
 import { t } from '#app/I18N/index.js';
 import { MediaMetadataProperty } from '#V2/formatters/types.js';
@@ -24,6 +24,7 @@ const Media = ({
   width = 500,
   height = 300,
 }: MediaProps) => {
+  const baseId = useId();
   const playerRefs = useRef<React.RefObject<PlayerInstance>[]>([]);
   if (playerRefs.current.length !== values.length) {
     playerRefs.current = Array.from({ length: values.length }, () =>
@@ -53,10 +54,12 @@ const Media = ({
             playerRef?.current?.seekTo(time, 'seconds');
           };
 
+          const figId = `${baseId}-${index}`;
+
           return (
             // eslint-disable-next-line react/no-array-index-key
             <div key={index} className="flex flex-col items-center gap-2">
-              <figure aria-labelledby={label} className="w-full bg-gray-100 rounded-md">
+              <figure aria-labelledby={figId} className="w-full bg-gray-100 rounded-md">
                 <MediaPlayer
                   className="m-auto"
                   playerRef={playerRef}
@@ -65,7 +68,7 @@ const Media = ({
                   height={height}
                 />
                 {alt && (
-                  <figcaption className="sr-only" id={label}>
+                  <figcaption className="sr-only" id={figId}>
                     {alt}
                   </figcaption>
                 )}

--- a/app/react/V2/Components/Metadata/Components/Media.tsx
+++ b/app/react/V2/Components/Metadata/Components/Media.tsx
@@ -13,6 +13,9 @@ type MediaProps = MetadataFieldProps & {
   height?: number;
 };
 
+type PlayerRef = NonNullable<React.ComponentProps<typeof MediaPlayer>['playerRef']>;
+type PlayerInstance = PlayerRef extends React.RefObject<infer T> ? T : never;
+
 const Media = ({
   label,
   values,
@@ -21,16 +24,16 @@ const Media = ({
   width = 500,
   height = 300,
 }: MediaProps) => {
-  const { value, alt, timelinks = [] } = values[0] || {};
-  type PlayerRef = NonNullable<React.ComponentProps<typeof MediaPlayer>['playerRef']>;
-  type PlayerInstance = PlayerRef extends React.RefObject<infer T> ? T : never;
-  const playerRef = useRef<PlayerInstance>(null);
+  const playerRefs = useRef<React.RefObject<PlayerInstance>[]>([]);
+  if (playerRefs.current.length !== values.length) {
+    playerRefs.current = Array.from({ length: values.length }, () =>
+      React.createRef<PlayerInstance>()
+    );
+  }
 
-  const handleTimelinkClick = (time: number) => {
-    playerRef.current?.seekTo(time, 'seconds');
-  };
+  const nonEmptyValues = values?.filter(v => v.value) ?? [];
 
-  if (!value) {
+  if (nonEmptyValues.length === 0) {
     return null;
   }
 
@@ -43,42 +46,54 @@ const Media = ({
           hideLabel={hideLabel}
         />
       </dt>
-      <dd className="flex flex-col items-center gap-2">
-        <figure aria-labelledby={label} className="w-full bg-gray-100 rounded-md">
-          <MediaPlayer
-            className="m-auto"
-            playerRef={playerRef}
-            url={value}
-            width={width}
-            height={height}
-          />
-          {alt && (
-            <figcaption className="sr-only" id={label}>
-              {alt}
-            </figcaption>
-          )}
-        </figure>
+      <dd className="flex flex-col gap-4">
+        {nonEmptyValues.map(({ value, alt, timelinks = [] }, index) => {
+          const playerRef = playerRefs.current[index];
+          const handleTimelinkClick = (time: number) => {
+            playerRef?.current?.seekTo(time, 'seconds');
+          };
 
-        {timelinks.length > 0 && (
-          <nav className="w-full" aria-label={t('System', 'Timelinks', null, false)}>
-            <ul className="flex flex-col gap-2">
-              {timelinks.map(({ time, hh, mm, ss, label: timelinkLabel }) => (
-                <li key={timelinkLabel + time}>
-                  <button
-                    className="flex flex-row flex-nowrap"
-                    type="button"
-                    onClick={() => handleTimelinkClick(time)}
-                    aria-label={`${hh} ${mm} ${ss} : ${timelinkLabel}`}
-                  >
-                    <PlayIcon className="w-4 h-4" />
-                    {`${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`}{' '}
-                    - {timelinkLabel}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        )}
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={index} className="flex flex-col items-center gap-2">
+              <figure aria-labelledby={label} className="w-full bg-gray-100 rounded-md">
+                <MediaPlayer
+                  className="m-auto"
+                  playerRef={playerRef}
+                  url={value}
+                  width={width}
+                  height={height}
+                />
+                {alt && (
+                  <figcaption className="sr-only" id={label}>
+                    {alt}
+                  </figcaption>
+                )}
+              </figure>
+
+              {timelinks.length > 0 && (
+                <nav className="w-full" aria-label={t('System', 'Timelinks', null, false)}>
+                  <ul className="flex flex-col gap-2">
+                    {timelinks.map(({ time, hh, mm, ss, label: timelinkLabel }) => (
+                      <li key={timelinkLabel + time}>
+                        <button
+                          className="flex flex-row flex-nowrap"
+                          type="button"
+                          onClick={() => handleTimelinkClick(time)}
+                          aria-label={`${hh} ${mm} ${ss} : ${timelinkLabel}`}
+                        >
+                          <PlayIcon className="w-4 h-4" />
+                          {`${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`}{' '}
+                          - {timelinkLabel}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              )}
+            </div>
+          );
+        })}
       </dd>
     </MetadataCard>
   );

--- a/app/react/V2/Components/Metadata/Components/SimpleValue.tsx
+++ b/app/react/V2/Components/Metadata/Components/SimpleValue.tsx
@@ -9,9 +9,10 @@ type SimpleValueProps = MetadataFieldProps & {
 };
 
 const SimpleValue = ({ label, translationContext, values, hideLabel }: SimpleValueProps) => {
-  const value = values?.[0]?.value ?? '';
+  const nonEmptyValues =
+    values?.filter(v => v.value !== '' && v.value !== undefined && v.value !== null) ?? [];
 
-  if (value === '') {
+  if (nonEmptyValues.length === 0) {
     return null;
   }
 
@@ -24,7 +25,14 @@ const SimpleValue = ({ label, translationContext, values, hideLabel }: SimpleVal
           hideLabel={hideLabel}
         />
       </dt>
-      <dd className="font-medium text-sm text-gray-900">{value}</dd>
+      <dd className="flex flex-col gap-1">
+        {nonEmptyValues.map((v, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <span key={index} className="font-medium text-sm text-gray-900">
+            {v.value}
+          </span>
+        ))}
+      </dd>
     </MetadataCard>
   );
 };

--- a/app/react/V2/formatters/metadata/formatGeolocationProperty.ts
+++ b/app/react/V2/formatters/metadata/formatGeolocationProperty.ts
@@ -122,6 +122,7 @@ const formatGeolocationProperty = (
     name: property.name,
     label: property.label,
     type: 'geolocation',
+    ...(property.propertyGroup && { propertyGroup: property.propertyGroup }),
     values,
   };
 };

--- a/app/react/V2/formatters/metadata/formatImageProperty.ts
+++ b/app/react/V2/formatters/metadata/formatImageProperty.ts
@@ -17,14 +17,17 @@ const formatImageProperty = (
     templateProperty => templateProperty.name === property.name
   );
 
-  const value = metadata?.[property.name]?.[0]?.value as string | undefined;
+  const values = (metadata?.[property.name] ?? [])
+    .map(item => item?.value as string | undefined)
+    .filter((value): value is string => Boolean(value))
+    .map(value => ({ value, alt: value }));
 
   return {
     _id: property._id,
     name: property.name,
     label: property.label,
     type: property.type === 'preview' ? 'preview' : 'image',
-    values: value ? [{ value, alt: value }] : [],
+    values,
     style: originalProperty?.fullWidth ? 'cover' : 'contain',
   };
 };

--- a/app/react/V2/formatters/metadata/formatLinkProperty.ts
+++ b/app/react/V2/formatters/metadata/formatLinkProperty.ts
@@ -11,15 +11,19 @@ const formatLinkProperty = (
     return null;
   }
 
-  const link = metadata?.[property.name]?.[0]?.value as
-    | { url?: string; label?: string }
-    | undefined;
+  const values = (metadata?.[property.name] ?? []).map(item => {
+    const link = item?.value as { url?: string; label?: string } | undefined;
+    return {
+      value: link?.url ?? '',
+      label: link?.label ?? '',
+    };
+  });
 
   return {
     _id: property._id,
     name: property.name,
     type: property.type,
-    values: link ? [{ value: link.url ?? '', label: link.label ?? '' }] : [],
+    values,
     label: property.label,
     inherited: property.inherited,
     inheritedType: property.inheritedType,

--- a/app/react/V2/formatters/metadata/formatMediaProperty.ts
+++ b/app/react/V2/formatters/metadata/formatMediaProperty.ts
@@ -66,7 +66,7 @@ const formatMediaProperty = (
           alt: fileName,
           mimetype,
           fileType: getFileType(mimetype),
-          timelinks: timelinks || {},
+          timelinks,
         });
 
         return;

--- a/app/react/V2/formatters/metadata/formatMediaProperty.ts
+++ b/app/react/V2/formatters/metadata/formatMediaProperty.ts
@@ -23,7 +23,6 @@ const getFileType = (mimetype: string): string => {
   return type === 'application' ? 'document' : type;
 };
 
-// eslint-disable-next-line max-statements
 const formatMediaProperty = (
   property: BaseMetadataProperty,
   metadata?: Entity['metadata']
@@ -32,7 +31,7 @@ const formatMediaProperty = (
     return null;
   }
 
-  const value = metadata?.[property.name]?.[0]?.value as string | undefined;
+  const metadataValues = metadata?.[property.name] ?? [];
 
   const formattedProperty: MediaMetadataProperty = {
     _id: property._id,
@@ -44,28 +43,41 @@ const formatMediaProperty = (
     inheritedType: property.inheritedType,
   };
 
-  if (typeof value === 'string' && value.startsWith('(')) {
-    const match = value.match(/^\(([^,]+),\s*({.*})\)$/);
-    if (match) {
-      const fileUrl = match[1];
-      const timelinksData = JSON.parse(match[2]);
-      const timelinks = processTimelines(timelinksData.timelinks);
-      const fileName = fileUrl.split('/').pop() || 'Unknown file';
-      const mimetype = getMimetypeFromUrl(fileUrl);
-      formattedProperty.values.push({
-        value: fileUrl,
-        alt: fileName,
-        mimetype,
-        fileType: getFileType(mimetype),
-        timelinks: timelinks || {},
-      });
+  // eslint-disable-next-line max-statements
+  metadataValues.forEach(item => {
+    const value = item?.value as string | undefined;
+
+    if (!value) {
+      return;
     }
-  } else if (value) {
+
+    if (typeof value === 'string' && value.startsWith('(')) {
+      const match = value.match(/^\(([^,]+),\s*({.*})\)$/);
+
+      if (match) {
+        const fileUrl = match[1];
+        const timelinksData = JSON.parse(match[2]);
+        const timelinks = processTimelines(timelinksData.timelinks);
+        const fileName = fileUrl.split('/').pop() || 'Unknown file';
+        const mimetype = getMimetypeFromUrl(fileUrl);
+
+        formattedProperty.values.push({
+          value: fileUrl,
+          alt: fileName,
+          mimetype,
+          fileType: getFileType(mimetype),
+          timelinks: timelinks || {},
+        });
+
+        return;
+      }
+    }
+
     formattedProperty.values.push({
       value,
       timelinks: [],
     });
-  }
+  });
 
   return formattedProperty;
 };

--- a/app/react/V2/formatters/metadata/formatSimpleProperty.ts
+++ b/app/react/V2/formatters/metadata/formatSimpleProperty.ts
@@ -12,14 +12,22 @@ const formatSimpleProperty = (
     return null;
   }
 
-  const rawValue = metadata?.[property.name]?.[0]?.value;
-  const value = rawValue === null || rawValue === undefined ? '' : String(rawValue);
+  const rawValues = metadata?.[property.name] ?? [];
+  const values =
+    rawValues.length > 0
+      ? rawValues.map(item => {
+          const value = item?.value;
+          return {
+            value: value === null || value === undefined ? '' : String(value),
+          };
+        })
+      : [{ value: '' }];
 
   return {
     _id: property._id,
     name: property.name,
     type: property.type,
-    values: [{ value }],
+    values,
     label: property.label,
     inherited: property.inherited,
     inheritedType: property.inheritedType,

--- a/app/react/V2/formatters/metadata/specs/formatGeolocationProperty.spec.ts
+++ b/app/react/V2/formatters/metadata/specs/formatGeolocationProperty.spec.ts
@@ -147,6 +147,10 @@ describe('formatGeolocationProperty', () => {
       name: 'group1',
       label: 'group1',
       type: 'geolocation',
+      propertyGroup: [
+        { name: 'locationA', label: 'Location A' },
+        { name: 'locationB', label: 'Location B' },
+      ],
       values: [
         { value: { latitude: 10, longitude: 20 }, label: 'Location A', color: '#1A73E8' },
         {
@@ -183,6 +187,16 @@ describe('formatGeolocationProperty', () => {
       name: '__group1',
       label: '__group1',
       type: 'geolocation',
+      propertyGroup: [
+        { name: 'locationB', label: 'Location B' },
+        {
+          name: 'rel_1',
+          label: 'Rel 1',
+          inherited: true,
+          content: '69f0a4ac62c282d87ef5970f',
+          property: 'x',
+        },
+      ],
       values: [
         {
           value: { latitude: -5, longitude: -6 },
@@ -233,6 +247,16 @@ describe('formatGeolocationProperty', () => {
       name: '__group2',
       label: '__group2',
       type: 'geolocation',
+      propertyGroup: [
+        { name: 'locationB', label: 'Location B' },
+        {
+          name: 'rel_nested',
+          label: 'Rel Nested',
+          inherited: true,
+          content: '69f0a4ac62c282d87ef5970f',
+          property: 'y',
+        },
+      ],
       values: [
         {
           value: { latitude: -5, longitude: -6 },

--- a/app/react/V2/formatters/metadata/specs/formatImageProperty.spec.ts
+++ b/app/react/V2/formatters/metadata/specs/formatImageProperty.spec.ts
@@ -67,4 +67,29 @@ describe('formatImageProperty', () => {
       style: 'contain',
     });
   });
+
+  it('should keep all image values', () => {
+    const property = {
+      _id: 'p2',
+      name: 'related_images',
+      label: 'Related images',
+      type: 'image',
+    } as BaseMetadataProperty;
+
+    const metadata = {
+      related_images: [{ value: '/api/files/image-1.png' }, { value: '/api/files/image-2.png' }],
+    } as Entity['metadata'];
+
+    expect(formatImageProperty(property, metadata)).toEqual({
+      _id: 'p2',
+      name: 'related_images',
+      label: 'Related images',
+      type: 'image',
+      values: [
+        { value: '/api/files/image-1.png', alt: '/api/files/image-1.png' },
+        { value: '/api/files/image-2.png', alt: '/api/files/image-2.png' },
+      ],
+      style: 'contain',
+    });
+  });
 });

--- a/app/react/V2/formatters/metadata/specs/formatLinkProperty.spec.ts
+++ b/app/react/V2/formatters/metadata/specs/formatLinkProperty.spec.ts
@@ -19,6 +19,20 @@ describe('formatLinkProperty', () => {
         },
       },
     ],
+    linkMulti: [
+      {
+        value: {
+          label: 'first',
+          url: 'https://first.example.com',
+        },
+      },
+      {
+        value: {
+          label: 'second',
+          url: 'https://second.example.com',
+        },
+      },
+    ],
   } as Entity['metadata'];
 
   it('should format the link property', () => {
@@ -88,6 +102,28 @@ describe('formatLinkProperty', () => {
       type: 'link',
       values: [],
       label: 'Link 3',
+      inherited: undefined,
+      inheritedType: undefined,
+    });
+  });
+
+  it('should keep all link values', () => {
+    const textProperty = {
+      _id: 'p2',
+      name: 'linkMulti',
+      label: 'Link Multi',
+      type: 'link',
+    } as BaseMetadataProperty;
+
+    expect(formatLinkProperty(textProperty, metadata)).toEqual({
+      _id: 'p2',
+      name: 'linkMulti',
+      type: 'link',
+      values: [
+        { value: 'https://first.example.com', label: 'first' },
+        { value: 'https://second.example.com', label: 'second' },
+      ],
+      label: 'Link Multi',
       inherited: undefined,
       inheritedType: undefined,
     });

--- a/app/react/V2/formatters/metadata/specs/formatMediaProperty.spec.ts
+++ b/app/react/V2/formatters/metadata/specs/formatMediaProperty.spec.ts
@@ -79,6 +79,55 @@ describe('formatMediaProperty', () => {
     });
   });
 
+  it('should keep all media values and preserve timelinks per item', () => {
+    const metadata = {
+      media: [
+        {
+          value:
+            '(/api/files/video-one.mp4, {"timelinks":{"00:00:02":"Timelink 1","00:00:04":"Timelink 2"}})',
+        },
+        {
+          value: '/api/files/video-two.webm',
+        },
+      ],
+    } as Entity['metadata'];
+
+    expect(formatMediaProperty(mediaProperty, metadata)).toEqual({
+      _id: '1.15',
+      name: 'media',
+      type: 'media',
+      values: [
+        {
+          value: '/api/files/video-one.mp4',
+          alt: 'video-one.mp4',
+          mimetype: 'video/mp4',
+          fileType: 'video',
+          timelinks: [
+            {
+              label: 'Timelink 1',
+              hh: 0,
+              mm: 0,
+              ss: 2,
+              time: 2,
+            },
+            {
+              label: 'Timelink 2',
+              hh: 0,
+              mm: 0,
+              ss: 4,
+              time: 4,
+            },
+          ],
+        },
+        {
+          value: '/api/files/video-two.webm',
+          timelinks: [],
+        },
+      ],
+      label: 'Media',
+    });
+  });
+
   it('should keep external URLs as plain values', () => {
     const metadata = {
       media: [

--- a/app/react/V2/formatters/metadata/specs/formatSimpleProperty.spec.ts
+++ b/app/react/V2/formatters/metadata/specs/formatSimpleProperty.spec.ts
@@ -6,6 +6,7 @@ describe('formatSimpleProperty', () => {
   const metadata = {
     simple_text: [{ value: 'Emergency incident report' }],
     numeric_field: [{ value: 42 }],
+    multi_text: [{ value: 'First value' }, { value: 'Second value' }, { value: '' }],
     empty_text: [{ value: '' }],
     empty_array: [],
   } as Entity['metadata'];
@@ -109,6 +110,25 @@ describe('formatSimpleProperty', () => {
       type: 'numeric',
       values: [{ value: '42' }],
       label: 'Numeric',
+      inherited: undefined,
+      inheritedType: undefined,
+    });
+  });
+
+  it('should keep all values when metadata contains multiple items', () => {
+    const property = {
+      _id: 'p7',
+      name: 'multi_text',
+      label: 'Multiple text values',
+      type: 'text',
+    } as BaseMetadataProperty;
+
+    expect(formatSimpleProperty(property, metadata)).toEqual({
+      _id: 'p7',
+      name: 'multi_text',
+      type: 'text',
+      values: [{ value: 'First value' }, { value: 'Second value' }, { value: '' }],
+      label: 'Multiple text values',
       inherited: undefined,
       inheritedType: undefined,
     });


### PR DESCRIPTION
Fixes some metadata displaying components that assumed that there's only one value for a field when in reality a field can be a relationship with multiple inherited values. This way rendering a metadata property should be agnostic of whether it's an entities own value or an inherited one.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
