### PR TITLE
Fix false mismatches when saving template relationship properties

### DIFF
--- a/app/react/V2/Routes/Settings/Templates/components/ConfigPropertyPanel.tsx
+++ b/app/react/V2/Routes/Settings/Templates/components/ConfigPropertyPanel.tsx
@@ -24,11 +24,7 @@ import {
 import { ThesaurusField } from './fields/ThesaurusField.js';
 import { RelationshipFields } from './fields/RelationshipFields.js';
 import { MatchingPropertiesTable } from './MatchingPropertiesTable.js';
-import {
-  optionalIdMatches,
-  relationshipConfigMatches,
-  translationsKeys,
-} from '../helpers.js';
+import { optionalIdMatches, relationshipConfigMatches, translationsKeys } from '../helpers.js';
 import { PropertyRow } from '../types.js';
 import { GeneratedIdField } from './fields/GeneratedIdField.js';
 

--- a/app/react/V2/Routes/Settings/Templates/components/ConfigPropertyPanel.tsx
+++ b/app/react/V2/Routes/Settings/Templates/components/ConfigPropertyPanel.tsx
@@ -24,7 +24,11 @@ import {
 import { ThesaurusField } from './fields/ThesaurusField.js';
 import { RelationshipFields } from './fields/RelationshipFields.js';
 import { MatchingPropertiesTable } from './MatchingPropertiesTable.js';
-import { translationsKeys } from '../helpers.js';
+import {
+  optionalIdMatches,
+  relationshipConfigMatches,
+  translationsKeys,
+} from '../helpers.js';
 import { PropertyRow } from '../types.js';
 import { GeneratedIdField } from './fields/GeneratedIdField.js';
 
@@ -172,7 +176,7 @@ export const ConfigPropertyPanel: React.FC<ConfigPropertyPanelProps> = ({
 
     if (type === 'select' || type === 'multiselect') {
       const hasContentMismatch = matchingProperties.some(
-        (prop: ClientProperty) => prop.content !== content
+        (prop: ClientProperty) => !optionalIdMatches(prop.content, content)
       );
       if (hasContentMismatch) {
         return false;
@@ -182,9 +186,7 @@ export const ConfigPropertyPanel: React.FC<ConfigPropertyPanelProps> = ({
     if (type === 'relationship') {
       const hasRelationshipMismatch = matchingProperties.some(
         (prop: ClientProperty) =>
-          prop.content !== content ||
-          prop.relationType !== relationType ||
-          JSON.stringify(prop.inherit) !== JSON.stringify(inherit)
+          !relationshipConfigMatches(prop, { content, relationType, inherit })
       );
       if (hasRelationshipMismatch) {
         return false;

--- a/app/react/V2/Routes/Settings/Templates/components/MatchingPropertiesTable.tsx
+++ b/app/react/V2/Routes/Settings/Templates/components/MatchingPropertiesTable.tsx
@@ -112,7 +112,7 @@ function relationTypeCellRenderer(
 function inheritTypeCellRenderer(inherit: { property: string; type: string } | undefined) {
   return (cell: CellContext<MatchingPropRow, { type: string } | undefined>) => {
     const value = cell.getValue()?.type as keyof typeof translationsKeys;
-    const matches = inheritMatches(cell.getValue(), inherit);
+    const matches = inheritMatches(cell.row.original.inherit, inherit);
     return (
       <span className={`flex items-center gap-2 ${matches ? '' : 'text-error-600'}`}>
         {propertyIconsSmall[value]}

--- a/app/react/V2/Routes/Settings/Templates/components/MatchingPropertiesTable.tsx
+++ b/app/react/V2/Routes/Settings/Templates/components/MatchingPropertiesTable.tsx
@@ -9,7 +9,7 @@ import { Translate, t } from '#app/I18N/index.js';
 import { CellContext, ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { PropertyTypeSchema } from '#shared/types/commonTypes.js';
 import { ClientTemplateSchema } from '#V2/shared/types.js';
-import { translationsKeys } from '../helpers.js';
+import { inheritMatches, optionalIdMatches, translationsKeys } from '../helpers.js';
 
 type MatchingPropRow = {
   templateId: string;
@@ -65,7 +65,7 @@ const ThesauriCellComponent: React.FC<ThesauriCellProps> = ({
   currentContent,
   thesauri,
 }) => {
-  const matches = value === (currentContent || '');
+  const matches = optionalIdMatches(value, currentContent);
   const thesaurus = thesauri.find(thesaurusItem => thesaurusItem._id === value);
   const displayName = thesaurus ? thesaurus.name : value || <Translate>No type</Translate>;
   return <span className={matches ? '' : 'text-error-600'}>{displayName}</span>;
@@ -83,7 +83,7 @@ function thesauriCellRenderer(
 function entitiesCellRenderer(content: string | undefined, templates: ClientTemplateSchema[]) {
   return (cell: CellContext<MatchingPropRow, string | undefined>) => {
     const value = cell.getValue();
-    const matches = value === content || (!content && !value);
+    const matches = optionalIdMatches(value, content);
     const foundTemplate = templates.find(tmpl => tmpl._id === value);
     const displayValue = foundTemplate ? (
       <Translate context={foundTemplate._id} truncate={30}>
@@ -102,17 +102,17 @@ function relationTypeCellRenderer(
 ) {
   return (cell: CellContext<MatchingPropRow, string | undefined>) => {
     const value = cell.getValue();
-    const matches = value === (relationType || '');
+    const matches = optionalIdMatches(value, relationType);
     const relationshipType = relationshipTypes.find(rt => rt._id === value);
     const displayValue = relationshipType ? relationshipType.name : <Translate>No type</Translate>;
     return <span className={matches ? '' : 'text-error-600'}>{displayValue}</span>;
   };
 }
 
-function inheritTypeCellRenderer(inheritType: string | undefined) {
+function inheritTypeCellRenderer(inherit: { property: string; type: string } | undefined) {
   return (cell: CellContext<MatchingPropRow, { type: string } | undefined>) => {
     const value = cell.getValue()?.type as keyof typeof translationsKeys;
-    const matches = value === inheritType || (!inheritType && !value);
+    const matches = inheritMatches(cell.getValue(), inherit);
     return (
       <span className={`flex items-center gap-2 ${matches ? '' : 'text-error-600'}`}>
         {propertyIconsSmall[value]}
@@ -226,7 +226,7 @@ export const MatchingPropertiesTable = ({
       columnHelper.accessor('inherit', {
         id: 'inheritType',
         header: InheritTypeHeader,
-        cell: inheritTypeCellRenderer(inherit?.type),
+        cell: inheritTypeCellRenderer(inherit),
         enableSorting: false,
       })
     );

--- a/app/react/V2/Routes/Settings/Templates/components/fields/RelationshipFields.tsx
+++ b/app/react/V2/Routes/Settings/Templates/components/fields/RelationshipFields.tsx
@@ -134,7 +134,7 @@ export const RelationshipFields = ({ control, disabled, templateId }: Relationsh
                 if (option && option.type) {
                   field.onChange({ property: value, type: option.type });
                 } else {
-                  field.onChange('');
+                  field.onChange(undefined);
                 }
               }}
               value={field.value?.property || ''}

--- a/app/react/V2/Routes/Settings/Templates/helpers.ts
+++ b/app/react/V2/Routes/Settings/Templates/helpers.ts
@@ -97,27 +97,33 @@ const cleanProperty = (prop: PropertyRow) => {
 const isEmptyValue = (value: unknown): boolean =>
   value === null || value === undefined || value === '';
 
-const normalizeOptionalId = (value: string | null | undefined): string | undefined =>
-  isEmptyValue(value) ? undefined : value;
+const normalizeOptionalId = (value: string | null | undefined): string | undefined => {
+  if (isEmptyValue(value)) {
+    return undefined;
+  }
+
+  return value as string;
+};
 
 type InheritValue = { property: string; type: string } | string | null | undefined;
 
-const normalizeInherit = (inherit: InheritValue): { property: string; type: string } | undefined => {
+const normalizeInherit = (
+  inherit: InheritValue
+): { property: string; type: string } | undefined => {
   if (isEmptyValue(inherit) || typeof inherit !== 'object') {
     return undefined;
   }
 
-  if (inherit.property && inherit.type) {
-    return { property: inherit.property, type: inherit.type };
+  const { property, type } = inherit as { property?: string; type?: string };
+  if (property && type) {
+    return { property, type };
   }
 
   return undefined;
 };
 
-const optionalIdMatches = (
-  a: string | null | undefined,
-  b: string | null | undefined
-): boolean => normalizeOptionalId(a) === normalizeOptionalId(b);
+const optionalIdMatches = (a: string | null | undefined, b: string | null | undefined): boolean =>
+  normalizeOptionalId(a) === normalizeOptionalId(b);
 
 const inheritMatches = (a: InheritValue, b: InheritValue): boolean =>
   JSON.stringify(normalizeInherit(a)) === JSON.stringify(normalizeInherit(b));

--- a/app/react/V2/Routes/Settings/Templates/helpers.ts
+++ b/app/react/V2/Routes/Settings/Templates/helpers.ts
@@ -94,6 +94,50 @@ const cleanProperty = (prop: PropertyRow) => {
   return rest;
 };
 
+const isEmptyValue = (value: unknown): boolean =>
+  value === null || value === undefined || value === '';
+
+const normalizeOptionalId = (value: string | null | undefined): string | undefined =>
+  isEmptyValue(value) ? undefined : value;
+
+type InheritValue = { property: string; type: string } | string | null | undefined;
+
+const normalizeInherit = (inherit: InheritValue): { property: string; type: string } | undefined => {
+  if (isEmptyValue(inherit) || typeof inherit !== 'object') {
+    return undefined;
+  }
+
+  if (inherit.property && inherit.type) {
+    return { property: inherit.property, type: inherit.type };
+  }
+
+  return undefined;
+};
+
+const optionalIdMatches = (
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean => normalizeOptionalId(a) === normalizeOptionalId(b);
+
+const inheritMatches = (a: InheritValue, b: InheritValue): boolean =>
+  JSON.stringify(normalizeInherit(a)) === JSON.stringify(normalizeInherit(b));
+
+const relationshipConfigMatches = (
+  a: {
+    content?: string | null;
+    relationType?: string | null;
+    inherit?: InheritValue;
+  },
+  b: {
+    content?: string | null;
+    relationType?: string | null;
+    inherit?: InheritValue;
+  }
+): boolean =>
+  optionalIdMatches(a.content, b.content) &&
+  optionalIdMatches(a.relationType, b.relationType) &&
+  inheritMatches(a.inherit, b.inherit);
+
 export {
   processDefaultProperties,
   processProperties,
@@ -101,4 +145,7 @@ export {
   emptyTemplate,
   translationsKeys,
   confirmationMessages,
+  optionalIdMatches,
+  inheritMatches,
+  relationshipConfigMatches,
 };

--- a/app/react/V2/Routes/Settings/Templates/specs/helpers.spec.ts
+++ b/app/react/V2/Routes/Settings/Templates/specs/helpers.spec.ts
@@ -1,8 +1,4 @@
-import {
-  inheritMatches,
-  optionalIdMatches,
-  relationshipConfigMatches,
-} from '../helpers.js';
+import { inheritMatches, optionalIdMatches, relationshipConfigMatches } from '../helpers.js';
 
 describe('template property matching helpers', () => {
   describe('optionalIdMatches', () => {

--- a/app/react/V2/Routes/Settings/Templates/specs/helpers.spec.ts
+++ b/app/react/V2/Routes/Settings/Templates/specs/helpers.spec.ts
@@ -1,0 +1,65 @@
+import {
+  inheritMatches,
+  optionalIdMatches,
+  relationshipConfigMatches,
+} from '../helpers.js';
+
+describe('template property matching helpers', () => {
+  describe('optionalIdMatches', () => {
+    it('should treat null, undefined and empty string as equivalent', () => {
+      expect(optionalIdMatches(null, undefined)).toBe(true);
+      expect(optionalIdMatches('', null)).toBe(true);
+      expect(optionalIdMatches(undefined, '')).toBe(true);
+    });
+
+    it('should compare non-empty ids strictly', () => {
+      expect(optionalIdMatches('abc', 'abc')).toBe(true);
+      expect(optionalIdMatches('abc', 'def')).toBe(false);
+      expect(optionalIdMatches('abc', '')).toBe(false);
+    });
+  });
+
+  describe('inheritMatches', () => {
+    it('should treat empty inherit values as equivalent', () => {
+      expect(inheritMatches(null, undefined)).toBe(true);
+      expect(inheritMatches('', null)).toBe(true);
+      expect(inheritMatches(undefined, '')).toBe(true);
+    });
+
+    it('should compare inherit objects by property and type', () => {
+      const inherit = { property: 'prop1', type: 'text' };
+
+      expect(inheritMatches(inherit, { ...inherit })).toBe(true);
+      expect(inheritMatches(inherit, null)).toBe(false);
+      expect(inheritMatches(inherit, { property: 'prop2', type: 'text' })).toBe(false);
+    });
+  });
+
+  describe('relationshipConfigMatches', () => {
+    it('should not flag a mismatch when only empty sentinels differ', () => {
+      expect(
+        relationshipConfigMatches(
+          {
+            content: '5bfbb1a0471dd0fc16ada146',
+            relationType: '6a156ed77cdd1afa52f8cdb8',
+            inherit: '',
+          },
+          {
+            content: '5bfbb1a0471dd0fc16ada146',
+            relationType: '6a156ed77cdd1afa52f8cdb8',
+            inherit: null,
+          }
+        )
+      ).toBe(true);
+    });
+
+    it('should flag a mismatch when relationship config differs', () => {
+      expect(
+        relationshipConfigMatches(
+          { content: 'a', relationType: 'b', inherit: null },
+          { content: 'a', relationType: 'c', inherit: null }
+        )
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixed template properties validations

When saving a template property that shares its label with properties in other templates, Save is disabled if the configs don’t match. The bug was strict comparison (=== / JSON.stringify) without normalizing empty values: the DB often stores null while the form uses "" or undefined (especially for inherit). Semantically identical configs were treated as mismatches, so Save stayed disabled even when nothing was actually wrong.