### PR TITLE
Quick fixes: settings toggles and Bert auth gate

### DIFF
--- a/app/react/V2/Components/AIAssistant/AskBertButton.tsx
+++ b/app/react/V2/Components/AIAssistant/AskBertButton.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { SparklesIcon } from '@heroicons/react/24/outline';
-import { useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { t, Translate } from '#app/I18N/index.js';
 import { useIsMobile } from '#app/V2/CustomHooks/useIsMobile.js';
 import { FeatureToggle } from '#V2/Components/UI/FeatureToggle.js';
-import { aiAssistantOpenAtom } from '#V2/atoms/aiAssistantOpenAtom.js';
+import { aiAssistantOpenAtom, userAtom } from '#V2/atoms/index.js';
 
 const AskBertButtonView = () => {
   const setOpen = useSetAtom(aiAssistantOpenAtom);
@@ -28,10 +28,18 @@ const AskBertButtonView = () => {
   );
 };
 
-const AskBertButton = () => (
-  <FeatureToggle feature="aiAssistant">
-    <AskBertButtonView />
-  </FeatureToggle>
-);
+const AskBertButton = () => {
+  const user = useAtomValue(userAtom);
+
+  if (!user?._id) {
+    return null;
+  }
+
+  return (
+    <FeatureToggle feature="aiAssistant">
+      <AskBertButtonView />
+    </FeatureToggle>
+  );
+};
 
 export { AskBertButton };

--- a/app/react/V2/Components/AIAssistant/BertHost.tsx
+++ b/app/react/V2/Components/AIAssistant/BertHost.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { FeatureToggle } from '#V2/Components/UI/FeatureToggle.js';
-import { aiAssistantOpenAtom } from '#V2/atoms/aiAssistantOpenAtom.js';
+import { aiAssistantOpenAtom, userAtom } from '#V2/atoms/index.js';
 import { BertModal } from './BertModal.js';
 import { useBertShortcut } from './useBertShortcut.js';
 import { useBertState } from './useBertState.js';
@@ -36,11 +36,19 @@ const BertHostView = ({
   return <BertModal open={open} onClose={() => setOpen(false)} {...bertState} />;
 };
 
-const BertHost = (props: BertHostProps) => (
-  <FeatureToggle feature="aiAssistant">
-    <BertHostView {...props} />
-  </FeatureToggle>
-);
+const BertHost = (props: BertHostProps) => {
+  const user = useAtomValue(userAtom);
+
+  if (!user?._id) {
+    return null;
+  }
+
+  return (
+    <FeatureToggle feature="aiAssistant">
+      <BertHostView {...props} />
+    </FeatureToggle>
+  );
+};
 
 export { BertHost };
 export type { BertHostProps };

--- a/app/react/V2/Routes/Settings/Collection/Collection.tsx
+++ b/app/react/V2/Routes/Settings/Collection/Collection.tsx
@@ -255,8 +255,8 @@ const Collection = () => {
                     <Translate className="text-sm font-medium text-ink">Public instance</Translate>
                   }
                   tip={tips.publicSharing}
-                  register={register}
-                  defaultChecked={formData.private}
+                  watch={watch}
+                  setValue={setValue}
                 />
                 {isClient && window.__featureFlags__?.v2GetEntity && (
                   <CollectionOptionToggle
@@ -267,8 +267,8 @@ const Collection = () => {
                       </Translate>
                     }
                     tip={tips.filterUnauthorizedRelated}
-                    register={register}
-                    defaultChecked={formData.filterUnauthorizedRelated}
+                    watch={watch}
+                    setValue={setValue}
                   />
                 )}
                 <CollectionOptionToggle
@@ -279,15 +279,15 @@ const Collection = () => {
                     </Translate>
                   }
                   tip={tips.cookiePolicy}
-                  register={register}
-                  defaultChecked={formData.cookiepolicy}
+                  watch={watch}
+                  setValue={setValue}
                 />
                 <CollectionOptionToggle
                   valueKey="allowcustomJS"
                   label={<Translate className="text-sm font-medium text-ink">Global JS</Translate>}
                   tip={tips.globalJS}
-                  register={register}
-                  defaultChecked={formData.allowcustomJS}
+                  watch={watch}
+                  setValue={setValue}
                 />
                 {!settings.newNameGeneration && (
                   <CollectionOptionToggle
@@ -298,8 +298,8 @@ const Collection = () => {
                       </Translate>
                     }
                     tip={tips.characterSupport}
-                    register={register}
-                    defaultChecked={formData.newNameGeneration}
+                    watch={watch}
+                    setValue={setValue}
                   />
                 )}
               </div>
@@ -342,8 +342,8 @@ const Collection = () => {
                     </Translate>
                   }
                   tip={tips.ocrTrigger}
-                  register={register}
-                  defaultChecked={formData.ocrServiceEnabled}
+                  watch={watch}
+                  setValue={setValue}
                 />
               </Card>
             )}
@@ -384,8 +384,8 @@ const Collection = () => {
                     </Translate>
                   }
                   tip={tips.openPublicForm}
-                  register={register}
-                  defaultChecked={formData.openPublicEndpoint}
+                  watch={watch}
+                  setValue={setValue}
                 />
                 <div className="sm:col-span-2">
                   <MultiSelect

--- a/app/react/V2/Routes/Settings/Collection/CollectionOptionToggle.tsx
+++ b/app/react/V2/Routes/Settings/Collection/CollectionOptionToggle.tsx
@@ -1,33 +1,38 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/20/solid';
-import { UseFormRegister } from 'react-hook-form';
-import { EnableButtonCheckbox } from '#V2/Components/Forms/index.js';
-import { Tooltip } from '#V2/Components/UI/index.js';
+import { UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { ToggleButton, Tooltip } from '#V2/Components/UI/index.js';
 import { ClientSettings } from '#app/apiResponseTypes.js';
 
 interface CollectionOptionToggleProps {
-  register: UseFormRegister<ClientSettings>;
+  watch: UseFormWatch<ClientSettings>;
+  setValue: UseFormSetValue<ClientSettings>;
   label: React.ReactElement;
   valueKey: keyof ClientSettings;
   tip: React.ReactNode;
-  defaultChecked?: boolean;
 }
 
 const CollectionOptionToggle = ({
-  register,
+  watch,
+  setValue,
   valueKey,
   label,
   tip,
-  defaultChecked,
-}: CollectionOptionToggleProps) => (
-  <div className="flex col-span-2 gap-4 items-center">
-    <EnableButtonCheckbox {...register(valueKey)} defaultChecked={defaultChecked} />
-    {label}
-    <Tooltip content={tip} placement="right">
-      <QuestionMarkCircleIcon className="h-5 w-5 text-ink-muted" />
-    </Tooltip>
-  </div>
-);
+}: CollectionOptionToggleProps) => {
+  const checked = !!watch(valueKey);
+
+  return (
+    <div className="flex col-span-2 gap-4 items-center">
+      <ToggleButton
+        checked={checked}
+        onToggle={() => setValue(valueKey, !checked, { shouldDirty: true })}
+      />
+      {label}
+      <Tooltip content={tip} placement="right">
+        <QuestionMarkCircleIcon className="h-5 w-5 text-ink-muted" />
+      </Tooltip>
+    </div>
+  );
+};
 
 export { CollectionOptionToggle };

--- a/app/react/V2/Routes/Settings/Collection/CollectionOptionToggle.tsx
+++ b/app/react/V2/Routes/Settings/Collection/CollectionOptionToggle.tsx
@@ -26,7 +26,9 @@ const CollectionOptionToggle = ({
       <ToggleButton
         checked={checked}
         onToggle={() => setValue(valueKey, !checked, { shouldDirty: true })}
-      />
+      >
+        {null}
+      </ToggleButton>
       {label}
       <Tooltip content={tip} placement="right">
         <QuestionMarkCircleIcon className="h-5 w-5 text-ink-muted" />

--- a/cypress/e2e/base/private-instance.cy.ts
+++ b/cypress/e2e/base/private-instance.cy.ts
@@ -23,10 +23,8 @@ describe('Private instance', () => {
     cy.contains('a', 'Settings').realClick();
     cy.contains('a', 'Collection').realClick();
     cy.contains('div', 'Public instance').within(() => {
-      cy.get('input[type="checkbox"]').check({ force: true });
-      cy.get('input[type="checkbox"]').should('be.checked');
-      cy.get('[data-testid="enable-button-checkbox"] > div').realHover();
-      cy.contains('div', 'Disable');
+      cy.get('[data-testid="toggle"]').check({ force: true });
+      cy.get('[data-testid="toggle"]').should('be.checked');
     });
     cy.contains('button', 'Save').realClick();
     cy.contains('div', 'Settings updated.');


### PR DESCRIPTION
## Summary
- Replace `EnableButtonCheckbox` with `ToggleButton` in Collection settings, wired through `watch`/`setValue` so toggles persist on save.
- Restrict Ask Bert button, modal host, and Ctrl+K shortcut to authenticated users only.
- Update private-instance Cypress test for the new toggle selector.