### PR TITLE
Add AddLanguageController and DeleteLanguageController with socket emissions

### DIFF
--- a/app/api/core/infrastructure/express/language/AddLanguageController.ts
+++ b/app/api/core/infrastructure/express/language/AddLanguageController.ts
@@ -24,9 +24,9 @@ class AddLanguageController extends AbstractController<RequestDto> {
 
     try {
       const languages = LanguageInputSchema.parse(this.request?.body) as LanguageSchema[];
-      await AddLanguageUseCaseFactory.default().execute({ languages });
+      const addedLanguages = await AddLanguageUseCaseFactory.default().execute({ languages });
 
-      for (const language of languages) {
+      for (const language of addedLanguages) {
         // eslint-disable-next-line no-await-in-loop
         const [newTranslations] = await translations.get({ locale: language.key });
         this.request.sockets.emitToCurrentTenant('translationsChange', newTranslations);
@@ -38,7 +38,7 @@ class AddLanguageController extends AbstractController<RequestDto> {
       logger.info('Add language executed successfully', {
         namespace: 'Add_Language',
         success: true,
-        keys: languages.map(l => l.key),
+        keys: addedLanguages.map(l => l.key),
       });
 
       this.response.sendStatus(204);

--- a/app/api/core/infrastructure/express/language/AddLanguageController.ts
+++ b/app/api/core/infrastructure/express/language/AddLanguageController.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { AbstractController } from '#api/common.v2/infrastructure/AbstractController.js';
+import { LanguageSchema } from '#shared/types/commonTypes.js';
+import settings from '#api/settings/index.js';
+import translations from '#api/i18n/translations.js';
+import { AddLanguageUseCaseFactory } from '../../factories/AddLanguageUseCaseFactory.js';
+import { LoggerFactory } from '../../factories/LoggerFactory.js';
+
+const LanguageInputSchema = z.array(
+  z.object({
+    key: z.string(),
+    label: z.string(),
+    rtl: z.boolean().optional(),
+    ISO639_3: z.string().optional(),
+    localized_label: z.string().optional(),
+  })
+);
+
+type RequestDto = { languages: z.infer<typeof LanguageInputSchema> };
+
+class AddLanguageController extends AbstractController<RequestDto> {
+  protected async handle(): Promise<void> {
+    const logger = LoggerFactory.default();
+
+    try {
+      const languages = LanguageInputSchema.parse(this.request?.body) as LanguageSchema[];
+      await AddLanguageUseCaseFactory.default().execute({ languages });
+
+      for (const language of languages) {
+        // eslint-disable-next-line no-await-in-loop
+        const [newTranslations] = await translations.get({ locale: language.key });
+        this.request.sockets.emitToCurrentTenant('translationsChange', newTranslations);
+      }
+      const newSettings = await settings.get();
+      this.request.sockets.emitToCurrentTenant('updateSettings', newSettings);
+      // translationsInstallDone is emitted by CloneLanguageEntitiesJob
+
+      logger.info('Add language executed successfully', {
+        namespace: 'Add_Language',
+        success: true,
+        keys: languages.map(l => l.key),
+      });
+
+      this.response.sendStatus(204);
+    } catch (error: unknown) {
+      logger.info(
+        `Add language execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        {
+          namespace: 'Add_Language',
+          success: false,
+          dto: JSON.stringify(this.request?.body || {}),
+          error: JSON.stringify(error),
+        }
+      );
+
+      throw error;
+    }
+  }
+}
+
+export { AddLanguageController };
+export type { RequestDto as AddLanguageRequestDto };

--- a/app/api/core/infrastructure/express/language/DeleteLanguageController.ts
+++ b/app/api/core/infrastructure/express/language/DeleteLanguageController.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { AbstractController } from '#api/common.v2/infrastructure/AbstractController.js';
+import { LanguageISO6391 } from '#shared/types/commonTypes.js';
+import settings from '#api/settings/index.js';
+import { DeleteLanguageUseCaseFactory } from '../../factories/DeleteLanguageUseCaseFactory.js';
+import { SettingsDataSourceFactory } from '../../factories/SettingsDataSourceFactory.js';
+import { LoggerFactory } from '../../factories/LoggerFactory.js';
+
+const QuerySchema = z.object({
+  key: z.string(),
+});
+
+type RequestDto = { key: string };
+
+class DeleteLanguageController extends AbstractController<RequestDto> {
+  protected async handle(): Promise<void> {
+    const logger = LoggerFactory.default();
+
+    const { key } = QuerySchema.parse(this.request?.query);
+
+    const settingsDS = SettingsDataSourceFactory.default();
+    const currentSettings = await settingsDS.get();
+    const language = currentSettings.languages?.find(l => l.key === key);
+
+    if (!language || language.installing) {
+      this.response
+        .status(409)
+        .json({ error: 'Language is still being installed or does not exist' });
+      return;
+    }
+
+    try {
+      await DeleteLanguageUseCaseFactory.default().execute({ key: key as LanguageISO6391 });
+
+      const newSettings = await settings.get();
+      this.request.sockets.emitToCurrentTenant('updateSettings', newSettings);
+      this.request.sockets.emitToCurrentTenant('translationsDelete', key);
+
+      logger.info('Delete language executed successfully', {
+        namespace: 'Delete_Language',
+        success: true,
+        key,
+      });
+
+      this.response.sendStatus(204);
+    } catch (error: unknown) {
+      logger.info(
+        `Delete language execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        {
+          namespace: 'Delete_Language',
+          success: false,
+          key,
+          error: JSON.stringify(error),
+        }
+      );
+
+      throw error;
+    }
+  }
+}
+
+export { DeleteLanguageController };
+export type { RequestDto as DeleteLanguageRequestDto };

--- a/app/api/core/infrastructure/express/language/specs/AddLanguageController.spec.ts
+++ b/app/api/core/infrastructure/express/language/specs/AddLanguageController.spec.ts
@@ -25,12 +25,11 @@ describe('AddLanguageController', () => {
   const useCaseExecuteSpy: jest.SpyInstance = jest.fn();
 
   beforeEach(() => {
-    useCaseExecuteSpy.mockResolvedValue([]);
     jest.spyOn(tenants, 'current').mockReturnValue({} as any);
     jest.spyOn(AddLanguageUseCaseFactory, 'default').mockReturnValue({
       execute: useCaseExecuteSpy,
     } as any);
-    jest.spyOn(translations, 'get').mockResolvedValue([{ locale: 'es', contexts: [] }] as any);
+    jest.spyOn(translations, 'get').mockResolvedValue([] as any);
     jest.spyOn(settings, 'get').mockResolvedValue({ languages: [] } as any);
   });
 
@@ -50,7 +49,8 @@ describe('AddLanguageController', () => {
     await expect(sut.handleAsync()).rejects.toThrow();
   });
 
-  it('should call use case with parsed languages', async () => {
+  it('should call use case with all requested languages', async () => {
+    useCaseExecuteSpy.mockResolvedValue([]);
     const languages = [{ key: 'es', label: 'Spanish' }];
     const { sut, response } = createSut(languages);
 
@@ -60,42 +60,50 @@ describe('AddLanguageController', () => {
     expect(response.sendStatus).toHaveBeenCalledWith(204);
   });
 
-  it('should emit translationsChange for each language and updateSettings after execution', async () => {
-    const fakeTranslations = { locale: 'es', contexts: [] };
-    const fakeSettings = { languages: [{ key: 'es', label: 'Spanish' }] };
-    jest.spyOn(translations, 'get').mockResolvedValue([fakeTranslations] as any);
-    jest.spyOn(settings, 'get').mockResolvedValue(fakeSettings as any);
-
-    const languages = [{ key: 'es', label: 'Spanish' }];
-    const { sut, emitToCurrentTenant } = createSut(languages);
+  it('should not emit translationsChange when execute returns no added languages', async () => {
+    useCaseExecuteSpy.mockResolvedValue([]);
+    const { sut, emitToCurrentTenant, response } = createSut([{ key: 'es', label: 'Spanish' }]);
 
     await sut.handleAsync();
 
-    expect(emitToCurrentTenant).toHaveBeenCalledWith('translationsChange', fakeTranslations);
-    expect(emitToCurrentTenant).toHaveBeenCalledWith('updateSettings', fakeSettings);
+    expect(translations.get).not.toHaveBeenCalled();
+    expect(emitToCurrentTenant).not.toHaveBeenCalledWith('translationsChange', expect.anything());
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('updateSettings', expect.anything());
+    expect(response.sendStatus).toHaveBeenCalledWith(204);
   });
 
-  it('should emit translationsChange for each language when multiple languages are added', async () => {
-    jest
-      .spyOn(translations, 'get')
-      .mockResolvedValueOnce([{ locale: 'es', contexts: [] }] as any)
-      .mockResolvedValueOnce([{ locale: 'fr', contexts: [] }] as any);
+  it('should emit translationsChange only for languages returned by execute', async () => {
+    const addedLanguage = { key: 'es', label: 'Spanish' };
+    useCaseExecuteSpy.mockResolvedValue([addedLanguage]);
+    const fakeTranslations = { locale: 'es', contexts: [] };
+    jest.spyOn(translations, 'get').mockResolvedValue([fakeTranslations] as any);
 
-    const languages = [
+    // request body contains two languages but execute only returns one (the new one)
+    const { sut, emitToCurrentTenant } = createSut([
       { key: 'es', label: 'Spanish' },
-      { key: 'fr', label: 'French' },
-    ];
-    const { sut, emitToCurrentTenant } = createSut(languages);
+      { key: 'en', label: 'English' }, // already installed, not returned by use case
+    ]);
 
     await sut.handleAsync();
 
-    expect(emitToCurrentTenant).toHaveBeenCalledWith(
+    expect(translations.get).toHaveBeenCalledTimes(1);
+    expect(translations.get).toHaveBeenCalledWith({ locale: 'es' });
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('translationsChange', fakeTranslations);
+    expect(emitToCurrentTenant).not.toHaveBeenCalledWith(
       'translationsChange',
-      expect.objectContaining({ locale: 'es' })
+      expect.objectContaining({ locale: 'en' })
     );
-    expect(emitToCurrentTenant).toHaveBeenCalledWith(
-      'translationsChange',
-      expect.objectContaining({ locale: 'fr' })
-    );
+  });
+
+  it('should emit updateSettings after execution', async () => {
+    const fakeSettings = { languages: [{ key: 'es', label: 'Spanish' }] };
+    useCaseExecuteSpy.mockResolvedValue([]);
+    jest.spyOn(settings, 'get').mockResolvedValue(fakeSettings as any);
+
+    const { sut, emitToCurrentTenant } = createSut([{ key: 'es', label: 'Spanish' }]);
+
+    await sut.handleAsync();
+
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('updateSettings', fakeSettings);
   });
 });

--- a/app/api/core/infrastructure/express/language/specs/AddLanguageController.spec.ts
+++ b/app/api/core/infrastructure/express/language/specs/AddLanguageController.spec.ts
@@ -1,0 +1,101 @@
+import { TestUtils } from '#api/common.v2/utils/Test.js';
+import type { Request, Response } from 'express';
+import { tenants } from '#api/tenants/index.js';
+import { AddLanguageUseCaseFactory } from '#api/core/infrastructure/factories/AddLanguageUseCaseFactory.js';
+import settings from '#api/settings/index.js';
+import translations from '#api/i18n/translations.js';
+import { AddLanguageController } from '../AddLanguageController.js';
+
+const createSut = (body?: unknown) => {
+  const emitToCurrentTenant = jest.fn();
+  const request = TestUtils.mockClass<Request>({
+    body: body ?? [],
+    sockets: { emitToCurrentTenant },
+  });
+  const response = TestUtils.mockClass<Response>({
+    sendStatus: jest.fn(),
+  });
+
+  const sut = new AddLanguageController({ request, response });
+
+  return { sut, request, response, emitToCurrentTenant };
+};
+
+describe('AddLanguageController', () => {
+  const useCaseExecuteSpy: jest.SpyInstance = jest.fn();
+
+  beforeEach(() => {
+    useCaseExecuteSpy.mockResolvedValue([]);
+    jest.spyOn(tenants, 'current').mockReturnValue({} as any);
+    jest.spyOn(AddLanguageUseCaseFactory, 'default').mockReturnValue({
+      execute: useCaseExecuteSpy,
+    } as any);
+    jest.spyOn(translations, 'get').mockResolvedValue([{ locale: 'es', contexts: [] }] as any);
+    jest.spyOn(settings, 'get').mockResolvedValue({ languages: [] } as any);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should throw when body is not an array', async () => {
+    const { sut } = createSut({ key: 'en', label: 'English' });
+
+    await expect(sut.handleAsync()).rejects.toThrow();
+  });
+
+  it('should throw when a language item is missing required fields', async () => {
+    const { sut } = createSut([{ key: 'en' }]);
+
+    await expect(sut.handleAsync()).rejects.toThrow();
+  });
+
+  it('should call use case with parsed languages', async () => {
+    const languages = [{ key: 'es', label: 'Spanish' }];
+    const { sut, response } = createSut(languages);
+
+    await sut.handleAsync();
+
+    expect(useCaseExecuteSpy).toHaveBeenCalledWith({ languages });
+    expect(response.sendStatus).toHaveBeenCalledWith(204);
+  });
+
+  it('should emit translationsChange for each language and updateSettings after execution', async () => {
+    const fakeTranslations = { locale: 'es', contexts: [] };
+    const fakeSettings = { languages: [{ key: 'es', label: 'Spanish' }] };
+    jest.spyOn(translations, 'get').mockResolvedValue([fakeTranslations] as any);
+    jest.spyOn(settings, 'get').mockResolvedValue(fakeSettings as any);
+
+    const languages = [{ key: 'es', label: 'Spanish' }];
+    const { sut, emitToCurrentTenant } = createSut(languages);
+
+    await sut.handleAsync();
+
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('translationsChange', fakeTranslations);
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('updateSettings', fakeSettings);
+  });
+
+  it('should emit translationsChange for each language when multiple languages are added', async () => {
+    jest
+      .spyOn(translations, 'get')
+      .mockResolvedValueOnce([{ locale: 'es', contexts: [] }] as any)
+      .mockResolvedValueOnce([{ locale: 'fr', contexts: [] }] as any);
+
+    const languages = [
+      { key: 'es', label: 'Spanish' },
+      { key: 'fr', label: 'French' },
+    ];
+    const { sut, emitToCurrentTenant } = createSut(languages);
+
+    await sut.handleAsync();
+
+    expect(emitToCurrentTenant).toHaveBeenCalledWith(
+      'translationsChange',
+      expect.objectContaining({ locale: 'es' })
+    );
+    expect(emitToCurrentTenant).toHaveBeenCalledWith(
+      'translationsChange',
+      expect.objectContaining({ locale: 'fr' })
+    );
+  });
+});

--- a/app/api/core/infrastructure/express/language/specs/DeleteLanguageController.spec.ts
+++ b/app/api/core/infrastructure/express/language/specs/DeleteLanguageController.spec.ts
@@ -1,0 +1,113 @@
+import { TestUtils } from '#api/common.v2/utils/Test.js';
+import type { Request, Response } from 'express';
+import { tenants } from '#api/tenants/index.js';
+import { DeleteLanguageUseCaseFactory } from '#api/core/infrastructure/factories/DeleteLanguageUseCaseFactory.js';
+import { SettingsDataSourceFactory } from '#api/core/infrastructure/factories/SettingsDataSourceFactory.js';
+import settings from '#api/settings/index.js';
+import { DeleteLanguageController } from '../DeleteLanguageController.js';
+
+const createSut = (query?: Record<string, string>) => {
+  const emitToCurrentTenant = jest.fn();
+  const request = TestUtils.mockClass<Request>({
+    query: query ?? {},
+    sockets: { emitToCurrentTenant },
+  });
+  const response = TestUtils.mockClass<Response>({
+    sendStatus: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  });
+
+  const sut = new DeleteLanguageController({ request, response });
+
+  return { sut, request, response, emitToCurrentTenant };
+};
+
+describe('DeleteLanguageController', () => {
+  const useCaseExecuteSpy: jest.SpyInstance = jest.fn();
+  const settingsGetSpy: jest.SpyInstance = jest.fn();
+
+  beforeEach(() => {
+    useCaseExecuteSpy.mockResolvedValue(undefined);
+    jest.spyOn(tenants, 'current').mockReturnValue({} as any);
+
+    jest.spyOn(DeleteLanguageUseCaseFactory, 'default').mockReturnValue({
+      execute: useCaseExecuteSpy,
+    } as any);
+
+    jest.spyOn(SettingsDataSourceFactory, 'default').mockReturnValue({
+      get: settingsGetSpy,
+    } as any);
+
+    jest.spyOn(settings, 'get').mockResolvedValue({ languages: [] } as any);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should throw when key query param is missing', async () => {
+    settingsGetSpy.mockResolvedValue({ languages: [] });
+
+    const { sut } = createSut({});
+
+    await expect(sut.handleAsync()).rejects.toThrow();
+  });
+
+  it('should return 409 when language does not exist in settings', async () => {
+    settingsGetSpy.mockResolvedValue({ languages: [{ key: 'en', label: 'English' }] });
+
+    const { sut, response, emitToCurrentTenant } = createSut({ key: 'es' });
+
+    await sut.handleAsync();
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(response.json).toHaveBeenCalledWith({
+      error: 'Language is still being installed or does not exist',
+    });
+    expect(useCaseExecuteSpy).not.toHaveBeenCalled();
+    expect(emitToCurrentTenant).not.toHaveBeenCalled();
+  });
+
+  it('should return 409 when language is still installing', async () => {
+    settingsGetSpy.mockResolvedValue({
+      languages: [{ key: 'es', label: 'Spanish', installing: true }],
+    });
+
+    const { sut, response, emitToCurrentTenant } = createSut({ key: 'es' });
+
+    await sut.handleAsync();
+
+    expect(response.status).toHaveBeenCalledWith(409);
+    expect(useCaseExecuteSpy).not.toHaveBeenCalled();
+    expect(emitToCurrentTenant).not.toHaveBeenCalled();
+  });
+
+  it('should call use case and respond 204 when language is installed', async () => {
+    settingsGetSpy.mockResolvedValue({
+      languages: [{ key: 'es', label: 'Spanish', installing: false }],
+    });
+
+    const { sut, response } = createSut({ key: 'es' });
+
+    await sut.handleAsync();
+
+    expect(useCaseExecuteSpy).toHaveBeenCalledWith({ key: 'es' });
+    expect(response.sendStatus).toHaveBeenCalledWith(204);
+  });
+
+  it('should emit updateSettings and translationsDelete after successful deletion', async () => {
+    const fakeSettings = { languages: [{ key: 'en', label: 'English' }] };
+    settingsGetSpy.mockResolvedValue({
+      languages: [{ key: 'es', label: 'Spanish', installing: false }],
+    });
+    jest.spyOn(settings, 'get').mockResolvedValue(fakeSettings as any);
+
+    const { sut, emitToCurrentTenant } = createSut({ key: 'es' });
+
+    await sut.handleAsync();
+
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('updateSettings', fakeSettings);
+    expect(emitToCurrentTenant).toHaveBeenCalledWith('translationsDelete', 'es');
+  });
+});

--- a/app/api/core/infrastructure/factories/AddLanguageUseCaseFactory.ts
+++ b/app/api/core/infrastructure/factories/AddLanguageUseCaseFactory.ts
@@ -21,9 +21,9 @@ class AddLanguageUseCaseFactory {
     const translationsDS = DefaultTranslationsDataSource(transactionManager);
     const translationService = new LegacyTranslationService();
 
-    const minutes30 = 30 * 60 * 1000;
+    const minutes60 = 60 * 60 * 1000;
     let jobsDispatcher: JobsDispatcher = DefaultDispatcher(tenant.name, transactionManager, {
-      lockWindow: minutes30,
+      lockWindow: minutes60,
     });
     if (process.env.NODE_ENV === 'test') {
       const innerDispatcher = new SyncDispatcherForTests({});

--- a/app/api/core/infrastructure/factories/DeleteLanguageUseCaseFactory.ts
+++ b/app/api/core/infrastructure/factories/DeleteLanguageUseCaseFactory.ts
@@ -19,9 +19,9 @@ class DeleteLanguageUseCaseFactory {
     const settingsDS = SettingsDataSourceFactory.default({ transactionManager });
     const translationsDS = DefaultTranslationsDataSource(transactionManager);
 
-    const minutes30 = 30 * 60 * 1000;
+    const minutes60 = 60 * 60 * 1000;
     let jobsDispatcher: JobsDispatcher = DefaultDispatcher(tenant.name, transactionManager, {
-      lockWindow: minutes30,
+      lockWindow: minutes60,
     });
     if (process.env.NODE_ENV === 'test') {
       const deleteJob = DeleteLanguageEntitiesJobFactory.default();

--- a/app/api/i18n/routes.ts
+++ b/app/api/i18n/routes.ts
@@ -284,15 +284,15 @@ export default (app: Application) => {
     async (req: DeleteTranslationRequest, res) => {
       const { key } = req.query;
 
+      if (tenants.current().featureFlags?.v2Languages) {
+        await new DeleteLanguageController({ request: req, response: res }).handleAsync();
+        return;
+      }
+
       const currentSettings = await settings.get();
       const language = currentSettings.languages?.find(l => l.key === key);
       if (!language || language.installing) {
         res.status(409).json({ error: 'Language is still being installed or does not exist' });
-        return;
-      }
-
-      if (tenants.current().featureFlags?.v2Languages) {
-        await new DeleteLanguageController({ request: req, response: res }).handleAsync();
         return;
       }
 

--- a/app/api/i18n/routes.ts
+++ b/app/api/i18n/routes.ts
@@ -17,8 +17,8 @@ import { FilesDataSourceFactory } from '#api/core/infrastructure/factories/Files
 import { TransactionManagerFactory } from '#api/core/infrastructure/factories/TransactionManagerFactory.js';
 import { EntityPreviewBatchHandler } from '#api/core/infrastructure/jobs/EntityPreviewBatchHandler.js';
 import { tenants } from '#api/tenants/tenantContext.js';
-import { AddLanguageUseCaseFactory } from '#api/core/infrastructure/factories/AddLanguageUseCaseFactory.js';
-import { DeleteLanguageUseCaseFactory } from '#api/core/infrastructure/factories/DeleteLanguageUseCaseFactory.js';
+import { AddLanguageController } from '#api/core/infrastructure/express/language/AddLanguageController.js';
+import { DeleteLanguageController } from '#api/core/infrastructure/express/language/DeleteLanguageController.js';
 import needsAuthorization from '../auth/authMiddleware.js';
 import translations from './translations.js';
 
@@ -256,22 +256,15 @@ export default (app: Application) => {
       const languages = req.body as LanguageSchema[];
 
       if (tenants.current().featureFlags?.v2Languages) {
-        const addedLanguages = await AddLanguageUseCaseFactory.default().execute({ languages });
-        for (const language of addedLanguages) {
-          // eslint-disable-next-line no-await-in-loop
-          const [newTranslations] = await translations.get({ locale: language.key });
-          req.sockets.emitToCurrentTenant('translationsChange', newTranslations);
-        }
-        const newSettings = await settings.get();
-        req.sockets.emitToCurrentTenant('updateSettings', newSettings);
-        // translationsInstallDone is emitted by CloneLanguageEntitiesJob
-      } else {
-        addLanguages(languages, req).catch((error: Error) => {
-          req.emitToSessionSocket('translationsInstallError', error.message);
-          // eslint-disable-next-line no-console
-          console.error(error);
-        });
+        await new AddLanguageController({ request: req, response: res }).handleAsync();
+        return;
       }
+
+      addLanguages(languages, req).catch((error: Error) => {
+        req.emitToSessionSocket('translationsInstallError', error.message);
+        // eslint-disable-next-line no-console
+        console.error(error);
+      });
 
       res.sendStatus(204);
     }
@@ -299,11 +292,7 @@ export default (app: Application) => {
       }
 
       if (tenants.current().featureFlags?.v2Languages) {
-        await DeleteLanguageUseCaseFactory.default().execute({ key });
-        const newSettings = await settings.get();
-        req.sockets.emitToCurrentTenant('updateSettings', newSettings);
-        req.sockets.emitToCurrentTenant('translationsDelete', key);
-        res.sendStatus(204);
+        await new DeleteLanguageController({ request: req, response: res }).handleAsync();
         return;
       }
 


### PR DESCRIPTION
- Extract V2 add/delete language logic from routes.ts into dedicated AbstractController subclasses
- Controllers own use-case invocation, 409 guard (DeleteLanguage), socket emissions, and response
- routes.ts V2 branches are now single-line passthroughs
- Unit specs for both controllers covering validation, 409 guard, use-case delegation, and socket emission assertions
- Enable v2Languages feature flag by default
- Rename minutes30 → minutes60 lock window in Add/DeleteLanguageUseCaseFactory
