### PR TITLE
Fix page editor new-page form reset and entity view versioning

### DIFF
--- a/app/react/V2/Routes/Settings/Pages/PageEditor.tsx
+++ b/app/react/V2/Routes/Settings/Pages/PageEditor.tsx
@@ -75,17 +75,10 @@ const PageEditor = () => {
   const editorDraftValuesRef = useRef<
     Record<string, { content?: string; script?: string; css?: string }>
   >({});
+  const lastAppliedLoaderSignatureRef = useRef<string | null>(null);
   const isNewPage = !page.sharedId;
+  const languagesReady = languages.length > 0;
   const { notify } = useRequestStatus();
-
-  const languagesSignature = useMemo(
-    () =>
-      languages
-        .map(l => l.key)
-        .sort()
-        .join(','),
-    [languages]
-  );
 
   const pageLoaderSignature = useMemo(
     () =>
@@ -102,7 +95,7 @@ const PageEditor = () => {
 
   const serverFormSeed = useMemo(
     () => buildPageEditorFormValues(page, languages),
-    [pageLoaderSignature, languagesSignature, page, languages]
+    [pageLoaderSignature, languages, page]
   );
 
   useEffect(() => {
@@ -137,18 +130,26 @@ const PageEditor = () => {
 
   const formSharedId = watch('sharedId');
 
-  // Re-sync form when loader data changes (after revalidate or navigation), not from save response.
+  // Re-sync form only when loader data changes (after revalidate or navigation).
   useEffect(() => {
-    if (languages.length === 0) {
+    if (!languagesReady) {
       return;
     }
     // After first save, navigate is pending — loader still has {}; skip until loader catches up.
     if (!page.sharedId && formSharedId) {
       return;
     }
+    // Do not overwrite in-progress edits on a new page before the first save.
+    if (!page.sharedId && Object.keys(dirtyFields).length > 0) {
+      return;
+    }
+    if (lastAppliedLoaderSignatureRef.current === pageLoaderSignature) {
+      return;
+    }
+    lastAppliedLoaderSignatureRef.current = pageLoaderSignature;
     reset(buildPageEditorFormValues(page, languages));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageLoaderSignature, languagesSignature, formSharedId, reset]);
+  }, [pageLoaderSignature, languagesReady, formSharedId, page, languages, dirtyFields]);
 
   const markdownSupport = watch('markdownSupport') === true;
   const showMarkdownDeprecation = !!watch('sharedId') && markdownSupport;
@@ -312,59 +313,63 @@ const PageEditor = () => {
             />
           </div>
 
-          <Tabs unmountTabs={false} tabListClassName="md:w-2/3 w-full" className="min-h-0 flex-1">
-            <Tabs.Tab id="Configuration" label={<Translate>Configuration</Translate>}>
-              <form className="pb-6">
-                <input className="hidden" {...register('sharedId')} />
-                <div className="flex flex-col max-w-2xl gap-4 pt-2">
-                  {showMarkdownDeprecation && (
-                    <MarkdownDeprecationBanner
-                      onUpgrade={() => setValue('markdownSupport', false, { shouldDirty: true })}
-                    />
-                  )}
-                  <ToggleButton
-                    checked={entityView}
-                    onToggle={() => setValue('entityView', !entityView, { shouldDirty: true })}
-                  >
-                    <Translate className="text-sm font-semibold text-ink">
-                      Enable this page to be used as an entity view page:
-                    </Translate>
-                  </ToggleButton>
-
-                  <InputField
-                    id={`title-${activeLocale}`}
-                    label={<Translate>Title</Translate>}
-                    {...register(`locales.${activeLocale}.title`, { required: true })}
-                    hasErrors={localeErrors?.title !== undefined}
-                    errorMessage={
-                      localeErrors?.title && <Translate>This field is required</Translate>
-                    }
-                  />
-
-                  {showPageUrlPreviews && (
-                    <CopyValueInput
-                      value={`/${activeLocale}/${getPageUrl(pageSharedId!, urlTitle ?? '')}`}
-                      label={<Translate>URL</Translate>}
-                      className="w-full"
-                      id={`page-url-${activeLocale}`}
-                    />
-                  )}
-
-                  {pageSharedId && showPageUrlPreviews && (
-                    <Link
-                      target="_blank"
-                      to={`/${activeLocale}/${getPageUrl(pageSharedId!, urlTitle ?? '')}`}
+          {!languagesReady ? (
+            <p className="pt-4 text-sm text-ink-secondary">
+              <Translate>Loading</Translate>
+            </p>
+          ) : (
+            <Tabs unmountTabs={false} tabListClassName="md:w-2/3 w-full" className="min-h-0 flex-1">
+              <Tabs.Tab id="Configuration" label={<Translate>Configuration</Translate>}>
+                <form className="pb-6">
+                  <input className="hidden" {...register('sharedId')} />
+                  <div className="flex flex-col max-w-2xl gap-4 pt-2">
+                    {showMarkdownDeprecation && (
+                      <MarkdownDeprecationBanner
+                        onUpgrade={() => setValue('markdownSupport', false, { shouldDirty: true })}
+                      />
+                    )}
+                    <ToggleButton
+                      checked={entityView}
+                      onToggle={() => setValue('entityView', !entityView, { shouldDirty: true })}
                     >
-                      <div className="flex gap-2 hover:font-bold hover:cursor-pointer">
-                        <ArrowTopRightOnSquareIcon className="w-4" />
-                        <Translate className="underline hover:text-primary-700">
-                          View page
-                        </Translate>
-                      </div>
-                    </Link>
-                  )}
+                      <Translate className="text-sm font-semibold text-ink">
+                        Enable this page to be used as an entity view page:
+                      </Translate>
+                    </ToggleButton>
 
-                  {!entityView && (
+                    <InputField
+                      id={`title-${activeLocale}`}
+                      label={<Translate>Title</Translate>}
+                      {...register(`locales.${activeLocale}.title`, { required: true })}
+                      hasErrors={localeErrors?.title !== undefined}
+                      errorMessage={
+                        localeErrors?.title && <Translate>This field is required</Translate>
+                      }
+                    />
+
+                    {showPageUrlPreviews && (
+                      <CopyValueInput
+                        value={`/${activeLocale}/${getPageUrl(pageSharedId!, urlTitle ?? '')}`}
+                        label={<Translate>URL</Translate>}
+                        className="w-full"
+                        id={`page-url-${activeLocale}`}
+                      />
+                    )}
+
+                    {pageSharedId && showPageUrlPreviews && (
+                      <Link
+                        target="_blank"
+                        to={`/${activeLocale}/${getPageUrl(pageSharedId!, urlTitle ?? '')}`}
+                      >
+                        <div className="flex gap-2 hover:font-bold hover:cursor-pointer">
+                          <ArrowTopRightOnSquareIcon className="w-4" />
+                          <Translate className="underline hover:text-primary-700">
+                            View page
+                          </Translate>
+                        </div>
+                      </Link>
+                    )}
+
                     <div className="flex flex-wrap gap-2 pt-2">
                       <Button
                         variant="secondary"
@@ -389,60 +394,60 @@ const PageEditor = () => {
                         <Translate>Publish</Translate>
                       </Button>
                     </div>
-                  )}
-                </div>
-              </form>
-            </Tabs.Tab>
+                  </div>
+                </form>
+              </Tabs.Tab>
 
-            <Tabs.Tab id="HTML" label={<Translate>HTML</Translate>}>
-              <PageEditorHtmlPanel
-                activeLocale={activeLocale}
-                localeDraft={localeDraft}
-                register={register}
-                setValue={setValue}
-                onDraftChange={(language, draft) => {
-                  editorDraftValuesRef.current[language] = {
-                    ...editorDraftValuesRef.current[language],
-                    ...draft,
-                  };
-                }}
-                useLegacyMarkdown={markdownSupport}
-                editorLayoutKey={editorLayoutKey}
-              />
-            </Tabs.Tab>
+              <Tabs.Tab id="HTML" label={<Translate>HTML</Translate>}>
+                <PageEditorHtmlPanel
+                  activeLocale={activeLocale}
+                  localeDraft={localeDraft}
+                  register={register}
+                  setValue={setValue}
+                  onDraftChange={(language, draft) => {
+                    editorDraftValuesRef.current[language] = {
+                      ...editorDraftValuesRef.current[language],
+                      ...draft,
+                    };
+                  }}
+                  useLegacyMarkdown={markdownSupport}
+                  editorLayoutKey={editorLayoutKey}
+                />
+              </Tabs.Tab>
 
-            <Tabs.Tab id="Javascript" label={<Translate>Javascript</Translate>}>
-              <PageEditorJavascriptPanel
-                activeLocale={activeLocale}
-                localeDraft={localeDraft}
-                register={register}
-                setValue={setValue}
-                onDraftChange={(language, draft) => {
-                  editorDraftValuesRef.current[language] = {
-                    ...editorDraftValuesRef.current[language],
-                    ...draft,
-                  };
-                }}
-                editorLayoutKey={editorLayoutKey}
-              />
-            </Tabs.Tab>
+              <Tabs.Tab id="Javascript" label={<Translate>Javascript</Translate>}>
+                <PageEditorJavascriptPanel
+                  activeLocale={activeLocale}
+                  localeDraft={localeDraft}
+                  register={register}
+                  setValue={setValue}
+                  onDraftChange={(language, draft) => {
+                    editorDraftValuesRef.current[language] = {
+                      ...editorDraftValuesRef.current[language],
+                      ...draft,
+                    };
+                  }}
+                  editorLayoutKey={editorLayoutKey}
+                />
+              </Tabs.Tab>
 
-            <Tabs.Tab id="CSS" label={<Translate>CSS</Translate>}>
-              <PageEditorCssPanel
-                activeLocale={activeLocale}
-                localeDraft={localeDraft}
-                register={register}
-                setValue={setValue}
-                onDraftChange={(language, draft) => {
-                  editorDraftValuesRef.current[language] = {
-                    ...editorDraftValuesRef.current[language],
-                    ...draft,
-                  };
-                }}
-                editorLayoutKey={editorLayoutKey}
-              />
-            </Tabs.Tab>
-          </Tabs>
+              <Tabs.Tab id="CSS" label={<Translate>CSS</Translate>}>
+                <PageEditorCssPanel
+                  activeLocale={activeLocale}
+                  localeDraft={localeDraft}
+                  register={register}
+                  setValue={setValue}
+                  onDraftChange={(language, draft) => {
+                    editorDraftValuesRef.current[language] = {
+                      ...editorDraftValuesRef.current[language],
+                      ...draft,
+                    };
+                  }}
+                  editorLayoutKey={editorLayoutKey}
+                />
+              </Tabs.Tab>
+            </Tabs>
+          )}
         </SettingsContent.Body>
 
         <SettingsContent.Footer>
@@ -456,12 +461,16 @@ const PageEditor = () => {
             <Button
               variant="primary"
               onClick={handleSubmit(handleSaveAndPreview)}
-              disabled={getValues('entityView') || isSubmitting}
+              disabled={!languagesReady || getValues('entityView') || isSubmitting}
             >
               <Translate>Save & Preview</Translate>
             </Button>
 
-            <Button variant="success" onClick={handleSubmit(handleSave)} disabled={isSubmitting}>
+            <Button
+              variant="success"
+              onClick={handleSubmit(handleSave)}
+              disabled={!languagesReady || isSubmitting}
+            >
               <Translate>Save</Translate>
             </Button>
           </div>

--- a/playwright/e2e/pages.contract.spec.ts
+++ b/playwright/e2e/pages.contract.spec.ts
@@ -20,6 +20,17 @@ const PAGE_TITLE = `E2E Custom Page ${Date.now()}`;
 const HTML_MARKER_TEXT = `E2E marker ${Date.now()}`;
 const HTML_MARKER_CONTENT = `<h1>${HTML_MARKER_TEXT}</h1>`;
 
+/** ToggleButton hides the input; click via accessible name (label text), not data-testid. */
+const entityViewCheckbox = (page: Page) =>
+  page.getByRole('checkbox', { name: /entity view page/i });
+
+async function setEntityView(page: Page, enabled: boolean) {
+  const checkbox = entityViewCheckbox(page);
+  if ((await checkbox.isChecked()) !== enabled) {
+    await checkbox.click({ force: true });
+  }
+}
+
 test('pages contract creates a custom page that renders at its URL', async ({ page }) => {
   test.setTimeout(3 * 60 * 1000);
 
@@ -51,13 +62,12 @@ test('pages contract creates a custom page that renders at its URL', async ({ pa
     await page.waitForTimeout(500);
     await expect(titleInput).toHaveValue(PAGE_TITLE);
 
-    const entityViewToggle = page.getByTestId('toggle').first();
-    await entityViewToggle.click();
+    await setEntityView(page, true);
     await page.waitForTimeout(500);
-    await expect(entityViewToggle).toBeChecked();
-    await entityViewToggle.click();
+    await expect(entityViewCheckbox(page)).toBeChecked();
+    await setEntityView(page, false);
     await page.waitForTimeout(500);
-    await expect(entityViewToggle).not.toBeChecked();
+    await expect(entityViewCheckbox(page)).not.toBeChecked();
 
     await page.getByRole('tab', { name: 'HTML' }).click();
     await page.locator('.monaco-editor').first().click();
@@ -131,10 +141,9 @@ test('pages contract entity view page shows publish and restore after save', asy
     await page.waitForTimeout(500);
     await expect(titleInput).toHaveValue(ENTITY_VIEW_PAGE_TITLE);
 
-    const entityViewToggle = page.getByTestId('toggle').first();
-    await entityViewToggle.click();
+    await setEntityView(page, true);
     await page.waitForTimeout(500);
-    await expect(entityViewToggle).toBeChecked();
+    await expect(entityViewCheckbox(page)).toBeChecked();
 
     const saveResponsePromise = page.waitForResponse(
       response =>

--- a/playwright/e2e/pages.contract.spec.ts
+++ b/playwright/e2e/pages.contract.spec.ts
@@ -48,6 +48,16 @@ test('pages contract creates a custom page that renders at its URL', async ({ pa
     const titleInput = page.locator('[id^="title-"]').first();
     await expect(titleInput).toBeVisible();
     await titleInput.fill(PAGE_TITLE);
+    await page.waitForTimeout(500);
+    await expect(titleInput).toHaveValue(PAGE_TITLE);
+
+    const entityViewToggle = page.getByTestId('toggle').first();
+    await entityViewToggle.click();
+    await page.waitForTimeout(500);
+    await expect(entityViewToggle).toBeChecked();
+    await entityViewToggle.click();
+    await page.waitForTimeout(500);
+    await expect(entityViewToggle).not.toBeChecked();
 
     await page.getByRole('tab', { name: 'HTML' }).click();
     await page.locator('.monaco-editor').first().click();
@@ -97,5 +107,52 @@ test('pages contract creates a custom page that renders at its URL', async ({ pa
     await gotoWithRetry(draftPageUrl, page);
     await expect(page).toHaveURL(new RegExp(`${draftPageUrl}$`));
     await expect(page.getByRole('heading', { name: HTML_MARKER_TEXT })).toBeVisible();
+  });
+});
+
+const ENTITY_VIEW_PAGE_TITLE = `E2E Entity View Page ${Date.now()}`;
+
+test('pages contract entity view page shows publish and restore after save', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+
+  await test.step('Login and navigate to Pages settings', async () => {
+    await loginAsAdmin(page);
+    await gotoWithRetry('/settings/pages', page);
+    await expect(page.getByTestId('settings-pages')).toBeVisible();
+  });
+
+  await test.step('Create entity view page and save', async () => {
+    await page.getByRole('link', { name: 'Add page' }).click();
+    await expect(page).toHaveURL(/\/settings\/pages\/new/);
+
+    const titleInput = page.locator('[id^="title-"]').first();
+    await expect(titleInput).toBeVisible();
+    await titleInput.fill(ENTITY_VIEW_PAGE_TITLE);
+    await page.waitForTimeout(500);
+    await expect(titleInput).toHaveValue(ENTITY_VIEW_PAGE_TITLE);
+
+    const entityViewToggle = page.getByTestId('toggle').first();
+    await entityViewToggle.click();
+    await page.waitForTimeout(500);
+    await expect(entityViewToggle).toBeChecked();
+
+    const saveResponsePromise = page.waitForResponse(
+      response =>
+        response.url().includes('/api/pages') &&
+        response.request().method() === 'POST' &&
+        response.status() === 200
+    );
+    await page.getByRole('button', { name: /^Save$/ }).click();
+    await saveResponsePromise;
+
+    await expect(page.getByText('Saved successfully').first()).toBeVisible();
+    await expect(page).toHaveURL(/\/settings\/pages\/edit\/[a-z0-9]+/i);
+  });
+
+  await test.step('Configuration shows Publish and Restore for entity view page', async () => {
+    await page.getByRole('tab', { name: 'Configuration' }).click();
+    await expect(page.getByRole('button', { name: 'Publish' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Restore' })).toBeVisible();
+    await expect(page.locator('[id^="page-url-"]')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
fixes #9180

## Summary
- Fix react-hook-form reset on `/settings/pages/new` so title and entity view toggle are not wiped while editing before the first save.
- Show Publish and Restore on saved entity view pages (backend already supports releases; entity views load published content).
- Extend Playwright pages contract tests for title/toggle persistence and entity view versioning UI.

## Test plan
- [x] On `/settings/pages/new`, change title and toggle entity view before save — values persist.
- [x] Save new page — navigates to edit URL with correct title and entityView in payload.
- [x] Saved entity view page — Publish and Restore visible on Configuration tab; no public page URL field.
- [x] `yarn playwright test playwright/e2e/pages.contract.spec.ts` (e2e stack running)

Made with [Cursor](https://cursor.com)