### PR TITLE
Fix stale library filter counts after aggregation updates

### DIFF
--- a/app/react/Forms/components/LookupMultiSelect.tsx
+++ b/app/react/Forms/components/LookupMultiSelect.tsx
@@ -20,6 +20,9 @@ function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
   return value !== null && value !== undefined;
 }
 
+const aggregationOptionsSignature = (options: Option[], optionsValue: string) =>
+  options.map(option => `${option[optionsValue]}:${option.results ?? ''}`).join('\0');
+
 export const debounceTime = 200;
 
 export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupMultiSelectState> {
@@ -41,25 +44,50 @@ export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupM
     this.onFilter = debounce(this.onFilter.bind(this), debounceTime) as (
       searchTerm: string
     ) => Promise<void>;
+    this.refreshPreloadedOptions = this.refreshPreloadedOptions.bind(this);
+  }
+
+  async refreshPreloadedOptions() {
+    const { lookup, options, optionsValue } = this.props;
+    if (!lookup) {
+      return;
+    }
+
+    const { options: lookupResult, count } = await lookup('');
+    const combinedOptions = [...options, ...lookupResult].filter(uniqueOptions(optionsValue));
+
+    this.setState({
+      preloadedOptions: combinedOptions,
+      lookupOptions: [],
+      totalPossibleOptions: count,
+    });
   }
 
   async componentDidMount() {
     if (this.props.lookup) {
-      const { options, count } = await this.props.lookup('');
-      const combinedOptions = [...this.props.options, ...options].filter(
-        uniqueOptions(this.props.optionsValue)
-      );
-      this.setState({ preloadedOptions: combinedOptions, totalPossibleOptions: count });
+      await this.refreshPreloadedOptions();
     }
   }
 
   async componentDidUpdate(prevProps: LookupMultiSelectProps) {
-    if (prevProps.lookup !== this.props.lookup) {
-      const { options, count } = await this.props.lookup('');
-      const combinedOptions = [...this.props.options, ...options].filter(
-        uniqueOptions(this.props.optionsValue)
-      );
-      this.setState({ preloadedOptions: combinedOptions, totalPossibleOptions: count });
+    const optionsChanged =
+      aggregationOptionsSignature(prevProps.options, prevProps.optionsValue) !==
+      aggregationOptionsSignature(this.props.options, this.props.optionsValue);
+    const lookupChanged = prevProps.lookup !== this.props.lookup;
+
+    if (!optionsChanged && !lookupChanged) {
+      return;
+    }
+
+    if (optionsChanged) {
+      this.setState({
+        preloadedOptions: this.props.options,
+        lookupOptions: [],
+      });
+    }
+
+    if (this.props.lookup) {
+      await this.refreshPreloadedOptions();
     }
   }
 

--- a/app/react/Forms/components/specs/LookupMultiSelect.spec.tsx
+++ b/app/react/Forms/components/specs/LookupMultiSelect.spec.tsx
@@ -277,6 +277,50 @@ describe('LookupMultiSelect (React Testing Library)', () => {
     });
   });
 
+  it('should update displayed aggregation counts when props.options change with the same lookup ref', async () => {
+    const lookup = jest.fn(async () => ({
+      options: [{ label: 'Organization 001', value: 'org-1', results: 999 }],
+      count: 1,
+    }));
+
+    const initialOptions = [
+      { label: 'Organization 001', value: 'org-1', results: 400 },
+      { label: 'Organization 002', value: 'org-2', results: 300 },
+    ];
+
+    const { rerender } = render(
+      <LookupMultiSelect
+        options={initialOptions}
+        lookup={lookup}
+        value={[]}
+        onChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(lookup).toHaveBeenCalledWith(''));
+    expect(screen.getByText('400')).toBeInTheDocument();
+    expect(screen.getByText('300')).toBeInTheDocument();
+
+    rerender(
+      <LookupMultiSelect
+        options={[
+          { label: 'Organization 001', value: 'org-1', results: 40 },
+          { label: 'Organization 002', value: 'org-2', results: 30 },
+        ]}
+        lookup={lookup}
+        value={[]}
+        onChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('40')).toBeInTheDocument();
+      expect(screen.getByText('30')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('400')).not.toBeInTheDocument();
+    expect(screen.queryByText('300')).not.toBeInTheDocument();
+  });
+
   it('should not render a search bar if lookup returns 5 or fewer options', async () => {
     const initialOptions = Array.from({ length: 5 }, (_, i) => ({
       label: `Option${i + 1}`,

--- a/app/react/Forms/components/specs/LookupMultiSelect.spec.tsx
+++ b/app/react/Forms/components/specs/LookupMultiSelect.spec.tsx
@@ -289,12 +289,7 @@ describe('LookupMultiSelect (React Testing Library)', () => {
     ];
 
     const { rerender } = render(
-      <LookupMultiSelect
-        options={initialOptions}
-        lookup={lookup}
-        value={[]}
-        onChange={jest.fn()}
-      />
+      <LookupMultiSelect options={initialOptions} lookup={lookup} value={[]} onChange={jest.fn()} />
     );
 
     await waitFor(() => expect(lookup).toHaveBeenCalledWith(''));


### PR DESCRIPTION
## Summary
- Sync `LookupMultiSelect` preloaded options when aggregation counts change in `props.options`, fixing stale relationship/select filter counts after cross-filtering (regression from lookup memoization in #9145).
- Extract `refreshPreloadedOptions` and clear lookup search results when the aggregation context changes.
- Add RTL test covering rerender with the same memoized lookup ref.

## Test plan
- [x] `yarn test app/react/Forms/components/specs/LookupMultiSelect.spec.tsx`
- [ ] Library → Heroes template → apply Super powers filter → Organization counts update (e.g. 400 → 40)


Made with [Cursor](https://cursor.com)