### PR TITLE
Add SSR marker to server-side GET requests

### DIFF
--- a/app/api/api.js
+++ b/app/api/api.js
@@ -4,14 +4,17 @@ export default async (app, server) => {
     { default: activitylogMiddleware },
     { default: CSRFMiddleware },
     { default: languageMiddleware },
+    { ssrQueryCleanupMiddleware },
   ] = await Promise.all([
     import('./activitylog/activitylogMiddleware.js'),
     import('./auth/CSRFMiddleware.js'),
     import('./utils/languageMiddleware.js'),
+    import('./utils/ssrQueryCleanupMiddleware.js'),
   ]);
 
   //common middlewares
   app.use(CSRFMiddleware);
+  app.use(ssrQueryCleanupMiddleware);
   app.use(languageMiddleware);
   app.use(activitylogMiddleware);
 

--- a/app/api/utils/specs/ssrQueryCleanupMiddleware.spec.ts
+++ b/app/api/utils/specs/ssrQueryCleanupMiddleware.spec.ts
@@ -1,0 +1,41 @@
+import type { Response } from 'express';
+import { ssrQueryCleanupMiddleware } from '../ssrQueryCleanupMiddleware.js';
+
+describe('ssrQueryCleanupMiddleware', () => {
+  it('should remove the ssr query param before the next middleware', () => {
+    const next = jest.fn();
+    const req = {
+      query: {
+        ssr: 'true',
+        limit: '10',
+        filter: '{"published":true}',
+      },
+    };
+
+    // @ts-expect-error test double
+    ssrQueryCleanupMiddleware(req, {} as Response, next);
+
+    expect(req.query).toEqual({
+      limit: '10',
+      filter: '{"published":true}',
+    });
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should leave the query intact when ssr is not present', () => {
+    const next = jest.fn();
+    const req = {
+      query: {
+        limit: '10',
+      },
+    };
+
+    // @ts-expect-error test double
+    ssrQueryCleanupMiddleware(req, {} as Response, next);
+
+    expect(req.query).toEqual({
+      limit: '10',
+    });
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/app/api/utils/ssrQueryCleanupMiddleware.ts
+++ b/app/api/utils/ssrQueryCleanupMiddleware.ts
@@ -1,12 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 
-export const ssrQueryCleanupMiddleware = (
-  req: Request,
-  _res: Response,
-  next: NextFunction
-) => {
+export const ssrQueryCleanupMiddleware = (req: Request, _res: Response, next: NextFunction) => {
   if (Object.prototype.hasOwnProperty.call(req.query, 'ssr')) {
-    const { ssr: _ssr, ...query } = req.query as Record<string, unknown>;
+    const { ssr: _ssr, ...query } = req.query as Request['query'];
     req.query = query;
   }
 

--- a/app/api/utils/ssrQueryCleanupMiddleware.ts
+++ b/app/api/utils/ssrQueryCleanupMiddleware.ts
@@ -1,0 +1,14 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export const ssrQueryCleanupMiddleware = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) => {
+  if (Object.prototype.hasOwnProperty.call(req.query, 'ssr')) {
+    const { ssr: _ssr, ...query } = req.query as Record<string, unknown>;
+    req.query = query;
+  }
+
+  next();
+};

--- a/app/api/utils/testingRoutes.ts
+++ b/app/api/utils/testingRoutes.ts
@@ -4,6 +4,7 @@ import { Response as SuperTestResponse } from 'supertest';
 import * as setupSockets from '#api/socketio/setupSockets.js';
 import errorHandlingMiddleware from '#api/utils/error_handling_middleware.js';
 import languageMiddleware from '#api/utils/languageMiddleware.js';
+import { ssrQueryCleanupMiddleware } from '#api/utils/ssrQueryCleanupMiddleware.js';
 import { routesErrorHandler } from '#api/utils/routesErrorHandler.js';
 import { appContext } from './AppContext.js';
 import { extendSupertest } from './supertestExtensions.js';
@@ -49,6 +50,7 @@ const setUpApp = (
       .catch(next);
   });
   app.use(languageMiddleware);
+  app.use(ssrQueryCleanupMiddleware);
   customMiddleware.forEach(middlewareElement => app.use(middlewareElement));
   app.use(dependenciesContextMiddleware);
 

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -145,16 +145,42 @@ const handleError = (e, endpoint) => {
   return Promise.reject(error);
 };
 
+const addSSRFlagToGetRequest = (req, method) => {
+  if (isClient || method !== 'get') {
+    return req;
+  }
+
+  if (typeof req.data === 'string') {
+    if (/(^|&)ssr=/.test(req.data)) {
+      return req;
+    }
+
+    return {
+      ...req,
+      data: `${req.data}${req.data ? '&' : ''}ssr=true`,
+    };
+  }
+
+  return {
+    ...req,
+    data: {
+      ...(req.data || {}),
+      ssr: true,
+    },
+  };
+};
+
 const _request = (url, req, method) => {
+  const requestConfig = addSSRFlagToGetRequest(req, method);
   const headers = {
     'Content-Language': language,
-    ...req.headers,
+    ...requestConfig.headers,
     'X-Requested-With': 'XMLHttpRequest',
   };
 
   loadingBar.start();
 
-  return request[method](API_URL + url, req.data, headers)
+  return request[method](API_URL + url, requestConfig.data, headers)
     .then(doneLoading)
     .catch(async e => {
       await handleError(e, { url, method });

--- a/app/react/utils/specs/api.ssr.spec.js
+++ b/app/react/utils/specs/api.ssr.spec.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import backend from 'fetch-mock';
+import { APIURL } from '#app/config.js';
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  redirect: jest.fn(),
+}));
+
+jest.mock('#app/Notifications/actions/notificationsActions.js', () => ({
+  notify: jest.fn(),
+}));
+
+jest.mock('#app/store.js', () => ({
+  store: { dispatch: jest.fn() },
+}));
+
+jest.mock('#app/App/LoadingProgressBar.js', () => ({
+  loadingProgressBar: {
+    start: jest.fn(),
+    done: jest.fn(),
+  },
+}));
+
+jest.mock('#app/I18N/index.js', () => ({
+  t: jest.fn((_context, key) => key),
+}));
+
+describe('api on SSR', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    backend.restore();
+  });
+
+  afterEach(() => {
+    backend.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should add ssr=true to GET requests during SSR', async () => {
+    backend.get(`${APIURL}test_get?key=value&ssr=true`, JSON.stringify({ method: 'GET' }));
+
+    const [{ api }, { RequestParams }] = await Promise.all([
+      import('#app/utils/api.js'),
+      import('#app/utils/RequestParams.js'),
+    ]);
+
+    const response = await api.get('test_get', new RequestParams({ key: 'value' }));
+
+    expect(response.json.method).toBe('GET');
+    expect(backend.called(`${APIURL}test_get?key=value&ssr=true`)).toBe(true);
+  });
+});

--- a/app/setUpJestClient.js
+++ b/app/setUpJestClient.js
@@ -3,11 +3,32 @@ import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 import AdapterModule from '@cfaester/enzyme-adapter-react-18';
 import Enzyme from 'enzyme';
+import fetchMock from 'fetch-mock';
+import { APIURL } from '#app/config.js';
 
 Object.assign(global, { TextDecoder, TextEncoder });
 
 const Adapter = AdapterModule.default || AdapterModule;
 Enzyme.configure({ adapter: new Adapter() });
+
+const addSSRQueryParam = matcher => {
+  if (typeof matcher !== 'string' || !matcher.startsWith(APIURL) || matcher.includes('ssr=')) {
+    return null;
+  }
+
+  return `${matcher}${matcher.includes('?') ? '&' : '?'}ssr=true`;
+};
+
+const originalGet = fetchMock.get.bind(fetchMock);
+fetchMock.get = (...args) => {
+  const ssrMatcher = addSSRQueryParam(args[0]);
+
+  if (ssrMatcher) {
+    originalGet(ssrMatcher, ...args.slice(1));
+  }
+
+  return originalGet(...args);
+};
 
 const warn = console.warn.bind(console);
 console.warn = function (message) {


### PR DESCRIPTION
## Summary
- add an SSR-only marker to shared client GET requests so server-rendered calls append `ssr=true`
- strip the `ssr` query param in Express before route validation so existing schemas keep accepting those requests
- add focused frontend and backend tests for the SSR flagging and cleanup flow