### PR TITLE
Skip migration and reindex for tenants without settings collection

### DIFF
--- a/app/api/core/infrastructure/jobs/MigrationJob.ts
+++ b/app/api/core/infrastructure/jobs/MigrationJob.ts
@@ -205,6 +205,13 @@ class MigrationJob implements Dispatchable {
       // eslint-disable-next-line no-await-in-loop
       await tenants.run(async () => {
         const tenant = tenants.current();
+        if (!(await this.deps.runner.tenantExists(tenant))) {
+          this.deps.logger.info(
+            `Skipping tenant '${tenantName}': no settings collection, tenant is not ready`
+          );
+          results.push({ status: 'done' });
+          return;
+        }
         const result = await this.deps.runner.migrateDelta(tenant, delta, schemaVersion);
         results.push(result);
       }, tenantName);
@@ -273,7 +280,14 @@ class MigrationJob implements Dispatchable {
     for (const tenantName of tenantNames) {
       // eslint-disable-next-line no-await-in-loop
       await tenants.run(async () => {
-        await this.deps.reindexTenant();
+        const tenant = tenants.current();
+        if (await this.deps.runner.tenantExists(tenant)) {
+          await this.deps.reindexTenant();
+        } else {
+          this.deps.logger.info(
+            `Skipping reindex for tenant '${tenantName}': no settings collection, tenant is not ready`
+          );
+        }
       }, tenantName);
       // eslint-disable-next-line no-await-in-loop
       await heartbeat();

--- a/app/api/core/infrastructure/jobs/specs/MigrationJob.spec.ts
+++ b/app/api/core/infrastructure/jobs/specs/MigrationJob.spec.ts
@@ -48,6 +48,7 @@ type MigrationCatalogueEntry = {
 const createFakeRunner = (options: {
   migrations: MigrationCatalogueEntry[];
   failDelta?: number;
+  tenantExists?: boolean;
 }): TenantMigrationRunner => {
   const dbForTenant = (tenant: { dbName: string }) => testingDB.db(tenant.dbName);
 
@@ -57,7 +58,15 @@ const createFakeRunner = (options: {
   };
 
   return {
-    async getPendingMigrations(tenant, schemaVersion) {
+    async tenantExists(_tenant: { dbName: string }) {
+      return options.tenantExists !== false;
+    },
+
+    async getPendingMigrations(tenant: { dbName: string }, schemaVersion: number) {
+      if (options.tenantExists === false) {
+        return { runnable: [], blocked: null };
+      }
+
       const applied = await appliedDeltas(tenant);
       const pending = options.migrations.filter(migration => !applied.has(migration.delta));
       const runnable: MigrationCatalogueEntry[] = [];
@@ -74,7 +83,13 @@ const createFakeRunner = (options: {
       return { runnable, blocked };
     },
 
-    async migrateDelta(tenant, delta, schemaVersion) {
+    async migrateDelta(
+      tenant: { dbName: string },
+      delta: number,
+      schemaVersion: number
+    ): Promise<
+      import('#api/core/infrastructure/mongodb/TenantMigrationRunner.js').TenantMigrationResult
+    > {
       const migration = options.migrations.find(m => m.delta === delta);
       if (!migration) {
         return { status: 'done' };
@@ -485,5 +500,24 @@ describe('MigrationJob', () => {
 
     expect(reindexTenant).toHaveBeenCalledTimes(1);
     expect(heartbeat).toHaveBeenCalledTimes(5);
+  });
+
+  it('should skip reindex for tenants that do not exist', async () => {
+    const heartbeat = jest.fn();
+    const reindexTenant = jest.fn();
+    const pgMigrator = new FakePgMigrator({ currentVersion: 100 });
+    const { dispatcher } = createJobFactory({
+      heartbeat,
+      reindexTenant,
+      pgMigrator,
+      runner: createFakeRunner({ migrations: defaultCatalogue, tenantExists: false }),
+    });
+
+    await dispatcher.dispatch(MigrationJob, {
+      reindex: false,
+      results: { appliedDataDeltas: [], appliedSchemaDeltas: [] },
+    });
+
+    expect(reindexTenant).not.toHaveBeenCalled();
   });
 });

--- a/app/api/core/infrastructure/mongodb/TenantMigrationRunner.ts
+++ b/app/api/core/infrastructure/mongodb/TenantMigrationRunner.ts
@@ -11,6 +11,7 @@ export type TenantPendingMigrations = {
 };
 
 export interface TenantMigrationRunner {
+  tenantExists(tenant: Tenant): Promise<boolean>;
   getPendingMigrations(tenant: Tenant, schemaVersion: number): Promise<TenantPendingMigrations>;
   migrateDelta(
     tenant: Tenant,

--- a/app/api/core/infrastructure/mongodb/TenantMigrationRunnerAdapter.ts
+++ b/app/api/core/infrastructure/mongodb/TenantMigrationRunnerAdapter.ts
@@ -9,15 +9,39 @@ import { Tenant } from '#api/tenants/tenantContext.js';
 import { getPendingMigrations, migrateDelta } from '#api/migrations/migrator.js';
 
 export class TenantMigrationRunnerAdapter implements TenantMigrationRunner {
+  private tenantExistsCache = new Map<string, boolean>();
+
   constructor(
     private migrationsDir: string,
     private loader: (path: string) => Promise<any>
   ) {}
 
+  async tenantExists(tenant: Tenant): Promise<boolean> {
+    const cached = this.tenantExistsCache.get(tenant.name);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const connection = DB.connectionForDB(tenant.dbName);
+    if (!connection.db) {
+      this.tenantExistsCache.set(tenant.name, false);
+      return false;
+    }
+
+    const count = await connection.db.collection('settings').countDocuments();
+    const exists = count > 0;
+    this.tenantExistsCache.set(tenant.name, exists);
+    return exists;
+  }
+
   async getPendingMigrations(
     tenant: Tenant,
     schemaVersion: number
   ): Promise<TenantPendingMigrations> {
+    if (!(await this.tenantExists(tenant))) {
+      return { runnable: [], blocked: null };
+    }
+
     let result: TenantPendingMigrations = { runnable: [], blocked: null };
 
     await tenants.run(async () => {
@@ -43,6 +67,10 @@ export class TenantMigrationRunnerAdapter implements TenantMigrationRunner {
     delta: number,
     schemaVersion: number
   ): Promise<TenantMigrationResult> {
+    if (!(await this.tenantExists(tenant))) {
+      return { status: 'done' };
+    }
+
     let result: TenantMigrationResult = { status: 'done' };
 
     await tenants.run(async () => {


### PR DESCRIPTION
## Summary

When running `yarn migrate --new` in production/staging, the synthetic `default` tenant is registered but its database does not actually exist. This caused the new migrator to attempt migrating and reindexing a non-existent tenant.

This PR skips migration and reindex operations for any tenant whose `settings` collection has no documents. The `settings` collection is used as the signal that a tenant has been initialized and is ready, which works for both single-tenant (default) and multi-tenant deployments regardless of environment.

We should probably consider removing this special case at some point, no default tenant in the config but in the tenants db  so it becomes the exact same as a normal tenant.