### PR TITLE
Improved pg user provisioning and tooling

### DIFF
--- a/app/api/config.ts
+++ b/app/api/config.ts
@@ -15,8 +15,8 @@ const PostgresEnvSchema = z
     POSTGRES_HOST: z.string().default('127.0.0.1'),
     POSTGRES_PORT: z.coerce.number().default(5432),
     POSTGRES_DB: z.string().default('uwazi_development'),
-    POSTGRES_USER: z.string().default('uwazi'),
-    POSTGRES_PASSWORD: z.string().default('uwazi'),
+    POSTGRES_USER: z.string().default('migrator_user'),
+    POSTGRES_PASSWORD: z.string().default('migrator_user'),
     POSTGRES_APP_USER: z.string().default('app_user'),
     POSTGRES_APP_PASSWORD: z.string().default('app_user'),
   })

--- a/app/api/core/infrastructure/postgresql/provisioning/001-create_application_user.sql
+++ b/app/api/core/infrastructure/postgresql/provisioning/001-create_application_user.sql
@@ -1,11 +1,22 @@
-CREATE ROLE app_user
-LOGIN
-PASSWORD 'app_user';
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'app_user') THEN
+    CREATE ROLE app_user LOGIN PASSWORD 'app_user';
+  END IF;
+END
+$$;
 
-GRANT CONNECT ON DATABASE uwazi_development TO app_user;
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_catalog.pg_database WHERE datname = 'uwazi_development') THEN
+    GRANT CONNECT ON DATABASE uwazi_development TO app_user;
+  END IF;
+  IF EXISTS (SELECT FROM pg_catalog.pg_database WHERE datname = 'uwazi') THEN
+    GRANT CONNECT ON DATABASE uwazi TO app_user;
+  END IF;
+END
+$$;
 
 GRANT USAGE ON SCHEMA public TO app_user;
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;

--- a/app/api/core/infrastructure/postgresql/provisioning/002-create_migrator_user.sql
+++ b/app/api/core/infrastructure/postgresql/provisioning/002-create_migrator_user.sql
@@ -1,0 +1,26 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'migrator_user') THEN
+    CREATE ROLE migrator_user LOGIN PASSWORD 'migrator_user';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_catalog.pg_database WHERE datname = 'uwazi_development') THEN
+    GRANT CONNECT ON DATABASE uwazi_development TO migrator_user;
+  END IF;
+  IF EXISTS (SELECT FROM pg_catalog.pg_database WHERE datname = 'uwazi') THEN
+    GRANT CONNECT ON DATABASE uwazi TO migrator_user;
+  END IF;
+END
+$$;
+
+GRANT USAGE, CREATE ON SCHEMA public TO migrator_user;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE migrator_user IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE migrator_user IN SCHEMA public
+  GRANT USAGE ON SEQUENCES TO app_user;

--- a/database/provision_postgres.sh
+++ b/database/provision_postgres.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../app/api/core/infrastructure/postgresql/provisioning" && pwd)"
+
+# Use standard PostgreSQL env vars, defaulting to local docker-like settings
+export PGHOST=${PGHOST:-127.0.0.1}
+export PGPORT=${PGPORT:-5432}
+export PGUSER=${PGUSER:-admin}
+export PGDATABASE=${PGDATABASE:-uwazi_development}
+
+echo "Provisioning PostgreSQL roles on ${PGHOST}:${PGPORT}/${PGDATABASE}..."
+
+(
+  for f in $(find "${SCRIPT_DIR}" -maxdepth 1 -name '*.sql' | sort -V); do
+    cat "$f"
+  done
+) | psql
+
+echo "Done."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
     ports:
       - '5432:5432'
     environment:
-      - POSTGRES_USER=uwazi
-      - POSTGRES_PASSWORD=uwazi
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin
       - POSTGRES_DB=uwazi_development
     volumes:
       - pgdata:/var/lib/postgresql/data

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "dump-db": "node --no-experimental-fetch scripts/bash.js ./database/dump_db.sh",
     "restore-db": "node --no-experimental-fetch scripts/bash.js ./database/restore_db.sh",
     "fixtures": "node --no-experimental-fetch scripts/bash.js ./uwazi-fixtures/restore.sh",
+    "provision-postgres": "node --no-experimental-fetch scripts/bash.js ./database/provision_postgres.sh",
     "add-migration": "./node_modules/.bin/plop --plopfile ./app/api/migrations/plopfile.cjs migration",
     "migrate": "node ./scripts/runner.js ./scripts/migrate.js",
     "migrate-and-reindex": "node ./scripts/runner.js ./scripts/migrate_and_reindex.js",


### PR DESCRIPTION
 - Added 002-create_migrator_user.sql — creates the migrator_user role for DDL operations (table creation, schema alterations) with CREATE privilege on public schema

 - Updated 001-create_application_user.sql — made idempotent with conditional CREATE ROLE and conditional GRANT CONNECT; removed dead ALTER DEFAULT PRIVILEGES (was scoped to admin, not
   migrator_user)

 - Added ALTER DEFAULT PRIVILEGES bridge in 002 — any table/sequence created by migrator_user automatically grants SELECT/INSERT/UPDATE/DELETE (tables) and USAGE (sequences) to app_user

 - Added yarn provision-postgres — new script that concatenates all .sql files in the provisioning folder (sorted numerically) and pipes them to psql via standard PostgreSQL env vars (PGHOST,
   PGPORT, PGUSER, PGDATABASE)

 - Updated docker-compose.yml — changed postgres bootstrap user from uwazi/uwazi to admin/admin

 - Updated app/api/config.ts — changed default POSTGRES_USER/POSTGRES_PASSWORD from uwazi to migrator_user
