### PR TITLE
Add migration feature tag to new migration workflow logs

### DIFF
--- a/app/api/core/infrastructure/factories/LoggerFactory.ts
+++ b/app/api/core/infrastructure/factories/LoggerFactory.ts
@@ -2,10 +2,10 @@ import { StandardLogger } from '#api/core/libs/logger/infrastructure/StandardLog
 import { StandardJSONWriter } from '#api/core/libs/logger/infrastructure/writers/StandardJSONWriter.js';
 import { config } from '#api/config.js';
 import { DevelopmentWritter } from '#api/core/libs/logger/infrastructure/writers/DevelopmentWriter.js';
-import { MigrationHumanReadableWriter } from '#api/core/libs/logger/infrastructure/writers/MigrationHumanReadableWriter.js';
 import { getTenant } from '../mongodb/common/getConnectionForCurrentTenant.js';
 import { TestUtils } from '#api/common.v2/utils/Test.js';
 import { Logger } from '#api/core/libs/logger/contracts/Logger.js';
+import { LogWriter } from '#api/core/libs/logger/infrastructure/LogWriter.js';
 
 export class LoggerFactory {
   static default(_writer = StandardJSONWriter) {
@@ -56,9 +56,7 @@ export class LoggerFactory {
     return new StandardLogger(() => {}, getTenant());
   }
 
-  static migrationLogger(structured = false): Logger {
-    const writer = structured ? StandardJSONWriter : MigrationHumanReadableWriter;
-
+  static migrationLogger(writer: LogWriter): Logger {
     return new StandardLogger(writer, {
       name: 'Migration Logger',
       dbName: 'N/a',

--- a/app/api/migrations/MigrationService.ts
+++ b/app/api/migrations/MigrationService.ts
@@ -11,7 +11,9 @@ import { TransactionManagerFactory } from '#api/core/infrastructure/factories/Tr
 import { EventEmitterFactory } from '#api/core/libs/eventEmitter/EventEmitterFactory.js';
 import { IdGeneratorFactory } from '#api/core/infrastructure/factories/IdGeneratorFactory.js';
 import { LoggerFactory } from '#api/core/infrastructure/factories/LoggerFactory.js';
+import { withFeature } from '#api/core/libs/logger/infrastructure/StandardLogger.js';
 import { StandardJSONWriter } from '#api/core/libs/logger/infrastructure/writers/StandardJSONWriter.js';
+import { MigrationHumanReadableWriter } from '#api/core/libs/logger/infrastructure/writers/MigrationHumanReadableWriter.js';
 import { DefaultDispatcher } from '#api/core/libs/queue/configuration/factories.js';
 import { JobsDispatcher } from '#api/core/libs/queue/application/contracts/JobsDispatcher.js';
 import { Logger } from '#api/core/libs/logger/contracts/Logger.js';
@@ -100,9 +102,12 @@ const createDefaultLogger: LoggerFactoryFn = (options: {
   structuredLogs: boolean;
 }) => {
   if (options.async) {
-    return LoggerFactory.systemLogger(StandardJSONWriter);
+    return LoggerFactory.systemLogger(withFeature(StandardJSONWriter, 'migration'));
   }
-  return LoggerFactory.migrationLogger(options.structuredLogs);
+  if (options.structuredLogs) {
+    return LoggerFactory.migrationLogger(withFeature(StandardJSONWriter, 'migration'));
+  }
+  return LoggerFactory.migrationLogger(MigrationHumanReadableWriter);
 };
 
 const createDefaultPgMigrator = (pool: any) => new PgMigrator(PG_MIGRATIONS_DIR, pool);

--- a/app/queueRegistry.ts
+++ b/app/queueRegistry.ts
@@ -79,6 +79,9 @@ import { tenants } from '#api/tenants/tenantContext.js';
 import { SendWelcomeEmailHandler } from '#api/core/infrastructure/jobs/SendWelcomeEmailHandler.js';
 import { MigrationJob } from '#api/core/infrastructure/jobs/MigrationJob.js';
 import { MigrationJobFactory } from '#api/core/infrastructure/factories/MigrationJobFactory.js';
+import { LoggerFactory } from '#api/core/infrastructure/factories/LoggerFactory.js';
+import { withFeature } from '#api/core/libs/logger/infrastructure/StandardLogger.js';
+import { StandardJSONWriter } from '#api/core/libs/logger/infrastructure/writers/StandardJSONWriter.js';
 
 type Register = <T extends Dispatchable>(
   dispatchable: DispatchableClass<T>,
@@ -332,5 +335,9 @@ export function registerJobs(register: Register) {
 
   register(SendWelcomeEmailHandler, async () => new SendWelcomeEmailHandler());
 
-  register(MigrationJob, async () => MigrationJobFactory.create());
+  register(MigrationJob, async () =>
+    MigrationJobFactory.create({
+      logger: LoggerFactory.systemLogger(withFeature(StandardJSONWriter, 'migration')),
+    })
+  );
 }


### PR DESCRIPTION
Adds `feature: 'migration'` metadata to all logs produced by the new migration workflow (`yarn migrate --new`), both in the sync/async orchestrator and in the async queue worker, so Graylog can filter migration logs consistently.