### PR TITLE
Fix V1 thesauri.save() bridge passing undefined actorId

### DIFF
--- a/app/api/thesauri/specs/thesauri.spec.js
+++ b/app/api/thesauri/specs/thesauri.spec.js
@@ -105,6 +105,30 @@ describe('thesauri', () => {
         const edited = await getById(dictionaryId);
         expect(edited.name).toBe('changed name');
       });
+
+      it('should dispatch a denormalization job with the actor userId', async () => {
+        const data = {
+          _id: dictionaryId,
+          name: 'Updated dict',
+          values: [{ label: 'new value' }],
+        };
+
+        const jobsBefore = await testingEnvironment.db.getAllFrom('jobs');
+
+        await testingEnvironment.runWithContext(async () => {
+          await thesauri.save(data);
+        });
+
+        const jobsAfter = await testingEnvironment.db.getAllFrom('jobs');
+        const newJobs = jobsAfter.filter(
+          j =>
+            j.name === 'DenormalizeThesaurusEntitiesHandler' &&
+            !jobsBefore.find(b => String(b._id) === String(j._id))
+        );
+
+        expect(newJobs).toHaveLength(1);
+        expect(newJobs[0].params.userId).toEqual(expect.any(String));
+      });
     });
 
     describe('validation', () => {

--- a/app/api/thesauri/thesauri.js
+++ b/app/api/thesauri/thesauri.js
@@ -85,7 +85,7 @@ const thesauri = {
     const updated = existing.update({ name, values });
     await service.update(updated, {
       tenantName: ExecutionContext.tenant.name,
-      actorId: ExecutionContext.actorId,
+      actorId: ExecutionContext.actor?._id,
     });
 
     return { _id: updated.id, name: updated.name, values: updated.values };


### PR DESCRIPTION
## Summary

V1 `thesauri.save()` referenced `ExecutionContext.actorId` which doesn't exist on the `ExecutionContext` class (it only has an `actor` getter). This caused `DenormalizeThesaurusEntitiesHandler` jobs to be dispatched without a `userId`, failing with "There is no userId" when processed by the queue.

## Fix

Changed `thesauri.js:88` from `ExecutionContext.actorId` → `ExecutionContext.actor?._id` to correctly extract the actor's ID.

## Test

Added a test that calls `thesauri.save()` within `runWithContext` and verifies the dispatched denormalization job has a valid `userId` string.