### PR TITLE
Fix PDF rendering for JPEG2000 images (PDF.js 5)

### DIFF
--- a/app/react/PDF/components/PDF.jsx
+++ b/app/react/PDF/components/PDF.jsx
@@ -7,7 +7,7 @@ import { Translate } from '#app/I18N/index.js';
 import { PDFPage } from '#app/PDF/index.js';
 import { BlankState } from '#app/V2/Components/UI/index.js';
 import { selectionHandlers } from '#V2/Components/PDFViewer/index.js';
-import { PDFJS, CMAP_URL } from '#V2/Components/PDFViewer/pdfjs.js';
+import { PDFJS, CMAP_URL, WASM_URL } from '#V2/Components/PDFViewer/pdfjs.js';
 import { isClient } from '../../utils/index.js';
 import 'pdfjs-dist/web/pdf_viewer.css';
 import { reportErrorToSentry } from '#app/V2/shared/errorUtils.js';
@@ -114,6 +114,7 @@ class PDF extends Component {
         url: file,
         cMapUrl: CMAP_URL,
         cMapPacked,
+        wasmUrl: WASM_URL,
         isEvalSupported: false,
       })
         .promise.then(pdf => {

--- a/app/react/PDF/components/specs/PDF.spec.js
+++ b/app/react/PDF/components/specs/PDF.spec.js
@@ -13,6 +13,7 @@ jest.mock('#V2/Components/PDFViewer/pdfjs.js', () => ({
   PDFJS: { getDocument: jest.fn() },
   EventBus: function () {},
   CMAP_URL: '/legacy_character_maps/',
+  WASM_URL: '/pdfjs_wasm/',
 }));
 
 // eslint-disable-next-line max-statements
@@ -50,6 +51,7 @@ describe('PDF', () => {
       expect(PDFJS.getDocument).toHaveBeenCalledWith({
         cMapPacked: true,
         cMapUrl: legacyCharacterMapUrl,
+        wasmUrl: '/pdfjs_wasm/',
         isEvalSupported: false,
         url: props.file,
       });

--- a/app/react/V2/Components/PDFViewer/PDF.tsx
+++ b/app/react/V2/Components/PDFViewer/PDF.tsx
@@ -14,7 +14,7 @@ import { triggerScroll } from './functions/helpers.js';
 import { clearSnippets, tryHighlightAndScroll } from './functions/handleSnippets.js';
 import { adjustSelectionsToScale } from './functions/handleTextSelection.js';
 import { waitForElement } from './functions/waitForElement.js';
-import { PDFJS, CMAP_URL, EventBus, PDFDocumentProxy } from './pdfjs.js';
+import { PDFJS, CMAP_URL, WASM_URL, EventBus, PDFDocumentProxy } from './pdfjs.js';
 import { useContainerWidth } from './hooks/useContainerWidth.js';
 import { PDFPage } from './PDFPage.js';
 import { BlankState, ProgressBar } from '../UI/index.js';
@@ -216,6 +216,7 @@ const PDF = ({
       url: fileUrl,
       cMapUrl: CMAP_URL,
       cMapPacked: true,
+      wasmUrl: WASM_URL,
       isEvalSupported: false,
     });
 

--- a/app/react/V2/Components/PDFViewer/pdfjs.ts
+++ b/app/react/V2/Components/PDFViewer/pdfjs.ts
@@ -46,6 +46,7 @@ type EventBusType = typeof EventBus.prototype;
 const PDFJS = pdfjs;
 const { PixelsPerInch } = pdfjs;
 const CMAP_URL = '/legacy_character_maps/';
+const WASM_URL = '/pdfjs_wasm/';
 
 export type { PDFDocumentProxy, PDFEventMap, EventBusType };
-export { PDFJS, PDFJSViewer, EventBus, CMAP_URL, PixelsPerInch };
+export { PDFJS, PDFJSViewer, EventBus, CMAP_URL, WASM_URL, PixelsPerInch };

--- a/app/react/V2/Components/PDFViewer/specs/PDF.spec.tsx
+++ b/app/react/V2/Components/PDFViewer/specs/PDF.spec.tsx
@@ -37,6 +37,7 @@ jest.mock('../pdfjs.ts', () => ({
     getDocument: (...args: any[]) => mockGetDocument(...args),
   },
   CMAP_URL: '/legacy_character_maps/',
+  WASM_URL: '/pdfjs_wasm/',
   EventBus: mockEventBus,
   PixelsPerInch: { PDF_TO_CSS_UNITS: 1 },
 }));
@@ -103,6 +104,7 @@ describe('PDF', () => {
       url: '/file.pdf',
       cMapUrl: '/legacy_character_maps/',
       cMapPacked: true,
+      wasmUrl: '/pdfjs_wasm/',
       isEvalSupported: false,
     });
 

--- a/webpack/config.cjs
+++ b/webpack/config.cjs
@@ -254,6 +254,7 @@ module.exports = production => {
           { from: 'node_modules/leaflet/dist/images/', to: 'CSS/images' },
           { from: 'node_modules/leaflet/dist/images/', to: 'images' },
           { from: 'node_modules/pdfjs-dist/cmaps/', to: 'legacy_character_maps/' },
+          { from: 'node_modules/pdfjs-dist/wasm/', to: 'pdfjs_wasm/' },
         ],
       }),
 

--- a/webpack/webpack.server.js
+++ b/webpack/webpack.server.js
@@ -46,7 +46,9 @@ const webpackPort = Number(process.env.WEBPACK_PORT || 8080);
       const normalizedPath = filePath.replace(/\\/g, '/');
       return normalizedPath.endsWith('.css') ||
         normalizedPath.includes('webpack-assets.json') ||
-        normalizedPath.includes('/CSS/');
+        normalizedPath.includes('/CSS/') ||
+        normalizedPath.includes('/pdfjs_wasm/') ||
+        normalizedPath.includes('/legacy_character_maps/');
     },
   });
 


### PR DESCRIPTION
## Summary
- Configure `wasmUrl` for PDF.js 5 so JPEG2000 (JPX) images in scanned PDFs decode correctly
- Copy OpenJPEG WASM assets to `/pdfjs_wasm/` via webpack
- Write WASM and cmaps to disk in dev so Express can serve them (fixes 404 on `openjpeg.wasm` in hot mode)