### PR TITLE
Skip PG migration when tenant table already has data

### DIFF
--- a/app/api/core/infrastructure/postgresql/migrations/MigrateCollectionToPostgres.ts
+++ b/app/api/core/infrastructure/postgresql/migrations/MigrateCollectionToPostgres.ts
@@ -15,26 +15,33 @@ export class MigrateCollectionToPostgres {
     private tenantId: string
   ) {}
 
-  async migrate(config: MigrationConfig): Promise<number> {
+  async migrate(
+    config: MigrationConfig
+  ): Promise<{ migrated: number; skipped: boolean }> {
+    const table = new PostgresTable(config.pgTable, this.tenantId);
+    const existingCount = await table.query().count();
+
+    if (existingCount > 0) {
+      return { migrated: 0, skipped: true };
+    }
+
     const mongoDocs = await this.mongoDb
       .collection<Record<string, unknown>>(config.mongoCollection)
       .find({})
       .toArray();
 
     if (mongoDocs.length === 0) {
-      return 0;
+      return { migrated: 0, skipped: false };
     }
-
-    const table = new PostgresTable(config.pgTable, this.tenantId);
 
     for (let i = 0; i < mongoDocs.length; i += BATCH_SIZE) {
       const batch = mongoDocs.slice(i, i + BATCH_SIZE);
       const rows = batch.map(doc => config.mapDocument(doc));
 
       // eslint-disable-next-line no-await-in-loop
-      await table.upsert(rows);
+      await table.insert(rows);
     }
 
-    return mongoDocs.length;
+    return { migrated: mongoDocs.length, skipped: false };
   }
 }

--- a/app/api/core/infrastructure/postgresql/migrations/MigrateCollectionToPostgres.ts
+++ b/app/api/core/infrastructure/postgresql/migrations/MigrateCollectionToPostgres.ts
@@ -15,23 +15,14 @@ export class MigrateCollectionToPostgres {
     private tenantId: string
   ) {}
 
-  async migrate(
-    config: MigrationConfig
-  ): Promise<{ migrated: number; skipped: boolean }> {
-    const table = new PostgresTable(config.pgTable, this.tenantId);
-    const existingCount = await table.query().count();
-
-    if (existingCount > 0) {
-      return { migrated: 0, skipped: true };
-    }
-
+  private async fetchAndInsert(config: MigrationConfig, table: PostgresTable): Promise<number> {
     const mongoDocs = await this.mongoDb
       .collection<Record<string, unknown>>(config.mongoCollection)
       .find({})
       .toArray();
 
     if (mongoDocs.length === 0) {
-      return { migrated: 0, skipped: false };
+      return 0;
     }
 
     for (let i = 0; i < mongoDocs.length; i += BATCH_SIZE) {
@@ -42,6 +33,18 @@ export class MigrateCollectionToPostgres {
       await table.insert(rows);
     }
 
-    return { migrated: mongoDocs.length, skipped: false };
+    return mongoDocs.length;
+  }
+
+  async migrate(config: MigrationConfig): Promise<{ migrated: number; skipped: boolean }> {
+    const table = new PostgresTable(config.pgTable, this.tenantId);
+    const existingRow = await table.query().first();
+
+    if (existingRow !== undefined) {
+      return { migrated: 0, skipped: true };
+    }
+
+    const migrated = await this.fetchAndInsert(config, table);
+    return { migrated, skipped: false };
   }
 }

--- a/app/api/core/infrastructure/postgresql/migrations/specs/MigrateCollectionToPostgres.spec.ts
+++ b/app/api/core/infrastructure/postgresql/migrations/specs/MigrateCollectionToPostgres.spec.ts
@@ -54,10 +54,10 @@ describe('MigrateCollectionToPostgres', () => {
     };
 
     const migrator = makeMigrator();
-    const migrated = await migrator.migrate(config);
+    const result = await migrator.migrate(config);
 
-    expect(migrated.migrated).toBe(2);
-    expect(migrated.skipped).toBe(false);
+    expect(result.migrated).toBe(2);
+    expect(result.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
@@ -92,14 +92,14 @@ describe('MigrateCollectionToPostgres', () => {
     };
 
     const migratorA = new MigrateCollectionToPostgres(mongoDb, 'tenant-a');
-    const migratedA = await migratorA.migrate(config);
-    expect(migratedA.migrated).toBe(1);
-    expect(migratedA.skipped).toBe(false);
+    const resultA = await migratorA.migrate(config);
+    expect(resultA.migrated).toBe(1);
+    expect(resultA.skipped).toBe(false);
 
     const migratorB = new MigrateCollectionToPostgres(mongoDb, 'tenant-b');
-    const migratedB = await migratorB.migrate(config);
-    expect(migratedB.migrated).toBe(1);
-    expect(migratedB.skipped).toBe(false);
+    const resultB = await migratorB.migrate(config);
+    expect(resultB.migrated).toBe(1);
+    expect(resultB.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForA = pgRows.filter(r => r.tenant_id === 'tenant-a');
@@ -127,9 +127,9 @@ describe('MigrateCollectionToPostgres', () => {
     };
 
     const migrator = makeMigrator();
-    const migrated = await migrator.migrate(config);
-    expect(migrated.migrated).toBe(0);
-    expect(migrated.skipped).toBe(false);
+    const result = await migrator.migrate(config);
+    expect(result.migrated).toBe(0);
+    expect(result.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     expect(pgRows.filter(r => r.tenant_id === TENANT)).toHaveLength(0);
@@ -158,9 +158,9 @@ describe('MigrateCollectionToPostgres', () => {
     };
 
     const migrator = makeMigrator();
-    const migrated = await migrator.migrate(config);
-    expect(migrated.migrated).toBe(2500);
-    expect(migrated.skipped).toBe(false);
+    const result = await migrator.migrate(config);
+    expect(result.migrated).toBe(2500);
+    expect(result.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
@@ -189,9 +189,9 @@ describe('MigrateCollectionToPostgres', () => {
     });
 
     const migrator = makeMigrator();
-    const migrated = await migrator.migrate(ThesaurusMigrationConfig);
-    expect(migrated.migrated).toBe(1);
-    expect(migrated.skipped).toBe(false);
+    const result = await migrator.migrate(ThesaurusMigrationConfig);
+    expect(result.migrated).toBe(1);
+    expect(result.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);

--- a/app/api/core/infrastructure/postgresql/migrations/specs/MigrateCollectionToPostgres.spec.ts
+++ b/app/api/core/infrastructure/postgresql/migrations/specs/MigrateCollectionToPostgres.spec.ts
@@ -56,7 +56,8 @@ describe('MigrateCollectionToPostgres', () => {
     const migrator = makeMigrator();
     const migrated = await migrator.migrate(config);
 
-    expect(migrated).toBe(2);
+    expect(migrated.migrated).toBe(2);
+    expect(migrated.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
@@ -66,68 +67,6 @@ describe('MigrateCollectionToPostgres', () => {
     const byId = Object.fromEntries(rowsForTenant.map(r => [r._id, r]));
     expect(byId['64a1b2c3d4e5f6a7b8c9d0e1'].name).toBe('Countries');
     expect(byId['64a1b2c3d4e5f6a7b8c9d0e2'].name).toBe('Fruits');
-  });
-
-  it('should upsert — update existing rows and insert new ones', async () => {
-    const mongoDb = testingDB.db(testingDB.dbName);
-
-    await testingPG.setFixtures({
-      thesauri: [
-        {
-          _id: '64a1b2c3d4e5f6a7b8c9d0e3',
-          name: 'Old Colors',
-          values: JSON.stringify([{ id: 'v1', label: 'Red' }]),
-          tenant_id: TENANT,
-        },
-      ],
-    });
-
-    await mongoDb.collection('dictionaries').insertMany([
-      {
-        _id: new ObjectId('64a1b2c3d4e5f6a7b8c9d0e3'),
-        name: 'Updated Colors',
-        values: [
-          { id: 'v1', label: 'Red' },
-          { id: 'v2', label: 'Blue' },
-        ],
-      },
-      {
-        _id: new ObjectId('64a1b2c3d4e5f6a7b8c9d0e4'),
-        name: 'Shapes',
-        values: [{ id: 'v3', label: 'Circle' }],
-      },
-    ]);
-
-    const config: MigrationConfig = {
-      mongoCollection: 'dictionaries',
-      pgTable: 'thesauri',
-      mapDocument(doc: Record<string, unknown>) {
-        const _id = doc._id instanceof ObjectId ? doc._id.toHexString() : String(doc._id);
-        return {
-          _id,
-          name: doc.name,
-          values: JSON.stringify(doc.values ?? []),
-        };
-      },
-    };
-
-    const migrator = makeMigrator();
-    const migrated = await migrator.migrate(config);
-
-    expect(migrated).toBe(2);
-
-    const pgRows = await testingPG.getAllFrom('thesauri');
-    const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
-    expect(rowsForTenant).toHaveLength(2);
-    expect(rowsForTenant.every(r => r.tenant_id === TENANT)).toBe(true);
-
-    const byId = Object.fromEntries(rowsForTenant.map(r => [r._id, r]));
-    expect(byId['64a1b2c3d4e5f6a7b8c9d0e3'].name).toBe('Updated Colors');
-    expect(byId['64a1b2c3d4e5f6a7b8c9d0e3'].values).toEqual([
-      { id: 'v1', label: 'Red' },
-      { id: 'v2', label: 'Blue' },
-    ]);
-    expect(byId['64a1b2c3d4e5f6a7b8c9d0e4'].name).toBe('Shapes');
   });
 
   it('should isolate different tenants', async () => {
@@ -154,11 +93,13 @@ describe('MigrateCollectionToPostgres', () => {
 
     const migratorA = new MigrateCollectionToPostgres(mongoDb, 'tenant-a');
     const migratedA = await migratorA.migrate(config);
-    expect(migratedA).toBe(1);
+    expect(migratedA.migrated).toBe(1);
+    expect(migratedA.skipped).toBe(false);
 
     const migratorB = new MigrateCollectionToPostgres(mongoDb, 'tenant-b');
     const migratedB = await migratorB.migrate(config);
-    expect(migratedB).toBe(1);
+    expect(migratedB.migrated).toBe(1);
+    expect(migratedB.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForA = pgRows.filter(r => r.tenant_id === 'tenant-a');
@@ -187,7 +128,8 @@ describe('MigrateCollectionToPostgres', () => {
 
     const migrator = makeMigrator();
     const migrated = await migrator.migrate(config);
-    expect(migrated).toBe(0);
+    expect(migrated.migrated).toBe(0);
+    expect(migrated.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     expect(pgRows.filter(r => r.tenant_id === TENANT)).toHaveLength(0);
@@ -217,7 +159,8 @@ describe('MigrateCollectionToPostgres', () => {
 
     const migrator = makeMigrator();
     const migrated = await migrator.migrate(config);
-    expect(migrated).toBe(2500);
+    expect(migrated.migrated).toBe(2500);
+    expect(migrated.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
@@ -247,7 +190,8 @@ describe('MigrateCollectionToPostgres', () => {
 
     const migrator = makeMigrator();
     const migrated = await migrator.migrate(ThesaurusMigrationConfig);
-    expect(migrated).toBe(1);
+    expect(migrated.migrated).toBe(1);
+    expect(migrated.skipped).toBe(false);
 
     const pgRows = await testingPG.getAllFrom('thesauri');
     const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
@@ -267,5 +211,51 @@ describe('MigrateCollectionToPostgres', () => {
         ],
       },
     ]);
+  });
+
+  it('should skip migration when PostgreSQL table already contains data for tenant', async () => {
+    const mongoDb = testingDB.db(testingDB.dbName);
+
+    await testingPG.setFixtures({
+      thesauri: [
+        {
+          _id: '64a1b2c3d4e5f6a7b8c9d0e7',
+          name: 'Existing',
+          values: JSON.stringify([{ id: 'v1', label: 'Existing' }]),
+          tenant_id: TENANT,
+        },
+      ],
+    });
+
+    await mongoDb.collection('dictionaries').insertMany([
+      {
+        _id: new ObjectId('64a1b2c3d4e5f6a7b8c9d0e8'),
+        name: 'New',
+        values: [{ id: 'v2', label: 'New' }],
+      },
+    ]);
+
+    const config: MigrationConfig = {
+      mongoCollection: 'dictionaries',
+      pgTable: 'thesauri',
+      mapDocument(doc: Record<string, unknown>) {
+        return {
+          _id: doc._id instanceof ObjectId ? doc._id.toHexString() : String(doc._id),
+          name: doc.name,
+          values: JSON.stringify(doc.values ?? []),
+        };
+      },
+    };
+
+    const migrator = makeMigrator();
+    const result = await migrator.migrate(config);
+
+    expect(result.migrated).toBe(0);
+    expect(result.skipped).toBe(true);
+
+    const pgRows = await testingPG.getAllFrom('thesauri');
+    const rowsForTenant = pgRows.filter(r => r.tenant_id === TENANT);
+    expect(rowsForTenant).toHaveLength(1);
+    expect(rowsForTenant[0].name).toBe('Existing');
   });
 });

--- a/scripts/scripts.v2/migrateToPostgres.ts
+++ b/scripts/scripts.v2/migrateToPostgres.ts
@@ -60,8 +60,7 @@ async function migrateCollection(
   tenantName: string,
   collectionName: string,
   migrationConfig: MigrationConfig
-): Promise<number> {
-  let migrated = 0;
+): Promise<void> {
   await tenants.run(async () => {
     const tenantConfig = tenants.current();
     const mongoDb = DB.mongodb_Db(tenantConfig.dbName);
@@ -71,11 +70,14 @@ async function migrateCollection(
     log(`[${tenantName}] PostgreSQL table: ${migrationConfig.pgTable}`);
 
     const migrator = new MigrateCollectionToPostgres(mongoDb, tenantName);
-    migrated = await migrator.migrate(migrationConfig);
+    const result = await migrator.migrate(migrationConfig);
 
-    log(`[${tenantName}] Migrated ${migrated} rows for ${collectionName}`);
+    if (result.skipped) {
+      log(`[${tenantName}] Skipped ${collectionName}: PostgreSQL table already contains data for tenant`);
+    } else {
+      log(`[${tenantName}] Migrated ${result.migrated} rows for ${collectionName}`);
+    }
   }, tenantName);
-  return migrated;
 }
 
 (async function run() {


### PR DESCRIPTION
Changes to lcode>MigrateCollectionToPostgres</code> to check if the target PostgreSQL table already contains data for a tenant before migrating. If data exists, the migration is skipped entirely to avoid overwriting or conflicting with existing data.

### Changes
- Added a guard in <code>MigrateCollectionToPostgres.migrate()</code> that checks the PG table row count before reading from MongoDB.
- If the table already has data for the tenant, returns <code>{ migrated: 0, skipped: true }</code>.
- Changed <code>upsert</code> to <code>insert</code> in the migration loop, since the guard guarantees the table is empty.
- Updated the migration script (<code>migrateToPostgres.ts</code>) to log whether the migration was skipped or completed.
- Updated and added tests to cover the new skip behavior.