### PR TITLE
Fix live dataviz embeds serving stale snapshots

### DIFF
--- a/app/api/dataviz.v2/application/services/resolveDatavizRenderSnapshot.ts
+++ b/app/api/dataviz.v2/application/services/resolveDatavizRenderSnapshot.ts
@@ -2,13 +2,18 @@ import type { LanguageISO6391 } from '#shared/types/commonTypes.js';
 import type { DatavizEmbedPayload } from '#shared/types/datavizSchema.js';
 import { filterDataForDisplay } from '#shared/dataviz/filterDataForDisplay.js';
 import { buildManualDataDTO } from '#shared/dataviz/manualData.js';
-import { buildRenderSnapshotPayload } from './buildRenderSnapshot.js';
+import { buildTemplatesById } from '#shared/dataviz/bakeDatavizSnapshotColors.js';
+import { buildRenderSnapshotPayload, templateIdsFromQuery } from './buildRenderSnapshot.js';
 import { Dataviz } from '#api/dataviz.v2/domain/Dataviz.js';
 import {
   DatavizProcessingError,
   DatavizSnapshotUnavailableError,
 } from '#api/dataviz.v2/domain/errors.js';
+import { validateQueryStructure } from '#api/dataviz.v2/domain/validators/validateExecutableDatavizQuery.js';
 import type { DatavizSnapshotsDataSource } from '#api/dataviz.v2/application/contracts/DatavizSnapshotsDataSource.js';
+import type { DatavizQueryExecutor } from '#api/dataviz.v2/application/contracts/DatavizQueryExecutor.js';
+import type { TemplatesDataSource } from '#api/core/application/contracts/TemplatesDataSource.js';
+import type { User } from '#api/users.v2/model/User.js';
 
 type Input = {
   dataviz: Dataviz;
@@ -18,6 +23,51 @@ type Input = {
 
 type Deps = {
   snapshotsDS: DatavizSnapshotsDataSource;
+  queryExecutor: DatavizQueryExecutor;
+  templatesDS: TemplatesDataSource;
+  actor: User;
+};
+
+const toEmbedPayload = (
+  renderPayload: DatavizEmbedPayload,
+  dataviz: Dataviz,
+  locale: LanguageISO6391,
+  defaultLocale: LanguageISO6391,
+  stale = false
+): DatavizEmbedPayload => ({
+  data: filterDataForDisplay({ ...renderPayload.data, stale }, renderPayload.chart, {
+    locale,
+    defaultLocale,
+    dimensions: dataviz.query.dimensions,
+    measures: dataviz.query.measures,
+  }),
+  chart: renderPayload.chart,
+  appearance: renderPayload.appearance,
+});
+
+const resolveLiveQueryPayload = async (
+  dataviz: Dataviz,
+  deps: Deps
+): Promise<DatavizEmbedPayload> => {
+  validateQueryStructure(dataviz.query);
+
+  const data = await deps.queryExecutor.execute(dataviz.query, {
+    actor: deps.actor,
+    datavizId: dataviz.id,
+    appearance: dataviz.appearance,
+  });
+
+  const templateIds = templateIdsFromQuery(dataviz.query);
+  const templates =
+    templateIds.length > 0
+      ? (await deps.templatesDS.getByIds(templateIds)).map(template => ({
+          id: template.id,
+          name: template.name,
+          color: template.color,
+        }))
+      : [];
+
+  return buildRenderSnapshotPayload(dataviz, data, buildTemplatesById(templates));
 };
 
 const resolveDatavizRenderSnapshot = async (
@@ -33,14 +83,12 @@ const resolveDatavizRenderSnapshot = async (
       dataviz,
       buildManualDataDTO(dataviz.id, dataviz.manualData)
     );
-    return {
-      data: filterDataForDisplay(manualPayload.data, manualPayload.chart, {
-        locale,
-        defaultLocale,
-      }),
-      chart: manualPayload.chart,
-      appearance: manualPayload.appearance,
-    };
+    return toEmbedPayload(manualPayload, dataviz, locale, defaultLocale);
+  }
+
+  if (!dataviz.usesSnapshot) {
+    const livePayload = await resolveLiveQueryPayload(dataviz, deps);
+    return toEmbedPayload(livePayload, dataviz, locale, defaultLocale);
   }
 
   const snapshotResult = await deps.snapshotsDS.getByDatavizId(dataviz.id);
@@ -49,21 +97,9 @@ const resolveDatavizRenderSnapshot = async (
   }
 
   const snapshot = snapshotResult.getData();
-  const renderPayload = snapshot.payload;
   const stale = snapshot.queryHash !== dataviz.queryHash;
 
-  const data = filterDataForDisplay({ ...renderPayload.data, stale }, renderPayload.chart, {
-    locale,
-    defaultLocale,
-    dimensions: dataviz.query.dimensions,
-    measures: dataviz.query.measures,
-  });
-
-  return {
-    data,
-    chart: renderPayload.chart,
-    appearance: renderPayload.appearance,
-  };
+  return toEmbedPayload(snapshot.payload, dataviz, locale, defaultLocale, stale);
 };
 
 export { resolveDatavizRenderSnapshot };

--- a/app/api/dataviz.v2/application/specs/GetPublicDatavizEmbed.spec.ts
+++ b/app/api/dataviz.v2/application/specs/GetPublicDatavizEmbed.spec.ts
@@ -68,6 +68,8 @@ const createSut = (queryExecutor = createMockQueryExecutor()) =>
                 datavizDS: DatavizFactory.dataSource(),
                 snapshotsDS: DatavizFactory.snapshotsDataSource(),
                 settingsDS: SettingsDataSourceFactory.default({ transactionManager: tm }),
+                queryExecutor,
+                templatesDS: TemplatesDataSourceFactory.default(),
               },
               { actor, tenant: ExecutionContext.tenant, targetLanguage: 'en' }
             );
@@ -76,6 +78,7 @@ const createSut = (queryExecutor = createMockQueryExecutor()) =>
       }),
       datavizDS: DatavizFactory.dataSource(),
       snapshotsDS: DatavizFactory.snapshotsDataSource(),
+      queryExecutor,
     };
   });
 
@@ -219,8 +222,9 @@ describe('GetPublicDatavizEmbedUseCase', () => {
     );
   });
 
-  it('should reject live query charts without a snapshot on the public path', async () => {
-    const { create, getPublicEmbed, snapshotsDS } = createSut();
+  it('should execute live query when no snapshot exists on the public path', async () => {
+    const queryExecutor = createMockQueryExecutor();
+    const { create, getPublicEmbed, snapshotsDS } = createSut(queryExecutor);
     const dataviz = await create.execute({
       name: 'Live without snapshot',
       query: {
@@ -234,14 +238,18 @@ describe('GetPublicDatavizEmbedUseCase', () => {
     });
 
     await snapshotsDS.deleteByDatavizId(dataviz.id);
+    const callsAfterCreate = (queryExecutor.execute as jest.Mock).mock.calls.length;
 
-    await expect(getPublicEmbed().execute({ id: dataviz.id })).rejects.toThrow(
-      DatavizSnapshotUnavailableError
-    );
+    const payload = await getPublicEmbed().execute({ id: dataviz.id });
+
+    expect(queryExecutor.execute).toHaveBeenCalledTimes(callsAfterCreate + 1);
+    expect(payload.data.series).toHaveLength(1);
+    expect(payload.chart.type).toBe('pie');
   });
 
-  it('should serve snapshot data for live charts on the public path without executing queries', async () => {
-    const { create, getPublicEmbed } = createSut();
+  it('should execute live query for live charts instead of serving the saved snapshot', async () => {
+    const queryExecutor = createMockQueryExecutor();
+    const { create, getPublicEmbed } = createSut(queryExecutor);
     const dataviz = await create.execute({
       name: 'Live with snapshot',
       query: {
@@ -254,8 +262,61 @@ describe('GetPublicDatavizEmbedUseCase', () => {
       refresh: { refreshMode: 'live' },
     });
 
+    const callsAfterCreate = (queryExecutor.execute as jest.Mock).mock.calls.length;
+    (queryExecutor.execute as jest.Mock).mockImplementation(async (_query, context) => ({
+      ...mockSnapshotData,
+      datavizId: context.datavizId ?? 'pending',
+      series: [{ id: 'main', label: 'Series', points: [{ key: 'b', label: 'Live B', value: 9 }] }],
+    }));
+
     const payload = await getPublicEmbed().execute({ id: dataviz.id });
 
+    expect(queryExecutor.execute).toHaveBeenCalledTimes(callsAfterCreate + 1);
+    expect(payload.data.series[0].points[0].label).toBe('Live B');
+    expect(payload.chart.type).toBe('pie');
+  });
+
+  it('should reject snapshot charts without a snapshot on the public path', async () => {
+    const { create, getPublicEmbed, snapshotsDS } = createSut();
+    const dataviz = await create.execute({
+      name: 'Snapshot without snapshot',
+      query: {
+        sources: [{ templateId: '507f1f77bcf86cd799439011' }],
+        dimensions: [{ property: 'title', propertyType: 'select' }],
+        measures: [{ aggregation: 'count', countMode: 'all' }],
+      },
+      chart: { type: 'pie' },
+      appearance: { colorMode: 'theme' },
+      refresh: { refreshMode: 'snapshot_manual' },
+    });
+
+    await snapshotsDS.deleteByDatavizId(dataviz.id);
+
+    await expect(getPublicEmbed().execute({ id: dataviz.id })).rejects.toThrow(
+      DatavizSnapshotUnavailableError
+    );
+  });
+
+  it('should serve snapshot data for snapshot charts without executing queries again', async () => {
+    const queryExecutor = createMockQueryExecutor();
+    const { create, getPublicEmbed } = createSut(queryExecutor);
+    const dataviz = await create.execute({
+      name: 'Snapshot with snapshot',
+      query: {
+        sources: [{ templateId: '507f1f77bcf86cd799439011' }],
+        dimensions: [{ property: 'title', propertyType: 'select' }],
+        measures: [{ aggregation: 'count', countMode: 'all' }],
+      },
+      chart: { type: 'pie' },
+      appearance: { colorMode: 'theme' },
+      refresh: { refreshMode: 'snapshot_manual' },
+    });
+
+    const callsAfterCreate = (queryExecutor.execute as jest.Mock).mock.calls.length;
+
+    const payload = await getPublicEmbed().execute({ id: dataviz.id });
+
+    expect(queryExecutor.execute).toHaveBeenCalledTimes(callsAfterCreate);
     expect(payload.data.series).toHaveLength(1);
     expect(payload.chart.type).toBe('pie');
   });

--- a/app/api/dataviz.v2/application/useCases/GetPublicDatavizEmbed.ts
+++ b/app/api/dataviz.v2/application/useCases/GetPublicDatavizEmbed.ts
@@ -1,7 +1,9 @@
 import type { DatavizEmbedPayload } from '#shared/types/datavizSchema.js';
 import type { SettingsDataSource } from '#api/core/application/contracts/SettingsDataSource.js';
+import type { TemplatesDataSource } from '#api/core/application/contracts/TemplatesDataSource.js';
 import { DatavizDataSource } from '#api/dataviz.v2/application/contracts/DatavizDataSource.js';
 import { DatavizSnapshotsDataSource } from '#api/dataviz.v2/application/contracts/DatavizSnapshotsDataSource.js';
+import type { DatavizQueryExecutor } from '#api/dataviz.v2/application/contracts/DatavizQueryExecutor.js';
 import { AbstractUseCase } from '#api/core/libs/UseCase.js';
 import { DatavizNotFoundError, DatavizUnauthorizedError } from '#api/dataviz.v2/domain/errors.js';
 import { resolveDatavizRenderSnapshot } from '#api/dataviz.v2/application/services/resolveDatavizRenderSnapshot.js';
@@ -16,6 +18,8 @@ type Deps = {
   datavizDS: DatavizDataSource;
   snapshotsDS: DatavizSnapshotsDataSource;
   settingsDS: SettingsDataSource;
+  queryExecutor: DatavizQueryExecutor;
+  templatesDS: TemplatesDataSource;
 };
 
 class GetPublicDatavizEmbedUseCase extends AbstractUseCase<Input, Output, Deps> {
@@ -41,7 +45,12 @@ class GetPublicDatavizEmbedUseCase extends AbstractUseCase<Input, Output, Deps> 
         locale: this.targetLanguage,
         defaultLocale,
       },
-      { snapshotsDS: this.deps.snapshotsDS }
+      {
+        snapshotsDS: this.deps.snapshotsDS,
+        queryExecutor: this.deps.queryExecutor,
+        templatesDS: this.deps.templatesDS,
+        actor: this.getActor(),
+      }
     );
   }
 }

--- a/app/api/dataviz.v2/infrastructure/factories/DatavizFactory.ts
+++ b/app/api/dataviz.v2/infrastructure/factories/DatavizFactory.ts
@@ -146,6 +146,8 @@ class DatavizFactory {
         settingsDS: SettingsDataSourceFactory.default({
           transactionManager: this.getTransactionManager(),
         }),
+        queryExecutor: this.queryExecutor(),
+        templatesDS: TemplatesDataSourceFactory.default(),
       },
       { actor, tenant, targetLanguage: overrides?.targetLanguage }
     );

--- a/app/api/dataviz.v2/infrastructure/http/specs/publicEmbedIntegration.spec.ts
+++ b/app/api/dataviz.v2/infrastructure/http/specs/publicEmbedIntegration.spec.ts
@@ -106,6 +106,28 @@ const scatterQueryChart = {
   refresh: { refreshMode: 'snapshot_manual' },
 };
 
+const livePieQueryChart = {
+  name: 'Live pie embed',
+  query: {
+    sources: [{ templateId: templateId.toString(), alias: 'cars' }],
+    dimensions: [
+      {
+        property: 'engine_size',
+        propertyType: 'numeric',
+        bucketStrategy: 'terms',
+        sort: 'key_asc',
+        maxBuckets: 10,
+      },
+    ],
+    measures: [{ aggregation: 'count', countMode: 'all' }],
+    language: 'en',
+    limit: 50,
+  },
+  chart: { type: 'pie' },
+  appearance: { colorMode: 'theme' },
+  refresh: { refreshMode: 'live' as const },
+};
+
 describe('public dataviz embed integration', () => {
   const app: Application = setUpApp(datavizRoutes, (req, _res, next) => {
     req.user = { _id: 'adminUser', role: 'admin' };
@@ -174,5 +196,72 @@ describe('public dataviz embed integration', () => {
       .expect(503);
 
     expect(embedResponse.body.code).toBe('DATAVIZ_SNAPSHOT_UNAVAILABLE');
+  });
+
+  it('should re-query the collection for live charts on each public embed load', async () => {
+    const createResponse = await request(app)
+      .post('/api/dataviz')
+      .send(livePieQueryChart)
+      .expect(200);
+    const datavizId = createResponse.body.id as string;
+
+    const firstEmbed = await request(app)
+      .get(`/api/public/dataviz/${datavizId}/data`)
+      .query({ locale: 'en' })
+      .expect(200);
+
+    expect(firstEmbed.body.data.meta.totalEntities).toBe(3);
+
+    await testingEnvironment.runWithContext(async () => {
+      const { getConnection } =
+        await import('#api/core/infrastructure/mongodb/common/getConnectionForCurrentTenant.js');
+      const db = getConnection();
+      await db.collection('entities').insertOne({
+        _id: factory.id('car4'),
+        sharedId: 'car_shared_4',
+        language: 'en',
+        template: templateId,
+        title: 'Car 4',
+        published: true,
+        metadata: {
+          registration_date: [{ value: 804863301 }],
+          engine_size: [{ value: 2.5 }],
+        },
+      });
+    });
+
+    const secondEmbed = await request(app)
+      .get(`/api/public/dataviz/${datavizId}/data`)
+      .query({ locale: 'en' })
+      .expect(200);
+
+    expect(secondEmbed.body.data.meta.totalEntities).toBe(4);
+  });
+
+  it('should still serve live charts when the saved snapshot was removed', async () => {
+    const createResponse = await request(app)
+      .post('/api/dataviz')
+      .send({
+        ...livePieQueryChart,
+        name: 'Live without snapshot',
+      })
+      .expect(200);
+
+    const datavizId = createResponse.body.id as string;
+
+    await testingEnvironment.runWithContext(async () => {
+      const snapshotsDS = (
+        await import('#api/dataviz.v2/infrastructure/factories/DatavizFactory.js')
+      ).DatavizFactory.snapshotsDataSource();
+      await snapshotsDS.deleteByDatavizId(datavizId);
+    });
+
+    const embedResponse = await request(app)
+      .get(`/api/public/dataviz/${datavizId}/data`)
+      .query({ locale: 'en' })
+      .expect(200);
+
+    expect(embedResponse.body.data.series).toHaveLength(1);
+    expect(embedResponse.body.data.meta.totalEntities).toBeGreaterThan(0);
   });
 });

--- a/app/api/dataviz.v2/infrastructure/http/specs/publicRoutes.spec.ts
+++ b/app/api/dataviz.v2/infrastructure/http/specs/publicRoutes.spec.ts
@@ -160,7 +160,7 @@ describe('public dataviz embed routes', () => {
     await settings.save({ ...current, private: false });
   });
 
-  it('should return 503 when a query chart has no snapshot', async () => {
+  it('should return 503 when a snapshot chart has no snapshot', async () => {
     const queryChart = await testingEnvironment.runWithContext(async () => {
       const transactionManager = ExecutionContext.transactionManager as MongoTransactionManager;
       const create = new CreateDatavizUseCase(
@@ -185,7 +185,7 @@ describe('public dataviz embed routes', () => {
         },
         chart: { type: 'pie' },
         appearance: { colorMode: 'theme' },
-        refresh: { refreshMode: 'live' },
+        refresh: { refreshMode: 'snapshot_manual' },
       });
 
       await DatavizFactory.snapshotsDataSource().deleteByDatavizId(created.id);


### PR DESCRIPTION
## Summary
- Public embeds with `refreshMode: live` now re-query the collection on each load instead of always returning the save-time snapshot.
- Snapshot modes (`snapshot_manual` / `snapshot_scheduled`) keep serving the persisted snapshot; missing snapshots still return 503.
- Adds unit and HTTP integration coverage for live re-query, live without snapshot, and snapshot-only behavior.