### PR TITLE
Add per-tenant maintenance mode toggled during migration reindex

### DIFF
--- a/app/api/core/infrastructure/factories/MigrationJobFactory.ts
+++ b/app/api/core/infrastructure/factories/MigrationJobFactory.ts
@@ -4,6 +4,7 @@ import { PostgresDB } from '#api/infrastructure/PostgresDB.js';
 import { PgMigrator } from '#api/core/infrastructure/postgresql/PgMigrator.js';
 import { ExecutionContext } from '#api/core/libs/ExecutionContext.js';
 import { MigrationJob, MigrationJobDeps } from '#api/core/infrastructure/jobs/MigrationJob.js';
+import { tenants, Tenant } from '#api/tenants/index.js';
 import { TenantMigrationRunner } from '#api/core/infrastructure/mongodb/TenantMigrationRunner.js';
 import { TenantMigrationRunnerAdapter } from '#api/core/infrastructure/mongodb/TenantMigrationRunnerAdapter.js';
 import { migrator } from '#api/migrations/migrator.js';
@@ -35,6 +36,7 @@ class MigrationJobFactory {
       logger: deps.logger || ExecutionContext.logger,
       dispatcher: deps.dispatcher || ExecutionContext.jobsDispatcher,
       reindexTenant: deps.reindexTenant || createReindexTenant(),
+      tenantsManager: deps.tenantsManager || tenants,
     });
   }
 }

--- a/app/api/core/infrastructure/jobs/MigrationJob.ts
+++ b/app/api/core/infrastructure/jobs/MigrationJob.ts
@@ -1,4 +1,5 @@
 import { tenants } from '#api/tenants/index.js';
+import { Tenant, Tenants } from '#api/tenants/tenantContext.js';
 import {
   Dispatchable,
   HeartbeatCallback,
@@ -26,6 +27,7 @@ type MigrationJobDeps = {
   logger: Logger;
   dispatcher: JobsDispatcher;
   reindexTenant: () => Promise<void>;
+  tenantsManager: Tenants;
 };
 
 class MigrationJob implements Dispatchable {
@@ -275,14 +277,14 @@ class MigrationJob implements Dispatchable {
   }
 
   private async reindexAllTenants(heartbeat: HeartbeatCallback): Promise<void> {
-    const tenantNames = Object.keys(tenants.tenants);
+    const tenantNames = Object.keys(this.deps.tenantsManager.tenants);
 
     for (const tenantName of tenantNames) {
       // eslint-disable-next-line no-await-in-loop
-      await tenants.run(async () => {
-        const tenant = tenants.current();
+      await this.deps.tenantsManager.run(async () => {
+        const tenant = this.deps.tenantsManager.current();
         if (await this.deps.runner.tenantExists(tenant)) {
-          await this.deps.reindexTenant();
+          await this.reindexTenant(tenant);
         } else {
           this.deps.logger.info(
             `Skipping reindex for tenant '${tenantName}': no settings collection, tenant is not ready`
@@ -291,6 +293,18 @@ class MigrationJob implements Dispatchable {
       }, tenantName);
       // eslint-disable-next-line no-await-in-loop
       await heartbeat();
+    }
+  }
+
+  private async reindexTenant(tenant: Tenant): Promise<void> {
+    await this.deps.tenantsManager.setMaintenance(tenant.name, true);
+    this.deps.logger.info(`Tenant '${tenant.name}' set to maintenance mode for reindex`);
+
+    try {
+      await this.deps.reindexTenant();
+    } finally {
+      await this.deps.tenantsManager.setMaintenance(tenant.name, false);
+      this.deps.logger.info(`Tenant '${tenant.name}' removed from maintenance mode after reindex`);
     }
   }
 }

--- a/app/api/core/infrastructure/jobs/specs/MigrationJob.spec.ts
+++ b/app/api/core/infrastructure/jobs/specs/MigrationJob.spec.ts
@@ -3,6 +3,7 @@ import { MigrationJob } from '#api/core/infrastructure/jobs/MigrationJob.js';
 import { createMockLogger } from '#api/core/libs/logger/infrastructure/MockLogger.js';
 import { JobsDispatcher } from '#api/core/libs/queue/application/contracts/JobsDispatcher.js';
 import { testingEnvironment } from '#api/utils/testingEnvironment.js';
+import { tenants } from '#api/tenants/tenantContext.js';
 import testingDB from '#api/utils/testing_db.js';
 import { PgMigrator } from '../../postgresql/PgMigrator.js';
 
@@ -146,10 +147,22 @@ const createJobFactory = (deps: {
   logger?: ReturnType<typeof createMockLogger>;
   reindexTenant?: jest.Mock;
   heartbeat?: jest.Mock;
+  tenantsManager?: any;
 }) => {
   const dispatcherRegistry: MigrationRegistry = {};
   const heartbeat = deps.heartbeat || jest.fn();
   const dispatcher = createTestDispatcher(dispatcherRegistry, heartbeat);
+
+  const tenantsManager = deps.tenantsManager || {
+    tenants: { default: { name: 'default', dbName: testingDB.dbName } },
+    current() {
+      return this.tenants.default;
+    },
+    async run(fn: () => Promise<void>, tenantName = 'default') {
+      return tenants.run(fn, tenantName);
+    },
+    async setMaintenance(_tenantName: string, _maintenance: boolean) {},
+  };
 
   dispatcherRegistry.MigrationJob = async () =>
     new MigrationJob({
@@ -158,6 +171,7 @@ const createJobFactory = (deps: {
       logger: deps.logger || createMockLogger(),
       dispatcher,
       reindexTenant: deps.reindexTenant || jest.fn(),
+      tenantsManager,
     });
 
   return { dispatcher, registry: dispatcherRegistry, heartbeat };
@@ -280,10 +294,21 @@ describe('MigrationJob', () => {
 
     const logger = createMockLogger();
     const reindexTenant = jest.fn();
+    const setMaintenance = jest.fn();
     const { dispatcher } = createJobFactory({
       logger,
       reindexTenant,
       runner: createFakeRunner({ migrations: defaultCatalogue }),
+      tenantsManager: {
+        tenants: { default: { name: 'default', dbName: testingDB.dbName } },
+        current() {
+          return this.tenants.default;
+        },
+        async run(fn: () => Promise<void>, tenantName = 'default') {
+          return tenants.run(fn, tenantName);
+        },
+        setMaintenance,
+      },
     });
 
     await dispatcher.dispatch(MigrationJob, {
@@ -292,6 +317,8 @@ describe('MigrationJob', () => {
     });
 
     expect(reindexTenant).toHaveBeenCalledTimes(1);
+    expect(setMaintenance).toHaveBeenCalledWith('default', true);
+    expect(setMaintenance).toHaveBeenCalledWith('default', false);
   });
 
   it('should not reindex when reindex flag is false', async () => {

--- a/app/api/tenants/index.ts
+++ b/app/api/tenants/index.ts
@@ -1,1 +1,2 @@
 export { tenants } from './tenantContext.js';
+export type { Tenant } from './tenantContext.js';

--- a/app/api/tenants/tenantContext.ts
+++ b/app/api/tenants/tenantContext.ts
@@ -38,6 +38,7 @@ type Tenant = {
   };
   globalMatomo?: { id: string; url: string };
   ciMatomoActive?: boolean;
+  maintenance?: boolean;
 };
 
 class Tenants {
@@ -119,8 +120,17 @@ class Tenants {
   getTenantsForFeatureFlag(featureFlag: TenantFeatureFlags) {
     return Object.values(this.tenants).filter(tenant => tenant?.featureFlags?.[featureFlag]);
   }
+
+  async setMaintenance(tenantName: string, maintenance: boolean) {
+    if (this.model) {
+      await this.model.setMaintenance(tenantName, maintenance);
+    }
+    if (this.tenants[tenantName]) {
+      this.tenants[tenantName].maintenance = maintenance;
+    }
+  }
 }
 
 const tenants = new Tenants(config.defaultTenant);
-export { tenants };
+export { tenants, Tenants };
 export type { Tenant, TenantFeatureFlags };

--- a/app/api/tenants/tenantsModel.ts
+++ b/app/api/tenants/tenantsModel.ts
@@ -52,6 +52,7 @@ const mongoSchema = new mongoose.Schema({
   },
   globalMatomo: { id: String, url: String },
   ciMatomoActive: Boolean,
+  maintenance: Boolean,
 });
 
 type DBTenant = Partial<Tenant> & { name: string };
@@ -143,6 +144,15 @@ class TenantsModel extends EventEmitter {
       );
     }
     return this.model.find({}, Object.keys(mongoSchema.paths)).lean();
+  }
+
+  async setMaintenance(tenantName: string, maintenance: boolean) {
+    if (!this.model) {
+      throw new Error(
+        'tenants model has not been initialized, make sure you called initialize() method'
+      );
+    }
+    await this.model.updateOne({ name: tenantName }, { $set: { maintenance } });
   }
 }
 

--- a/app/api/utils/maintenanceMiddleware.ts
+++ b/app/api/utils/maintenanceMiddleware.ts
@@ -1,0 +1,11 @@
+import type { Request, Response, NextFunction } from 'express';
+import { tenants } from '#api/tenants/tenantContext.js';
+
+const maintenanceMiddleware = (_req: Request, res: Response, next: NextFunction) => {
+  if (tenants.current().maintenance) {
+    return res.status(503).json({ error: 'Service Unavailable', maintenance: true });
+  }
+  next();
+};
+
+export { maintenanceMiddleware };

--- a/app/api/utils/specs/maintenanceMiddleware.spec.ts
+++ b/app/api/utils/specs/maintenanceMiddleware.spec.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import express, { Application } from 'express';
+import { tenants } from '#api/tenants/tenantContext.js';
+import { maintenanceMiddleware } from '../maintenanceMiddleware.js';
+import { multitenantMiddleware } from '../multitenantMiddleware.js';
+import { appContextMiddleware } from '../appContextMiddleware.js';
+
+const testingRoutes = (app: Application) => {
+  app.get('/api/testGET', (_req, res, next) => {
+    res.json(tenants.current());
+    next();
+  });
+};
+
+describe('maintenance middleware', () => {
+  it('should pass through when tenant is not in maintenance', async () => {
+    tenants.add({ name: 'test' });
+
+    const app: Application = express();
+    app.use(appContextMiddleware);
+    app.use(multitenantMiddleware);
+    app.use(maintenanceMiddleware);
+    testingRoutes(app);
+
+    const response = await request(app).get('/api/testGET').set('tenant', 'test');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should return 503 when tenant is in maintenance', async () => {
+    tenants.add({ name: 'test', maintenance: true });
+
+    const app: Application = express();
+    app.use(appContextMiddleware);
+    app.use(multitenantMiddleware);
+    app.use(maintenanceMiddleware);
+    testingRoutes(app);
+
+    const response = await request(app).get('/api/testGET').set('tenant', 'test');
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({ error: 'Service Unavailable', maintenance: true });
+  });
+});

--- a/app/server.js
+++ b/app/server.js
@@ -34,6 +34,7 @@ import { closeSockets } from './api/socketio/setupSockets.js';
 import { tenants } from './api/tenants/tenantContext.js';
 import errorHandlingMiddleware from './api/utils/error_handling_middleware.js';
 import { handleError } from './api/utils/handleError.js';
+import { maintenanceMiddleware } from './api/utils/maintenanceMiddleware.js';
 import { multitenantMiddleware } from './api/utils/multitenantMiddleware.js';
 import { routesErrorHandler } from './api/utils/routesErrorHandler.js';
 import { serverSideRender } from './react/server.js';
@@ -137,6 +138,7 @@ app.use(appContextMiddleware);
 
 // this middleware should go just before any other that accesses to db
 app.use(multitenantMiddleware);
+app.use(maintenanceMiddleware);
 app.use(requestIdMiddleware);
 
 console.info('==> Connecting to', maskMongoPassword(config.DBHOST));


### PR DESCRIPTION
Adds a `maintenance` boolean flag per tenant. When enabled, the express middleware responds with HTTP 503 for that tenant. The new migration workflow enables maintenance mode around reindex and disables it afterwards.