### PR TITLE
9352 - reduce entityv2 URL multiplication for SEO

### DIFF
--- a/app/api/documents/documents.js
+++ b/app/api/documents/documents.js
@@ -29,6 +29,27 @@ const documents = {
     return document.fullText[page].replace(pageNumberMatch, '');
   },
 
+  async fullText(_id) {
+    if (!_id) {
+      throw createError('document does not exists', 404);
+    }
+
+    const document = (
+      await FilesDAOFactory.default().getById(_id.toString(), { withFullText: true })
+    ).getData(null);
+
+    if (!document || !document.fullText) {
+      throw createError('document does not exists', 404);
+    }
+
+    const pageNumberMatch = /\[\[(\d+)\]\]/g;
+    return Object.keys(document.fullText)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map(page => document.fullText[page].replace(pageNumberMatch, ''))
+      .join('\n\n');
+  },
+
   get(query, select) {
     return entities.get(query, select);
   },

--- a/app/api/documents/documents.js
+++ b/app/api/documents/documents.js
@@ -43,11 +43,12 @@ const documents = {
     }
 
     const pageNumberMatch = /\[\[(\d+)\]\]/g;
+    // Form-feed separates pages so the client can render page containers for SEO.
     return Object.keys(document.fullText)
       .map(Number)
       .sort((a, b) => a - b)
       .map(page => document.fullText[page].replace(pageNumberMatch, ''))
-      .join('\n\n');
+      .join('\f');
   },
 
   get(query, select) {

--- a/app/api/documents/routes.ts
+++ b/app/api/documents/routes.ts
@@ -28,4 +28,28 @@ export const documentRoutes = (app: Application) => {
         .catch(next);
     }
   );
+
+  app.get(
+    '/api/documents/fulltext',
+    validateAndCoerceRequest({
+      type: 'object',
+      properties: {
+        query: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+          },
+        },
+      },
+    }),
+
+    async (req: Request, res: Response, next: NextFunction) => {
+      documents
+        .fullText(req.query._id)
+        .then((result: string) => {
+          res.json({ data: result });
+        })
+        .catch(next);
+    }
+  );
 };

--- a/app/api/documents/specs/documents.spec.ts
+++ b/app/api/documents/specs/documents.spec.ts
@@ -9,7 +9,7 @@ import { mockID } from '#shared/uniqueID.js';
 // eslint-disable-next-line node/no-restricted-import
 import fs from 'fs/promises';
 import { documents } from '../documents.js';
-import { fixtures } from './fixtures.js';
+import { document1, fixtures } from './fixtures.js';
 
 describe('documents', () => {
   beforeEach(async () => {
@@ -34,6 +34,13 @@ describe('documents', () => {
         expect(docs[1].fullText).not.toBeDefined();
         expect(docs[0].title).toBe('Batman finishes');
       });
+    });
+  });
+
+  describe('fullText', () => {
+    it('should return concatenated pages without page markers', async () => {
+      const text = await documents.fullText(document1);
+      expect(text).toBe('page 1\n\npage 2');
     });
   });
 

--- a/app/api/documents/specs/documents.spec.ts
+++ b/app/api/documents/specs/documents.spec.ts
@@ -40,7 +40,7 @@ describe('documents', () => {
   describe('fullText', () => {
     it('should return concatenated pages without page markers', async () => {
       const text = await documents.fullText(document1);
-      expect(text).toBe('page 1\n\npage 2');
+      expect(text).toBe('page 1\fpage 2');
     });
   });
 

--- a/app/api/documents/specs/routes.spec.ts
+++ b/app/api/documents/specs/routes.spec.ts
@@ -72,4 +72,26 @@ describe('document routes', () => {
       );
     });
   });
+
+  describe('GET/fulltext', () => {
+    it('should return concatenated document plaintext', async () => {
+      const res: SuperTestResponse = await request(app)
+        .get('/api/documents/fulltext')
+        .query({ _id: document1.toString() });
+
+      expect(res.body).toEqual({ data: 'page 1\n\npage 2' });
+    });
+
+    it('should return error when file does not exists', async () => {
+      const res: SuperTestResponse = await request(app)
+        .get('/api/documents/fulltext')
+        .query({ _id: db.id().toString() });
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          error: 'document does not exists',
+        })
+      );
+    });
+  });
 });

--- a/app/api/documents/specs/routes.spec.ts
+++ b/app/api/documents/specs/routes.spec.ts
@@ -79,7 +79,7 @@ describe('document routes', () => {
         .get('/api/documents/fulltext')
         .query({ _id: document1.toString() });
 
-      expect(res.body).toEqual({ data: 'page 1\n\npage 2' });
+      expect(res.body).toEqual({ data: 'page 1\fpage 2' });
     });
 
     it('should return error when file does not exists', async () => {

--- a/app/react/App/styles/globalFontOverride.cjs
+++ b/app/react/App/styles/globalFontOverride.cjs
@@ -2,9 +2,13 @@
 // other tools like Monaco code editor and PDFJS.The custom font is forced on the rendering
 // breaking styles and functionality.
 const globalFontOverride = {
-  '.tw-content *:not(.monaco-code-editor-container):not(.monaco-code-editor-container *):not(#pdf-container .textLayer):not(#pdf-container .textLayer *)':
+  '.tw-content *:not(.monaco-code-editor-container):not(.monaco-code-editor-container *):not(#pdf-container .textLayer):not(#pdf-container .textLayer *):not(.entity-plaintext-mono):not(.entity-plaintext-mono *):not([data-entity-plaintext]):not([data-entity-plaintext] *)':
     {
       'font-family': "'Inter', sans-serif !important",
+    },
+  '.tw-content .entity-plaintext-mono, .tw-content .entity-plaintext-mono *, .tw-content [data-entity-plaintext], .tw-content [data-entity-plaintext] *':
+    {
+      'font-family': '"JetBrains Mono", ui-monospace, monospace !important',
     },
 };
 

--- a/app/react/V2/Routes/Entity/Components/Files/EntityFilesContext.tsx
+++ b/app/react/V2/Routes/Entity/Components/Files/EntityFilesContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import { useRevalidator, useSearchParams } from 'react-router';
+import { useRevalidator } from 'react-router';
+import { useUpdateEntityUrl } from '../../entityUrlState.js';
 import { MAIN_TAB_PARAM, SIDE_TAB_PARAM } from '../../urlParams.js';
 import { FileType } from '#shared/types/fileType.js';
 import { Entity } from '#V2/api/entities/types.js';
@@ -66,7 +67,7 @@ const EntityFilesProvider = ({
   const settings = useAtomValue(settingsAtom);
   const defaultLanguage = settings?.languages?.find(language => language.default)?.key;
   const { revalidate } = useRevalidator();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const updateEntityUrl = useUpdateEntityUrl();
   const [selectedRowIds, setSelectedRowIds] = useState<string[]>([]);
   const [focusedRowId, setFocusedRowId] = useState<string>();
   const [isEditing, setIsEditing] = useState(false);
@@ -148,12 +149,16 @@ const EntityFilesProvider = ({
 
   const navigateToFilesSideTab = useCallback(
     (tab: FilesSideTabId) => {
-      const next = new URLSearchParams(searchParams.toString());
-      next.set(MAIN_TAB_PARAM, 'files');
-      next.set(SIDE_TAB_PARAM, tab);
-      setSearchParams(next, { replace: true, preventScrollReset: true });
+      updateEntityUrl({
+        search: next => {
+          next.set(MAIN_TAB_PARAM, 'files');
+        },
+        hash: hash => {
+          hash.set(SIDE_TAB_PARAM, tab);
+        },
+      });
     },
-    [searchParams, setSearchParams]
+    [updateEntityUrl]
   );
 
   const closeAddFileModal = useCallback(() => {

--- a/app/react/V2/Routes/Entity/Components/context/entityLanguageUtils.ts
+++ b/app/react/V2/Routes/Entity/Components/context/entityLanguageUtils.ts
@@ -3,7 +3,7 @@ import type { LanguagesListSchema } from '#shared/types/commonTypes.js';
 import { availableLanguages } from '#shared/language/index.js';
 import { FetchResponseError } from '#shared/JSONRequest.js';
 import type { Entity, FileType } from '#V2/api/entities/types.js';
-import { getPagePlaintext } from '#V2/api/files/index.js';
+import { getDocumentPlaintext } from '#V2/api/files/index.js';
 import { getMainDocument } from '#V2/formatters/index.js';
 import { httpServices } from '#V2/services/http/index.js';
 import { entityLoaderCache } from '../../EntityLoaderCache.js';
@@ -20,7 +20,6 @@ const resolveRtl = (languageKey: string, languages: LanguagesListSchema): boolea
 
 type PlaintextQuery = {
   isRaw: boolean;
-  page: number;
 };
 
 const seedLoaderCache = (entity: Entity, language: string, mainDocument?: FileType) => {
@@ -74,17 +73,17 @@ const resolvePlaintext = async (document: FileType | undefined, query: Plaintext
     return undefined;
   }
 
-  const cached = entityLoaderCache.getPlaintext(document._id, query.page);
+  const cached = entityLoaderCache.getPlaintext(document._id);
   if (cached !== undefined) {
     return cached;
   }
 
-  const response = await getPagePlaintext(document._id, query.page);
+  const response = await getDocumentPlaintext(document._id);
   if (response instanceof FetchResponseError) {
     return undefined;
   }
 
-  entityLoaderCache.setPlaintext(document._id, query.page, response);
+  entityLoaderCache.setPlaintext(document._id, response);
   return response;
 };
 

--- a/app/react/V2/Routes/Entity/Components/context/hooks/useEntityLanguageState.ts
+++ b/app/react/V2/Routes/Entity/Components/context/hooks/useEntityLanguageState.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router';
 import { t } from '#app/I18N/index.js';
 import type { Entity, FileType } from '#V2/api/entities/types.js';
 import { notify } from '#V2/utils/notifyBridge.js';
-import { PAGE_PARAM, VIEW_MODE_PARAM } from '../../../urlParams.js';
+import { useEntityHashParams } from '../../../entityUrlState.js';
+import { VIEW_MODE_PARAM } from '../../../urlParams.js';
 import {
   applyLanguageSnapshot,
   fetchEntityForLanguage,
@@ -28,7 +28,7 @@ const useApplyLanguage = (
   defaultLanguage: string | undefined,
   setters: LanguageSnapshotSetters
 ) => {
-  const [searchParams] = useSearchParams();
+  const hashParams = useEntityHashParams();
   const applyGenerationRef = useRef(0);
   const invalidateApply = useCallback(() => {
     applyGenerationRef.current += 1;
@@ -54,8 +54,7 @@ const useApplyLanguage = (
         defaultLanguage
       );
       const nextPlaintext = await resolvePlaintext(nextMainDocument, {
-        isRaw: searchParams.get(VIEW_MODE_PARAM) === 'true',
-        page: Number(searchParams.get(PAGE_PARAM) || '1'),
+        isRaw: hashParams.get(VIEW_MODE_PARAM) === 'true',
       });
       if (!isCurrent()) return 'stale';
 
@@ -70,7 +69,7 @@ const useApplyLanguage = (
       );
       return 'applied';
     },
-    [loaderEntity, defaultLanguage, setters, searchParams]
+    [loaderEntity, defaultLanguage, setters, hashParams]
   );
 
   return { applyLanguage, invalidateApply };

--- a/app/react/V2/Routes/Entity/Components/context/hooks/useEntityLanguageSync.ts
+++ b/app/react/V2/Routes/Entity/Components/context/hooks/useEntityLanguageSync.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef, type MutableRefObject } from 'react';
-import { useSearchParams } from 'react-router';
 import type { Entity, FileType } from '#V2/api/entities/types.js';
 import { entityLoaderCache } from '../../../EntityLoaderCache.js';
-import { PAGE_PARAM, VIEW_MODE_PARAM } from '../../../urlParams.js';
+import { useEntityHashParams } from '../../../entityUrlState.js';
+import { VIEW_MODE_PARAM } from '../../../urlParams.js';
 import { useMetadataEditing } from '../MetadataEditingContext.js';
 import {
   resolvePlaintext,
@@ -98,9 +98,8 @@ const useSyncPagePlaintext = ({
   mainDocument?: FileType;
   setPagePlaintext: (text: string | undefined) => void;
 }) => {
-  const [searchParams] = useSearchParams();
-  const pageParam = searchParams.get(PAGE_PARAM) || '1';
-  const isRawView = searchParams.get(VIEW_MODE_PARAM) === 'true';
+  const hashParams = useEntityHashParams();
+  const isRawView = hashParams.get(VIEW_MODE_PARAM) === 'true';
 
   useEffect(() => {
     let cancelled = false;
@@ -116,9 +115,8 @@ const useSyncPagePlaintext = ({
       };
     }
 
-    const page = Number(pageParam);
-    setPagePlaintext(entityLoaderCache.getPlaintext(mainDocument._id, page));
-    resolvePlaintext(mainDocument, { isRaw: true, page })
+    setPagePlaintext(entityLoaderCache.getPlaintext(mainDocument._id));
+    resolvePlaintext(mainDocument, { isRaw: true })
       .then(text => {
         if (!cancelled) setPagePlaintext(text);
       })
@@ -129,7 +127,7 @@ const useSyncPagePlaintext = ({
     return () => {
       cancelled = true;
     };
-  }, [mainDocument, pageParam, isRawView, setPagePlaintext]);
+  }, [mainDocument, isRawView, setPagePlaintext]);
 };
 
 export { useLoaderLanguageSync, useSyncPagePlaintext };

--- a/app/react/V2/Routes/Entity/Components/document/DocumentViewModeSelect.tsx
+++ b/app/react/V2/Routes/Entity/Components/document/DocumentViewModeSelect.tsx
@@ -1,43 +1,50 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Bars3BottomLeftIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
-import { useSearchParams } from 'react-router';
 import { t } from '#app/I18N/index.js';
 import { isClient } from '#app/utils/index.js';
+import { useEntityHashParams, useUpdateEntityUrl } from '../../entityUrlState.js';
 import { PAGE_PARAM, VIEW_MODE_PARAM } from '../../urlParams.js';
 import { useDocumentPdf } from '#V2/Routes/Entity/Components/context/index.js';
 
 type ViewMode = 'raw' | 'normal';
 
 const DocumentViewModeSelect = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const updateEntityUrl = useUpdateEntityUrl();
   const { pdfController: pdfControls } = useDocumentPdf();
   const [ready, setReady] = useState(false);
   const [open, setOpen] = useState(false);
-  const initialPage = useRef(Number.parseInt(searchParams.get(PAGE_PARAM) || '1', 10));
+  const hashParams = useEntityHashParams();
+  const initialPage = useRef(Number.parseInt(hashParams.get(PAGE_PARAM) || '1', 10));
 
   useEffect(() => {
     setReady(true);
   }, []);
 
-  const isRaw = !isClient || !ready || searchParams.get(VIEW_MODE_PARAM) === 'true';
+  const isRaw = !isClient || !ready || hashParams.get(VIEW_MODE_PARAM) === 'true';
 
   const selectMode = useCallback(
     (value: ViewMode) => {
-      const next = new URLSearchParams(searchParams.toString());
-      const currentPage = searchParams.get(PAGE_PARAM) || '1';
-      if (value === 'raw') {
-        next.set(VIEW_MODE_PARAM, 'true');
-      } else {
-        next.delete(VIEW_MODE_PARAM);
-        next.set(PAGE_PARAM, currentPage);
-      }
+      const currentPage = hashParams.get(PAGE_PARAM) || '1';
+      updateEntityUrl({
+        search: next => {
+          next.delete(VIEW_MODE_PARAM);
+        },
+        hash: next => {
+          if (value === 'raw') {
+            next.set(VIEW_MODE_PARAM, 'true');
+          } else {
+            next.delete(VIEW_MODE_PARAM);
+          }
+        },
+      });
       initialPage.current = Number(currentPage);
-      pdfControls?.goToPage(Number(currentPage));
-      setSearchParams(next, { replace: true, preventScrollReset: true });
+      if (value !== 'raw') {
+        pdfControls?.goToPage(Number(currentPage));
+      }
       setOpen(false);
     },
-    [pdfControls, searchParams, setSearchParams]
+    [pdfControls, hashParams, updateEntityUrl]
   );
 
   const modes = [

--- a/app/react/V2/Routes/Entity/Components/document/PlainText.tsx
+++ b/app/react/V2/Routes/Entity/Components/document/PlainText.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 interface PlainTextProps {
   text: string;
@@ -6,10 +6,44 @@ interface PlainTextProps {
   dir?: 'ltr' | 'rtl';
 }
 
-export const PlainText = ({ className = '', dir, text }: PlainTextProps) => (
-  <div className={`${className} whitespace-pre-line`} dir={dir}>
-    {text}
-  </div>
-);
+const PAGE_SEPARATOR = '\f';
+
+const splitPlaintextPages = (text: string): string[] => {
+  if (!text) {
+    return [];
+  }
+  if (text.includes(PAGE_SEPARATOR)) {
+    return text.split(PAGE_SEPARATOR);
+  }
+  return [text];
+};
+
+export const PlainText = ({ className = '', dir, text }: PlainTextProps) => {
+  const pages = useMemo(() => splitPlaintextPages(text), [text]);
+
+  return (
+    <div
+      className={`${className} entity-plaintext-mono flex flex-col gap-4 p-4 text-sm leading-relaxed text-ink`}
+      dir={dir}
+      data-entity-plaintext=""
+      data-testid="entity-plaintext"
+    >
+      {pages.map((pageText, index) => {
+        const pageNumber = index + 1;
+        return (
+          <section
+            key={pageNumber}
+            id={`page${pageNumber}`}
+            aria-label={`Page ${pageNumber}`}
+            className="entity-plaintext-mono whitespace-pre-line"
+          >
+            {pageText}
+          </section>
+        );
+      })}
+    </div>
+  );
+};
 
 export type { PlainTextProps };
+export { PAGE_SEPARATOR, splitPlaintextPages };

--- a/app/react/V2/Routes/Entity/Components/relationships/create-reference/CreateRelationshipModal.tsx
+++ b/app/react/V2/Routes/Entity/Components/relationships/create-reference/CreateRelationshipModal.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useAtomValue } from 'jotai';
-import { useSearchParams } from 'react-router';
 import { t } from '#app/I18N/index.js';
 import type { FileType } from '#V2/api/entities/types.js';
 import { create as createEntity, searchByTitle } from '#V2/api/entities/index.js';
@@ -20,6 +19,7 @@ import { RelationTypeStep } from './RelationTypeStep.js';
 import { TargetTextStep } from './TargetTextStep.js';
 import { CreateRelationshipModalHeader } from './CreateRelationshipModalHeader.js';
 import { useRelationshipSave } from '../hooks/useRelationshipSave.js';
+import { useEntityHashParams } from '#V2/Routes/Entity/entityUrlState.js';
 import { PAGE_PARAM } from '#V2/Routes/Entity/urlParams.js';
 
 type CreateRelationshipModalProps = {
@@ -33,7 +33,7 @@ const CreateRelationshipModal = ({ mainDocument }: CreateRelationshipModalProps)
   const relationshipTypes = useAtomValue(relationshipTypesAtom);
   const templates = useAtomValue(templatesAtom);
   const { handleSaveReference } = useRelationshipSave(mainDocument);
-  const [searchParams] = useSearchParams();
+  const hashParams = useEntityHashParams();
   const [isSaving, setIsSaving] = useState(false);
 
   const lookup = useCallback(
@@ -118,7 +118,7 @@ const CreateRelationshipModal = ({ mainDocument }: CreateRelationshipModalProps)
         selection: createReferenceSelection,
         targetEntityId: selectedEntity.sharedId,
         relationshipType: selectedRelationshipType,
-        sourcePage: searchParams.get(PAGE_PARAM) ?? '1',
+        sourcePage: hashParams.get(PAGE_PARAM) ?? '1',
         ...(selectedFile && { targetFileId: String(selectedFile._id) }),
         ...(targetSelection && { targetSelection }),
       });
@@ -140,7 +140,7 @@ const CreateRelationshipModal = ({ mainDocument }: CreateRelationshipModalProps)
     entity,
     handleSaveReference,
     reset,
-    searchParams,
+    hashParams,
     selectedEntity,
     selectedFile,
     selectedRelationshipType,

--- a/app/react/V2/Routes/Entity/Components/search/SearchView.tsx
+++ b/app/react/V2/Routes/Entity/Components/search/SearchView.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router';
 import { useForm, Controller } from 'react-hook-form';
 import { useAtomValue } from 'jotai';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/solid';
@@ -10,6 +9,7 @@ import {
   useEntityLanguage,
   useEntityScopedEntity,
 } from '#V2/Routes/Entity/Components/context/index.js';
+import { useEntityHashParams, useUpdateEntityUrl } from '../../entityUrlState.js';
 import { SEARCH_PARAM } from '../../urlParams.js';
 import { SearchResultsPanel } from './SearchResultsPanel.js';
 import { useEntitySearchSnippets } from './useEntitySearchSnippets.js';
@@ -21,8 +21,9 @@ type FormValues = {
 const SearchView = () => {
   const entity = useEntityScopedEntity();
   const { language, mainDocument } = useEntityLanguage();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const initial = searchParams.get(SEARCH_PARAM) || '';
+  const hashParams = useEntityHashParams();
+  const updateEntityUrl = useUpdateEntityUrl();
+  const initial = hashParams.get(SEARCH_PARAM) || '';
   const searchTerm = initial.trim();
   const templates = useAtomValue(templatesAtom);
   const { pdfController: mainPdfController } = useDocumentPdf();
@@ -54,14 +55,16 @@ const SearchView = () => {
   }, [mainDocument?._id, mainPdfController]);
 
   const onSubmit = async (data: FormValues) => {
-    const params = new URLSearchParams(searchParams);
     const value = data.search.trim();
-    if (value) {
-      params.set(SEARCH_PARAM, value);
-    } else {
-      params.delete(SEARCH_PARAM);
-    }
-    setSearchParams(params);
+    updateEntityUrl({
+      hash: next => {
+        if (value) {
+          next.set(SEARCH_PARAM, value);
+        } else {
+          next.delete(SEARCH_PARAM);
+        }
+      },
+    });
   };
 
   const activateSnippet = (snippetKey: string, pageText: { text: string; page: number }) => {

--- a/app/react/V2/Routes/Entity/Components/shared/EntityMainPaneHeader.tsx
+++ b/app/react/V2/Routes/Entity/Components/shared/EntityMainPaneHeader.tsx
@@ -14,9 +14,9 @@ const EntityMainPaneHeader = ({
 }: EntityMainPaneHeaderProps) => (
   <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-4">
     <TemplateLabel templateId={entity.template} />
-    <span className="min-w-0 flex-1 truncate text-xs font-semibold text-ink" no-translate="true">
+    <h1 className="m-0 min-w-0 flex-1 truncate text-xs font-semibold text-ink" no-translate="true">
       {entity.title}
-    </span>
+    </h1>
     {showDocumentViewMode ? (
       <div className="shrink-0">
         <DocumentViewModeSelect />

--- a/app/react/V2/Routes/Entity/Components/shared/EntitySeo.tsx
+++ b/app/react/V2/Routes/Entity/Components/shared/EntitySeo.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo } from 'react';
+import { Helmet } from 'react-helmet';
+import { useAtomValue } from 'jotai';
+import { localeAtom, templatesAtom } from '#V2/atoms/index.js';
+import { Entity } from '#V2/api/entities/types.js';
+import type { MetadataProperty } from '#V2/formatters/types.js';
+import { useFormatMetadata } from '#V2/Components/Metadata/hooks/useFormatMetadata.js';
+
+type EntitySeoProps = {
+  entity: Entity;
+};
+
+const formatPropertyValues = (property: MetadataProperty): string => {
+  switch (property.type) {
+    case 'text':
+    case 'generatedid':
+    case 'numeric':
+    case 'markdown':
+      return property.values
+        .map(item => item.value)
+        .filter(Boolean)
+        .join(', ');
+    case 'select':
+    case 'multiselect':
+      return property.values
+        .map(item => item.translatedLabel || item.label || item.value)
+        .filter(Boolean)
+        .join(', ');
+    case 'link':
+      return property.values
+        .map(item => item.label || item.value)
+        .filter(Boolean)
+        .join(', ');
+    case 'relationship':
+      if (property.mode === 'related') {
+        return property.values
+          .map(item => item.title)
+          .filter(Boolean)
+          .join(', ');
+      }
+      return '';
+    default:
+      return '';
+  }
+};
+
+const relatedEntityTitles = (entity: Entity, limit = 30): string[] => {
+  const titles = new Set<string>();
+  for (const relation of entity.relations || []) {
+    const title = relation.entityData?.title;
+    if (title && relation.entity !== entity.sharedId) {
+      titles.add(title);
+      if (titles.size >= limit) break;
+    }
+  }
+  return [...titles];
+};
+
+const EntitySeo = ({ entity }: EntitySeoProps) => {
+  const locale = useAtomValue(localeAtom);
+  const templates = useAtomValue(templatesAtom);
+  const { metadata, entityTemplate } = useFormatMetadata(entity, templates, {
+    groupGeolocationProperties: true,
+  });
+
+  const summaryRows = useMemo(
+    () =>
+      metadata
+        .map(property => ({
+          label: property.label,
+          value: formatPropertyValues(property),
+        }))
+        .filter(row => row.value),
+    [metadata]
+  );
+
+  const relationTitles = useMemo(() => relatedEntityTitles(entity), [entity]);
+
+  const description = useMemo(() => {
+    const parts = [entity.title];
+    if (entityTemplate?.name) {
+      parts.push(entityTemplate.name);
+    }
+    const preview = summaryRows
+      .slice(0, 3)
+      .map(row => `${row.label}: ${row.value}`)
+      .join('. ');
+    if (preview) {
+      parts.push(preview);
+    }
+    return parts.join(' — ').slice(0, 160);
+  }, [entity.title, entityTemplate?.name, summaryRows]);
+
+  const canonicalPath = `/${locale}/entityv2/${entity.sharedId}`;
+
+  const jsonLd = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'CreativeWork',
+      name: entity.title,
+      description,
+      inLanguage: entity.language || locale,
+      ...(relationTitles.length > 0 && {
+        mentions: relationTitles.map(name => ({ '@type': 'Thing', name })),
+      }),
+    }),
+    [entity.title, entity.language, locale, description, relationTitles]
+  );
+
+  return (
+    <>
+      <Helmet>
+        <title>{entity.title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={canonicalPath} />
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Helmet>
+      <aside className="sr-only" data-testid="entity-seo-summary" aria-hidden="true">
+        <h1>{entity.title}</h1>
+        {entityTemplate?.name ? <p>{entityTemplate.name}</p> : null}
+        {summaryRows.length > 0 ? (
+          <dl>
+            {summaryRows.map(row => (
+              <div key={row.label}>
+                <dt>{row.label}</dt>
+                <dd>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+        {relationTitles.length > 0 ? (
+          <ul>
+            {relationTitles.map(title => (
+              <li key={title}>{title}</li>
+            ))}
+          </ul>
+        ) : null}
+      </aside>
+    </>
+  );
+};
+
+export { EntitySeo };

--- a/app/react/V2/Routes/Entity/Components/shared/EntitySeo.tsx
+++ b/app/react/V2/Routes/Entity/Components/shared/EntitySeo.tsx
@@ -116,7 +116,6 @@ const EntitySeo = ({ entity }: EntitySeoProps) => {
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Helmet>
       <aside className="sr-only" data-testid="entity-seo-summary" aria-hidden="true">
-        <h1>{entity.title}</h1>
         {entityTemplate?.name ? <p>{entityTemplate.name}</p> : null}
         {summaryRows.length > 0 ? (
           <dl>

--- a/app/react/V2/Routes/Entity/Components/shared/index.ts
+++ b/app/react/V2/Routes/Entity/Components/shared/index.ts
@@ -1,5 +1,6 @@
 export { TabLabel } from './TabLabel.js';
 export { EntityMainPaneHeader } from './EntityMainPaneHeader.js';
 export { EntityLanguageBar } from './EntityLanguageBar.js';
+export { EntitySeo } from './EntitySeo.js';
 export { FileList } from './FileList.js';
 export { OCRButton } from './OCRButton.js';

--- a/app/react/V2/Routes/Entity/Entity.tsx
+++ b/app/react/V2/Routes/Entity/Entity.tsx
@@ -7,12 +7,12 @@ import { PaneLayout } from '#V2/Components/Layouts/PaneLayout.js';
 import { BlockDirtyNavigation, useTabGroup } from '#V2/Components/UI/index.js';
 import { ThemeProvider } from '#V2/theme/ThemeProvider.js';
 import { localeAtom } from '#V2/atoms/index.js';
-import { SnippetsSearchResponse } from '#V2/api/types.js';
 import {
   SearchHintsModal,
   EntityScopedProvider,
   EntityFilesProvider,
   EntityMainPaneHeader,
+  EntitySeo,
   FilesDeleteConfirmationModal,
   AddFileModal,
   useEntityFiles,
@@ -33,10 +33,6 @@ import {
 import { useEntityViewTabs } from './Tabs/hooks/useEntityViewTabs.js';
 import { LoaderResponse } from './types.js';
 
-type EntityViewProps = {
-  searchResults?: SnippetsSearchResponse;
-};
-
 const EntityCreateRelationshipModal = () => {
   const { mainDocument } = useEntityLanguage();
   return <CreateRelationshipModal mainDocument={mainDocument} />;
@@ -47,7 +43,7 @@ const EntityFilesFromEntity = ({ children }: { children: React.ReactNode }) => {
   return <EntityFilesProvider entity={entity}>{children}</EntityFilesProvider>;
 };
 
-const EntityView = ({ searchResults }: EntityViewProps) => {
+const EntityView = () => {
   const entity = useEntityScopedEntity();
   const { mainDocument, pagePlaintext, isRtl } = useEntityLanguage();
   useResetRelationshipsOnDocumentChange();
@@ -66,7 +62,6 @@ const EntityView = ({ searchResults }: EntityViewProps) => {
     entity,
     hasMainDocument,
     mainDocumentId: mainDocument?._id,
-    searchResults,
     filesSideTabs,
   });
   const { activeTabId: atomMainTabId } = useTabGroup('entity-main');
@@ -80,6 +75,7 @@ const EntityView = ({ searchResults }: EntityViewProps) => {
 
   return (
     <>
+      <EntitySeo entity={entity} />
       <FilesDeleteConfirmationModal />
       <AddFileModal />
       <BlockDirtyNavigation when={isEditing && (isDirty || isSaving)} onDiscard={cancelEdit} />
@@ -141,7 +137,6 @@ const Entity = () => {
   const entity = loaderData?.entity;
   const mainDocument = loaderData?.mainDocument;
   const pagePlaintext = loaderData?.pagePlaintext;
-  const searchResults = loaderData?.searchResults;
   const language = entity?.language || locale;
 
   if (!entity) {
@@ -158,7 +153,7 @@ const Entity = () => {
         pagePlaintext={pagePlaintext}
       >
         <EntityFilesFromEntity>
-          <EntityView searchResults={searchResults} />
+          <EntityView />
         </EntityFilesFromEntity>
         <SearchHintsModal />
         <EntityCreateRelationshipModal />

--- a/app/react/V2/Routes/Entity/EntityLoaderCache.ts
+++ b/app/react/V2/Routes/Entity/EntityLoaderCache.ts
@@ -145,24 +145,22 @@ class EntityLoaderCache {
     }
   }
 
-  getPlaintext(documentId: string, page: number): string | undefined {
+  getPlaintext(documentId: string): string | undefined {
     if (!isClient) {
       return undefined;
     }
 
-    const key = `${documentId}:${page}`;
-    return getCachedItem(this.plaintextCache, key, this.ttls.plaintext);
+    return getCachedItem(this.plaintextCache, documentId, this.ttls.plaintext);
   }
 
-  setPlaintext(documentId: string, page: number, text: string): void {
+  setPlaintext(documentId: string, text: string): void {
     if (isClient) {
-      const key = `${documentId}:${page}`;
-      setCachedItem(this.plaintextCache, key, text, this.limits.plaintext);
+      setCachedItem(this.plaintextCache, documentId, text, this.limits.plaintext);
     }
   }
 
   invalidatePlaintext(documentId: string): void {
-    invalidateByPrefix(this.plaintextCache, `${documentId}:`);
+    this.plaintextCache.delete(documentId);
   }
 
   getSearchResults(

--- a/app/react/V2/Routes/Entity/Tabs/footers/DocumentTabFooter.tsx
+++ b/app/react/V2/Routes/Entity/Tabs/footers/DocumentTabFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { t, Translate } from '#app/I18N/index.js';
+import { Translate } from '#app/I18N/index.js';
 import { NeedAuthorization } from '#V2/Components/UI/index.js';
 import type { FileType } from '#V2/api/entities/types.js';
 import { OCRButton } from '#V2/Routes/Entity/Components/shared/index.js';
@@ -11,15 +11,8 @@ type DocumentTabFooterProps = {
 };
 
 const DocumentTabFooter = ({ mainDocument }: DocumentTabFooterProps) => {
-  const {
-    pageNumber,
-    totalPages,
-    prevPage,
-    nextPage,
-    ocrServiceEnabled,
-    getPageSearchParams,
-    handlePageNavigation,
-  } = useDocumentPdfView({ mainDocument });
+  const { pageNumber, totalPages, nextPage, ocrServiceEnabled, isRaw, handlePageNavigation } =
+    useDocumentPdfView({ mainDocument });
 
   return (
     <EntityTabFooter>
@@ -31,35 +24,29 @@ const DocumentTabFooter = ({ mainDocument }: DocumentTabFooterProps) => {
             </NeedAuthorization>
           ) : null}
         </div>
-        <div className="flex items-center gap-2 justify-self-end text-tab font-medium">
-          <button
-            type="button"
-            onClick={() => handlePageNavigation('prev')}
-            disabled={pageNumber <= 1}
-            className="text-ink hover:text-ink-secondary disabled:text-ink-muted disabled:hover:text-ink-muted"
-          >
-            <Translate>Previous</Translate>
-          </button>
-          <div className="rounded bg-warm px-2 py-1 text-ink">
-            {pageNumber} / {totalPages}
+        {!isRaw ? (
+          <div className="flex items-center gap-2 justify-self-end text-tab font-medium">
+            <button
+              type="button"
+              onClick={() => handlePageNavigation('prev')}
+              disabled={pageNumber <= 1}
+              className="text-ink hover:text-ink-secondary disabled:text-ink-muted disabled:hover:text-ink-muted"
+            >
+              <Translate>Previous</Translate>
+            </button>
+            <div className="rounded bg-warm px-2 py-1 text-ink">
+              {pageNumber} / {totalPages}
+            </div>
+            <button
+              type="button"
+              onClick={() => handlePageNavigation('next')}
+              disabled={totalPages ? nextPage > totalPages : false}
+              className="text-ink hover:text-ink-secondary disabled:text-ink-muted disabled:hover:text-ink-muted"
+            >
+              <Translate>Next</Translate>
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={() => handlePageNavigation('next')}
-            disabled={totalPages ? nextPage > totalPages : false}
-            className="text-ink hover:text-ink-secondary disabled:text-ink-muted disabled:hover:text-ink-muted"
-          >
-            <Translate>Next</Translate>
-          </button>
-        </div>
-        <div className="sr-only">
-          <a href={`?${getPageSearchParams(prevPage).toString()}`} rel="prev">
-            {t('System', 'Previous', null, false)}
-          </a>
-          <a href={`?${getPageSearchParams(nextPage).toString()}`} rel="next">
-            {t('System', 'Next', null, false)}
-          </a>
-        </div>
+        ) : null}
       </div>
     </EntityTabFooter>
   );

--- a/app/react/V2/Routes/Entity/Tabs/hooks/resolveSideTabId.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/resolveSideTabId.ts
@@ -1,17 +1,13 @@
-import { SIDE_TAB, isValidSideTab, type SideTabId } from '../tabIds.js';
+import { isValidSideTab, type SideTabId } from '../tabIds.js';
 
 type SideTabButton = { id: string };
 
 const resolveSideTabId = (
   sideFromUrl: string | null,
-  sideButtons: SideTabButton[],
-  preferSearch: boolean
+  sideButtons: SideTabButton[]
 ): SideTabId | undefined => {
   if (isValidSideTab(sideFromUrl) && sideButtons.some(button => button.id === sideFromUrl)) {
     return sideFromUrl;
-  }
-  if (preferSearch && sideButtons.some(button => button.id === SIDE_TAB.SEARCH)) {
-    return SIDE_TAB.SEARCH;
   }
   const firstId = sideButtons[0]?.id;
   return firstId && isValidSideTab(firstId) ? firstId : undefined;

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useDocumentPdfPage.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useDocumentPdfPage.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router';
 import { isClient } from '#app/utils/index.js';
 import type { PDFControls } from '#V2/Components/PDFViewer/index.js';
 import type { FileType } from '#V2/api/entities/types.js';
+import { useEntityHashParams, useUpdateEntityUrl } from '../../entityUrlState.js';
 import { PAGE_PARAM, VIEW_MODE_PARAM } from '../../urlParams.js';
 
 type UseDocumentPdfPageParams = {
@@ -16,83 +16,92 @@ function useDocumentPdfPage({
   mainPdfController,
   setPdfController,
 }: UseDocumentPdfPageParams) {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const hashParams = useEntityHashParams();
+  const updateEntityUrl = useUpdateEntityUrl();
   const [ready, setReady] = useState(false);
-  const page = searchParams.get(PAGE_PARAM) || '1';
+  const page = hashParams.get(PAGE_PARAM) || '1';
   const pageNumber = Number.parseInt(page || '1', 10);
-  const initialPage = useRef<number>(pageNumber);
+  const targetPageRef = useRef(pageNumber);
+  const pageSyncEnabledRef = useRef(false);
+  const unlockTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const documentIdRef = useRef(mainDocument._id);
-  const isRaw = !isClient || !ready || searchParams.get(VIEW_MODE_PARAM) === 'true';
+  const isRaw = !isClient || !ready || hashParams.get(VIEW_MODE_PARAM) === 'true';
 
   useEffect(() => {
     setReady(true);
   }, []);
+
+  useEffect(
+    () => () => {
+      if (unlockTimeoutRef.current) clearTimeout(unlockTimeoutRef.current);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (pageSyncEnabledRef.current) {
+      targetPageRef.current = pageNumber;
+    }
+  }, [pageNumber]);
 
   useEffect(() => {
     if (documentIdRef.current === mainDocument._id) {
       return;
     }
     documentIdRef.current = mainDocument._id;
-    initialPage.current = 1;
+    targetPageRef.current = 1;
+    pageSyncEnabledRef.current = false;
     setPdfController(null);
-    if (searchParams.get(PAGE_PARAM) === '1') {
+    if (hashParams.get(PAGE_PARAM) === '1' || !hashParams.get(PAGE_PARAM)) {
       return;
     }
-    setSearchParams(
-      prev => {
-        const next = new URLSearchParams(prev);
+    updateEntityUrl({
+      hash: next => {
         next.set(PAGE_PARAM, '1');
-        return next;
       },
-      { replace: true, preventScrollReset: true }
-    );
-  }, [mainDocument._id, searchParams, setPdfController, setSearchParams]);
-
-  const getPageSearchParams = useCallback(
-    (pageParam: number | string) => {
-      const next = new URLSearchParams(searchParams.toString());
-      next.set(PAGE_PARAM, String(pageParam));
-      return next;
-    },
-    [searchParams]
-  );
+    });
+  }, [mainDocument._id, hashParams, setPdfController, updateEntityUrl]);
 
   const updatePageParam = useCallback(
     (pageParam: number | string) => {
-      setSearchParams(
-        prev => {
-          const next = new URLSearchParams(prev);
+      updateEntityUrl({
+        hash: next => {
           next.set(PAGE_PARAM, String(pageParam));
-          return next;
         },
-        { replace: true, preventScrollReset: true }
-      );
+      });
     },
-    [setSearchParams]
+    [updateEntityUrl]
   );
 
   const handlePageNavigation = useCallback(
     (direction: 'prev' | 'next') => {
+      if (isRaw) {
+        return;
+      }
       const targetPage =
         direction === 'prev'
           ? Math.max(1, pageNumber - 1)
           : Math.min(pageNumber + 1, mainDocument?.totalPages || 0);
-      if (isRaw) {
-        updatePageParam(targetPage);
-      } else if (mainPdfController) {
-        updatePageParam(targetPage);
-        mainPdfController.goToPage(targetPage);
-      } else {
-        updatePageParam(targetPage);
-      }
+      targetPageRef.current = targetPage;
+      pageSyncEnabledRef.current = true;
+      updatePageParam(targetPage);
+      mainPdfController?.goToPage(targetPage);
     },
     [mainDocument?.totalPages, isRaw, pageNumber, updatePageParam, mainPdfController]
   );
 
   const handlePageChange = useCallback(
     (newPageNumber: number) => {
-      if (newPageNumber !== initialPage.current) {
-        initialPage.current = newPageNumber;
+      if (!pageSyncEnabledRef.current) {
+        // Unlock once the restored page is visible; ignore earlier intersection noise.
+        if (newPageNumber === targetPageRef.current) {
+          pageSyncEnabledRef.current = true;
+          if (unlockTimeoutRef.current) clearTimeout(unlockTimeoutRef.current);
+        }
+        return;
+      }
+      if (newPageNumber !== targetPageRef.current) {
+        targetPageRef.current = newPageNumber;
         updatePageParam(newPageNumber);
       }
     },
@@ -101,11 +110,17 @@ function useDocumentPdfPage({
 
   const onPdfReady = useCallback(
     (controls: PDFControls) => {
-      const targetPage = initialPage.current || 1;
+      const targetPage = targetPageRef.current || 1;
       setPdfController(controls);
-      if (targetPage !== 1) {
-        controls.goToPage(targetPage);
+      if (targetPage === 1) {
+        pageSyncEnabledRef.current = true;
+        return;
       }
+      controls.goToPage(targetPage);
+      if (unlockTimeoutRef.current) clearTimeout(unlockTimeoutRef.current);
+      unlockTimeoutRef.current = setTimeout(() => {
+        pageSyncEnabledRef.current = true;
+      }, 400);
     },
     [setPdfController]
   );
@@ -124,7 +139,6 @@ function useDocumentPdfPage({
     prevPage,
     nextPage,
     isRaw,
-    getPageSearchParams,
     handlePageNavigation,
     handlePageChange,
     onPdfReady,

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useDocumentPdfTextHandlers.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useDocumentPdfTextHandlers.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useSearchParams } from 'react-router';
 import { useAtomValue } from 'jotai';
 import type { TextSelection } from '@huridocs/react-text-selection-handler';
 import { settingsAtom, userAtom } from '#V2/atoms/index.js';
@@ -10,12 +9,13 @@ import {
   useRelationshipsActions,
   useTocActions,
 } from '#V2/Routes/Entity/Components/context/index.js';
+import { useUpdateEntityUrl } from '../../entityUrlState.js';
 import { SIDE_TAB_PARAM } from '../../urlParams.js';
 import { SIDE_TAB } from '../tabIds.js';
 import { useEntityTabNavigation } from './useEntityTabNavigation.js';
 
 function useDocumentPdfTextHandlers() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const updateEntityUrl = useUpdateEntityUrl();
   const { ocrServiceEnabled } = useAtomValue(settingsAtom);
   const user = useAtomValue(userAtom);
   const [userIsAdminOrEditor, setUserIsAdminOrEditor] = useState(false);
@@ -65,11 +65,13 @@ function useDocumentPdfTextHandlers() {
       const tocEntry = convertTextSelectionToTocEntry(selection);
       addEntry(tocEntry);
       selectSideTab(SIDE_TAB.TOC);
-      const next = new URLSearchParams(searchParams.toString());
-      next.set(SIDE_TAB_PARAM, SIDE_TAB.TOC);
-      setSearchParams(next, { replace: true });
+      updateEntityUrl({
+        hash: next => {
+          next.set(SIDE_TAB_PARAM, SIDE_TAB.TOC);
+        },
+      });
     },
-    [addEntry, searchParams, selectSideTab, setSearchParams]
+    [addEntry, selectSideTab, updateEntityUrl]
   );
 
   return {

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useEntityTabChangeHandlers.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useEntityTabChangeHandlers.ts
@@ -1,11 +1,9 @@
 import { useCallback } from 'react';
-import { useSearchParams } from 'react-router';
 import { Entity as EntityType } from '#V2/api/entities/types.js';
+import { useUpdateEntityUrl } from '../../entityUrlState.js';
 import { MAIN_TAB_PARAM, SIDE_TAB_PARAM } from '../../urlParams.js';
 import { getSideTabButtons, type FilesSideTabsOptions } from '../sideTabSets.js';
-import { isValidMainTab, isValidSideTab, type MainTabId } from '../tabIds.js';
-
-type SetSearchParams = ReturnType<typeof useSearchParams>[1];
+import { MAIN_TAB, isValidMainTab, isValidSideTab, type MainTabId } from '../tabIds.js';
 
 type Params = {
   entity: EntityType;
@@ -13,7 +11,7 @@ type Params = {
   mainDocumentId?: string;
   filesSideTabs: FilesSideTabsOptions;
   activeMainTab: MainTabId;
-  setSearchParams: SetSearchParams;
+  hashParams: URLSearchParams;
 };
 
 const useEntityTabChangeHandlers = ({
@@ -22,52 +20,68 @@ const useEntityTabChangeHandlers = ({
   mainDocumentId,
   filesSideTabs,
   activeMainTab,
-  setSearchParams,
+  hashParams,
 }: Params) => {
+  const updateEntityUrl = useUpdateEntityUrl();
+
   const onMainTabChange = useCallback(
     (selectedMainTab: string) => {
       if (!isValidMainTab(selectedMainTab)) return;
-      setSearchParams(
-        prev => {
-          const next = new URLSearchParams(prev);
-          if (selectedMainTab !== activeMainTab) {
-            const nextSideButtons = getSideTabButtons({
-              activeMainTab: selectedMainTab,
-              entity,
-              hasMainDocument,
-              mainDocumentId,
-              filesSideTabs,
-            });
-            const rawS = next.get(SIDE_TAB_PARAM);
-            const sStillValid =
-              Boolean(rawS) &&
-              isValidSideTab(rawS) &&
-              nextSideButtons.some(button => button.id === rawS);
-            if (!sStillValid) next.delete(SIDE_TAB_PARAM);
+
+      updateEntityUrl({
+        search: next => {
+          if (selectedMainTab === MAIN_TAB.DOCUMENT && hasMainDocument) {
+            next.delete(MAIN_TAB_PARAM);
+          } else {
+            next.set(MAIN_TAB_PARAM, selectedMainTab);
           }
-          next.set(MAIN_TAB_PARAM, selectedMainTab);
-          return next;
         },
-        { replace: true, preventScrollReset: true }
-      );
+        hash: next => {
+          if (selectedMainTab === activeMainTab) return;
+          const nextSideButtons = getSideTabButtons({
+            activeMainTab: selectedMainTab,
+            entity,
+            hasMainDocument,
+            mainDocumentId,
+            filesSideTabs,
+          });
+          const rawS = hashParams.get(SIDE_TAB_PARAM);
+          const sStillValid =
+            Boolean(rawS) &&
+            isValidSideTab(rawS) &&
+            nextSideButtons.some(button => button.id === rawS);
+          if (!sStillValid) {
+            next.delete(SIDE_TAB_PARAM);
+          }
+        },
+      });
     },
-    [activeMainTab, setSearchParams, entity, hasMainDocument, mainDocumentId, filesSideTabs]
+    [
+      activeMainTab,
+      updateEntityUrl,
+      hashParams,
+      entity,
+      hasMainDocument,
+      mainDocumentId,
+      filesSideTabs,
+    ]
   );
 
   const onSideTabChange = useCallback(
     (selectedSideTab: string) => {
       if (!isValidSideTab(selectedSideTab)) return;
-      setSearchParams(
-        prev => {
-          const next = new URLSearchParams(prev);
-          next.set(SIDE_TAB_PARAM, selectedSideTab);
-          if (!next.get(MAIN_TAB_PARAM)) next.set(MAIN_TAB_PARAM, activeMainTab);
-          return next;
+      updateEntityUrl({
+        search: next => {
+          if (!next.get(MAIN_TAB_PARAM) && activeMainTab !== MAIN_TAB.DOCUMENT) {
+            next.set(MAIN_TAB_PARAM, activeMainTab);
+          }
         },
-        { replace: true, preventScrollReset: true }
-      );
+        hash: next => {
+          next.set(SIDE_TAB_PARAM, selectedSideTab);
+        },
+      });
     },
-    [activeMainTab, setSearchParams]
+    [activeMainTab, updateEntityUrl]
   );
 
   return { onMainTabChange, onSideTabChange };

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useEntityTabNavigation.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useEntityTabNavigation.ts
@@ -1,11 +1,13 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { useTabGroup } from '#V2/Components/UI/index.js';
+import { useUpdateEntityUrl } from '../../entityUrlState.js';
 import { MAIN_TAB_PARAM, SIDE_TAB_PARAM } from '../../urlParams.js';
 import { MAIN_TAB, SIDE_TAB, isValidMainTab } from '../tabIds.js';
 
 const useEntityTabNavigation = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
+  const updateEntityUrl = useUpdateEntityUrl();
   const { selectTab: selectSideTab } = useTabGroup('entity-side');
 
   const activeMainTab = useMemo(() => {
@@ -20,18 +22,22 @@ const useEntityTabNavigation = () => {
   const focusRelationshipsPanel = useCallback(() => {
     if (relationshipsOnMain) return;
     selectSideTab(SIDE_TAB.RELATIONSHIPS);
-    const next = new URLSearchParams(searchParams.toString());
-    next.set(SIDE_TAB_PARAM, SIDE_TAB.RELATIONSHIPS);
-    setSearchParams(next, { replace: true, preventScrollReset: true });
-  }, [relationshipsOnMain, searchParams, selectSideTab, setSearchParams]);
+    updateEntityUrl({
+      hash: next => {
+        next.set(SIDE_TAB_PARAM, SIDE_TAB.RELATIONSHIPS);
+      },
+    });
+  }, [relationshipsOnMain, selectSideTab, updateEntityUrl]);
 
   const focusDocumentPanel = useCallback(() => {
     if (documentOnMain) return;
     selectSideTab(SIDE_TAB.DOCUMENT);
-    const next = new URLSearchParams(searchParams.toString());
-    next.set(SIDE_TAB_PARAM, SIDE_TAB.DOCUMENT);
-    setSearchParams(next, { replace: true, preventScrollReset: true });
-  }, [documentOnMain, searchParams, selectSideTab, setSearchParams]);
+    updateEntityUrl({
+      hash: next => {
+        next.set(SIDE_TAB_PARAM, SIDE_TAB.DOCUMENT);
+      },
+    });
+  }, [documentOnMain, selectSideTab, updateEntityUrl]);
 
   return {
     activeMainTab,

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useEntityTabUrlSync.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useEntityTabUrlSync.ts
@@ -1,13 +1,11 @@
 import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router';
 import { mergeTabGroup, type TabGroupsState } from '#V2/Components/UI/Tabs/tabsAtoms.js';
 import { Entity as EntityType } from '#V2/api/entities/types.js';
+import { useUpdateEntityUrl } from '../../entityUrlState.js';
 import { MAIN_TAB_PARAM, SIDE_TAB_PARAM } from '../../urlParams.js';
 import { getSideTabButtons, type FilesSideTabsOptions } from '../sideTabSets.js';
-import { isValidMainTab, isValidSideTab, type MainTabId } from '../tabIds.js';
+import { MAIN_TAB, isValidMainTab, isValidSideTab, type MainTabId } from '../tabIds.js';
 import { resolveSideTabId, type SideTabButton } from './resolveSideTabId.js';
-
-type SetSearchParams = ReturnType<typeof useSearchParams>[1];
 
 type UseEntityTabUrlSyncParams = {
   entity: EntityType;
@@ -17,9 +15,8 @@ type UseEntityTabUrlSyncParams = {
   activeMainTab: MainTabId;
   mainTabIds: Set<MainTabId>;
   sideTabButtons: SideTabButton[];
-  preferSearch: boolean;
   searchParams: URLSearchParams;
-  setSearchParams: SetSearchParams;
+  hashParams: URLSearchParams;
   setTabGroups: (updater: (prev: TabGroupsState) => TabGroupsState) => void;
 };
 
@@ -31,14 +28,14 @@ const useEntityTabUrlSync = ({
   activeMainTab,
   mainTabIds,
   sideTabButtons,
-  preferSearch,
   searchParams,
-  setSearchParams,
+  hashParams,
   setTabGroups,
 }: UseEntityTabUrlSyncParams) => {
+  const updateEntityUrl = useUpdateEntityUrl();
   const previousSharedId = useRef(entity.sharedId);
   const mainTabParam = searchParams.get(MAIN_TAB_PARAM);
-  const sideTabParam = searchParams.get(SIDE_TAB_PARAM);
+  const sideTabParam = hashParams.get(SIDE_TAB_PARAM);
 
   useEffect(() => {
     if (previousSharedId.current === entity.sharedId) return;
@@ -50,8 +47,8 @@ const useEntityTabUrlSync = ({
   }, [entity.sharedId, setTabGroups]);
 
   useEffect(() => {
-    const syncTabsFromParams = (params: URLSearchParams) => {
-      const mainFromUrl = params.get(MAIN_TAB_PARAM);
+    const syncTabsFromParams = (mainParams: URLSearchParams, sideParams: URLSearchParams) => {
+      const mainFromUrl = mainParams.get(MAIN_TAB_PARAM);
       const mainId =
         isValidMainTab(mainFromUrl) && mainTabIds.has(mainFromUrl) ? mainFromUrl : activeMainTab;
       const sideButtons = getSideTabButtons({
@@ -61,7 +58,7 @@ const useEntityTabUrlSync = ({
         mainDocumentId,
         filesSideTabs,
       });
-      const sideId = resolveSideTabId(params.get(SIDE_TAB_PARAM), sideButtons, preferSearch);
+      const sideId = resolveSideTabId(sideParams.get(SIDE_TAB_PARAM), sideButtons);
 
       setTabGroups(prev => {
         let next = mergeTabGroup(prev, 'entity-main', { activeTabId: mainId });
@@ -72,43 +69,50 @@ const useEntityTabUrlSync = ({
       });
     };
 
-    syncTabsFromParams(searchParams);
-    const onPopState = () => {
-      syncTabsFromParams(new URLSearchParams(window.location.search));
-    };
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
+    syncTabsFromParams(searchParams, hashParams);
   }, [
     entity,
     activeMainTab,
     mainTabParam,
     sideTabParam,
     searchParams,
+    hashParams,
     hasMainDocument,
     mainDocumentId,
     filesSideTabs,
     mainTabIds,
-    preferSearch,
     setTabGroups,
   ]);
 
   useEffect(() => {
-    const raw = searchParams.get(SIDE_TAB_PARAM);
+    const raw = hashParams.get(SIDE_TAB_PARAM);
     if (!raw || !isValidSideTab(raw)) return;
     if (sideTabButtons.some(button => button.id === raw)) return;
-    const next = new URLSearchParams(searchParams.toString());
-    next.delete(SIDE_TAB_PARAM);
-    setSearchParams(next, { replace: true, preventScrollReset: true });
-  }, [searchParams, activeMainTab, sideTabButtons, setSearchParams]);
+    updateEntityUrl({
+      hash: next => {
+        next.delete(SIDE_TAB_PARAM);
+      },
+    });
+  }, [hashParams, activeMainTab, sideTabButtons, updateEntityUrl]);
 
   useEffect(() => {
     const raw = searchParams.get(MAIN_TAB_PARAM);
     if (!raw || !isValidMainTab(raw)) return;
+    if (raw === MAIN_TAB.DOCUMENT && hasMainDocument) {
+      updateEntityUrl({
+        search: next => {
+          next.delete(MAIN_TAB_PARAM);
+        },
+      });
+      return;
+    }
     if (mainTabIds.has(raw)) return;
-    const next = new URLSearchParams(searchParams.toString());
-    next.delete(MAIN_TAB_PARAM);
-    setSearchParams(next, { replace: true, preventScrollReset: true });
-  }, [searchParams, mainTabIds, setSearchParams]);
+    updateEntityUrl({
+      search: next => {
+        next.delete(MAIN_TAB_PARAM);
+      },
+    });
+  }, [searchParams, mainTabIds, hasMainDocument, updateEntityUrl]);
 };
 
 export { useEntityTabUrlSync };

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useEntityViewTabs.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useEntityViewTabs.ts
@@ -2,7 +2,7 @@ import { useSetAtom } from 'jotai';
 import { useSearchParams } from 'react-router';
 import { tabGroupsAtom } from '#V2/Components/UI/Tabs/tabsAtoms.js';
 import { Entity as EntityType } from '#V2/api/entities/types.js';
-import { SnippetsSearchResponse } from '#V2/api/types.js';
+import { useEntityHashParams } from '../../entityUrlState.js';
 import type { FilesSideTabsOptions } from '../sideTabSets.js';
 import { useEntityTabChangeHandlers } from './useEntityTabChangeHandlers.js';
 import { useEntityTabUrlSync } from './useEntityTabUrlSync.js';
@@ -12,27 +12,28 @@ type UseEntityViewTabsParams = {
   entity: EntityType;
   hasMainDocument: boolean;
   mainDocumentId?: string;
-  searchResults?: SnippetsSearchResponse;
   filesSideTabs: FilesSideTabsOptions;
 };
 
 const useEntityViewTabs = (params: UseEntityViewTabsParams) => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
+  const hashParams = useEntityHashParams();
   const setTabGroups = useSetAtom(tabGroupsAtom);
-  const tabs = useResolvedEntityTabs({ ...params, searchParams });
+
+  const tabs = useResolvedEntityTabs({ ...params, searchParams, hashParams });
 
   useEntityTabUrlSync({
     ...params,
     ...tabs,
     searchParams,
-    setSearchParams,
+    hashParams,
     setTabGroups,
   });
 
   const handlers = useEntityTabChangeHandlers({
     ...params,
     activeMainTab: tabs.activeMainTab,
-    setSearchParams,
+    hashParams,
   });
 
   return {

--- a/app/react/V2/Routes/Entity/Tabs/hooks/useResolvedEntityTabs.ts
+++ b/app/react/V2/Routes/Entity/Tabs/hooks/useResolvedEntityTabs.ts
@@ -1,6 +1,5 @@
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { Entity as EntityType } from '#V2/api/entities/types.js';
-import { SnippetsSearchResponse } from '#V2/api/types.js';
 import { MAIN_TAB_PARAM, SIDE_TAB_PARAM } from '../../urlParams.js';
 import { getSideTabButtons, type FilesSideTabsOptions } from '../sideTabSets.js';
 import { MAIN_TAB, isValidMainTab, type MainTabId } from '../tabIds.js';
@@ -10,22 +9,19 @@ type Params = {
   entity: EntityType;
   hasMainDocument: boolean;
   mainDocumentId?: string;
-  searchResults?: SnippetsSearchResponse;
   filesSideTabs: FilesSideTabsOptions;
   searchParams: URLSearchParams;
+  hashParams: URLSearchParams;
 };
 
 const useResolvedEntityTabs = ({
   entity,
   hasMainDocument,
   mainDocumentId,
-  searchResults,
   filesSideTabs,
   searchParams,
+  hashParams,
 }: Params) => {
-  const initialSearchResults = useRef(searchResults);
-  const preferSearch = Boolean(initialSearchResults.current);
-
   const mainTabIds = useMemo(() => {
     const ids = new Set<MainTabId>([MAIN_TAB.METADATA, MAIN_TAB.RELATIONSHIPS, MAIN_TAB.FILES]);
     if (hasMainDocument) ids.add(MAIN_TAB.DOCUMENT);
@@ -51,11 +47,11 @@ const useResolvedEntityTabs = ({
   );
 
   const activeSideTab = useMemo(
-    () => resolveSideTabId(searchParams.get(SIDE_TAB_PARAM), sideTabButtons, preferSearch),
-    [searchParams, sideTabButtons, preferSearch]
+    () => resolveSideTabId(hashParams.get(SIDE_TAB_PARAM), sideTabButtons),
+    [hashParams, sideTabButtons]
   );
 
-  return { mainTabIds, activeMainTab, sideTabButtons, activeSideTab, preferSearch };
+  return { mainTabIds, activeMainTab, sideTabButtons, activeSideTab };
 };
 
 export { useResolvedEntityTabs };

--- a/app/react/V2/Routes/Entity/Tabs/tabsContent/DocumentTab.tsx
+++ b/app/react/V2/Routes/Entity/Tabs/tabsContent/DocumentTab.tsx
@@ -139,9 +139,7 @@ const DocumentTab = ({
             />
           ) : null}
         </div>
-        <div
-          className={`h-full min-h-0 overflow-auto rounded-md bg-warm ${isRaw ? 'block' : 'hidden'}`}
-        >
+        <div className={`h-full min-h-0 overflow-auto ${isRaw ? 'block' : 'hidden'}`}>
           <PlainText text={pagePlaintext || ''} dir={isRtl ? 'rtl' : 'ltr'} />
         </div>
       </div>

--- a/app/react/V2/Routes/Entity/entityUrlState.ts
+++ b/app/react/V2/Routes/Entity/entityUrlState.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
+type UpdateEntityUrlOptions = {
+  replace?: boolean;
+  search?: (params: URLSearchParams) => void;
+  hash?: (params: URLSearchParams) => void;
+};
+
+const parseEntityHash = (hash: string = ''): URLSearchParams => {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  return new URLSearchParams(raw);
+};
+
+const serializeEntityHash = (params: URLSearchParams): string => {
+  const str = params.toString();
+  return str ? `#${str}` : '';
+};
+
+const useEntityHashParams = () => {
+  const { hash } = useLocation();
+  return useMemo(() => parseEntityHash(hash), [hash]);
+};
+
+const useUpdateEntityUrl = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (options: UpdateEntityUrlOptions) => {
+      const nextSearch = new URLSearchParams(
+        location.search.startsWith('?') ? location.search.slice(1) : location.search
+      );
+      const nextHash = parseEntityHash(location.hash);
+      options.search?.(nextSearch);
+      options.hash?.(nextHash);
+      const search = nextSearch.toString();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- fire-and-forget URL sync
+      navigate(
+        {
+          pathname: location.pathname,
+          search: search ? `?${search}` : '',
+          hash: serializeEntityHash(nextHash),
+        },
+        { replace: options.replace ?? true, preventScrollReset: true }
+      );
+    },
+    [location.hash, location.pathname, location.search, navigate]
+  );
+};
+
+export { parseEntityHash, serializeEntityHash, useEntityHashParams, useUpdateEntityUrl };
+export type { UpdateEntityUrlOptions };

--- a/app/react/V2/Routes/Entity/loader.ts
+++ b/app/react/V2/Routes/Entity/loader.ts
@@ -4,16 +4,15 @@ import { FetchResponseError } from '#shared/JSONRequest.js';
 import { getStore } from '#shared/atomStore/index.js';
 import { isClient } from '#app/utils/index.js';
 import { localeAtom, settingsAtom } from '#app/V2/atoms/index.js';
-import { getPagePlaintext } from '#V2/api/files/index.js';
-import { snippets } from '#V2/api/search/index.js';
-import { SnippetsSearchResponse } from '#V2/api/types.js';
+import { getDocumentPlaintext } from '#V2/api/files/index.js';
 import { ApiError } from '#shared/apiClient/index.js';
 import type { V2Services } from '#V2/services/types.js';
 import { httpServices } from '#V2/services/http/index.js';
 import { apiErrorToRequestError } from '#V2/shared/errorUtils.js';
 import { getMainDocument } from '#V2/formatters/index.js';
 import { entityLoaderCache } from './EntityLoaderCache.js';
-import { PAGE_PARAM, SEARCH_PARAM, VIEW_MODE_PARAM } from './Components/index.js';
+import { parseEntityHash } from './entityUrlState.js';
+import { VIEW_MODE_PARAM } from './Components/index.js';
 import { LoaderResponse } from './types.js';
 
 const entityNotFoundError = (sharedId: string) =>
@@ -22,6 +21,17 @@ const entityNotFoundError = (sharedId: string) =>
     status: 404,
     detail: `Entity ${sharedId} not found`,
   });
+
+const isRawFromRequest = (requestUrl: string) => {
+  const { hash } = new URL(requestUrl);
+  if (parseEntityHash(hash).get(VIEW_MODE_PARAM) === 'true') {
+    return true;
+  }
+  if (isClient && typeof window !== 'undefined') {
+    return parseEntityHash(window.location.hash).get(VIEW_MODE_PARAM) === 'true';
+  }
+  return false;
+};
 
 const createEntityLoader =
   (services: V2Services) =>
@@ -32,10 +42,7 @@ const createEntityLoader =
     const atomStore = getStore();
     const language = params.lang || atomStore.get(localeAtom);
     const defaultLanguage = atomStore.get(settingsAtom)?.languages?.find(l => l.default)?.key;
-    const { searchParams } = new URL(request.url);
-    const currentPage = searchParams.get(PAGE_PARAM) || '1';
-    const currentSearchTerm = searchParams.get(SEARCH_PARAM);
-    const isRaw = searchParams.get(VIEW_MODE_PARAM) === 'true';
+    const isRaw = isRawFromRequest(request.url);
 
     if (!entitySharedId) {
       return undefined;
@@ -46,7 +53,6 @@ const createEntityLoader =
     });
     let mainDocument = entityLoaderCache.getMainDocument(entitySharedId, language);
     let pagePlaintext: string | undefined = '';
-    let searchResults: SnippetsSearchResponse | undefined;
 
     if (!entity?._id) {
       const [fetchedEntity, error] = await services.entities.getBySharedId(entitySharedId, {
@@ -73,14 +79,10 @@ const createEntityLoader =
     }
 
     if (mainDocument?._id && (isRaw || !isClient)) {
-      pagePlaintext = entityLoaderCache.getPlaintext(mainDocument._id, Number(currentPage));
+      pagePlaintext = entityLoaderCache.getPlaintext(mainDocument._id);
 
       if (!pagePlaintext) {
-        const response = await getPagePlaintext(
-          mainDocument._id,
-          Number.parseInt(currentPage, 10),
-          headers
-        );
+        const response = await getDocumentPlaintext(mainDocument._id, headers);
 
         if (response instanceof FetchResponseError) {
           throw new Response(
@@ -99,38 +101,12 @@ const createEntityLoader =
           );
         } else {
           pagePlaintext = response;
-          entityLoaderCache.setPlaintext(mainDocument._id, Number(currentPage), pagePlaintext);
+          entityLoaderCache.setPlaintext(mainDocument._id, pagePlaintext);
         }
       }
     }
 
-    if (currentSearchTerm && entity?.sharedId) {
-      searchResults = entityLoaderCache.getSearchResults(
-        entity.sharedId,
-        language,
-        currentSearchTerm
-      );
-
-      if (!searchResults) {
-        searchResults = await snippets(
-          {
-            sharedId: entity.sharedId,
-            limit: 0,
-            searchString: currentSearchTerm,
-          },
-          headers
-        );
-
-        entityLoaderCache.setSearchResults(
-          entity.sharedId,
-          language,
-          currentSearchTerm,
-          searchResults
-        );
-      }
-    }
-
-    return { entity, mainDocument, pagePlaintext, searchResults };
+    return { entity, mainDocument, pagePlaintext };
   };
 
 const entityLoader = createEntityLoader(httpServices);

--- a/app/react/V2/Routes/Entity/specs/Entity.spec.tsx
+++ b/app/react/V2/Routes/Entity/specs/Entity.spec.tsx
@@ -380,14 +380,15 @@ describe('Entity view', () => {
 
       expect(screen.getByTestId('mock-pdf')).toBeInTheDocument();
 
-      expect(screen.getByText('This is the plain text').parentElement?.classList).toContain(
-        'hidden'
-      );
+      expect(
+        screen.getByText('This is the plain text').closest('.overflow-auto')?.classList
+      ).toContain('hidden');
 
       selectPlainTextView();
 
       await waitFor(() => {
-        expect(screen.getByText(pageText).parentElement?.classList).toContain('block');
+        expect(screen.getByText(pageText).closest('.overflow-auto')?.classList).toContain('block');
+        expect(screen.getByRole('region', { name: 'Page 1' })).toHaveAttribute('id', 'page1');
       });
     });
 
@@ -411,7 +412,7 @@ describe('Entity view', () => {
       await checkEntityRendered();
 
       await waitFor(() => {
-        expect(screen.getByText(pageText).parentElement?.classList).toContain('block');
+        expect(screen.getByText(pageText).closest('.overflow-auto')?.classList).toContain('block');
       });
 
       jest.restoreAllMocks();

--- a/app/react/V2/Routes/Entity/specs/Entity.spec.tsx
+++ b/app/react/V2/Routes/Entity/specs/Entity.spec.tsx
@@ -354,7 +354,7 @@ describe('Entity view', () => {
     const pageText = 'This is the plain text';
 
     beforeAll(() => {
-      jest.spyOn(files, 'getPagePlaintext').mockResolvedValue(pageText);
+      jest.spyOn(files, 'getDocumentPlaintext').mockResolvedValue(pageText);
     });
 
     afterAll(() => {
@@ -486,14 +486,10 @@ describe('Entity view', () => {
 
   describe('search tab', () => {
     it('should be shown by default when there is a search in the URL', async () => {
-      const snippets = {
-        data: [],
-      };
-
       render(
         <TestRouterContext
-          loaderData={{ entity: sampleEntity, pagePlaintext: '', searchResults: snippets }}
-          initialEntries={['/?searchTerm=term']}
+          loaderData={{ entity: sampleEntity, pagePlaintext: '' }}
+          initialEntries={['/#s=search&searchTerm=term']}
         >
           <TestAtomStoreProvider initialValues={[[templatesAtom, sampleTemplate]]}>
             <Entity />
@@ -531,7 +527,7 @@ describe('Entity view', () => {
             mainDocument: sampleMainDocument,
             pagePlaintext: '',
           }}
-          initialEntries={['/?s=search&searchTerm=search']}
+          initialEntries={['/#s=search&searchTerm=search']}
         >
           <TestAtomStoreProvider initialValues={[[templatesAtom, sampleTemplate]]}>
             <Entity />

--- a/app/react/V2/Routes/Entity/specs/entityUrlState.spec.ts
+++ b/app/react/V2/Routes/Entity/specs/entityUrlState.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment jsdom
+ */
+import { parseEntityHash, serializeEntityHash } from '../entityUrlState.js';
+
+describe('entityUrlState', () => {
+  describe('parseEntityHash / serializeEntityHash', () => {
+    it('parses and serializes hash params', () => {
+      const parsed = parseEntityHash('#page=5&s=toc');
+      expect(parsed.get('page')).toBe('5');
+      expect(parsed.get('s')).toBe('toc');
+      expect(serializeEntityHash(parsed)).toBe('#page=5&s=toc');
+    });
+
+    it('returns empty string for empty params', () => {
+      expect(serializeEntityHash(new URLSearchParams())).toBe('');
+    });
+  });
+});

--- a/app/react/V2/Routes/Entity/specs/loader.spec.ts
+++ b/app/react/V2/Routes/Entity/specs/loader.spec.ts
@@ -4,7 +4,6 @@
 import type { LoaderFunctionArgs } from 'react-router';
 import { ApiError } from '#shared/apiClient/index.js';
 import * as files from '#V2/api/files/index.js';
-import * as search from '#V2/api/search/index.js';
 import { Entity } from '#V2/api/entities/types.js';
 import { settingsAtom } from '#V2/atoms/settingsAtom.js';
 import { getStore } from '#shared/atomStore/index.js';
@@ -13,7 +12,6 @@ import { createEntityLoader } from '../loader.js';
 import { entityLoaderCache } from '../EntityLoaderCache.js';
 
 jest.mock('#V2/api/files/index.js');
-jest.mock('#V2/api/search/index.js');
 
 describe('Entity loader with cache integration', () => {
   let mockEntity: Partial<Entity>;
@@ -36,7 +34,7 @@ describe('Entity loader with cache integration', () => {
     };
 
     getBySharedId = jest.fn().mockResolvedValue([[mockEntity as Entity]]);
-    jest.spyOn(files, 'getPagePlaintext').mockResolvedValue('plaintext content');
+    jest.spyOn(files, 'getDocumentPlaintext').mockResolvedValue('plaintext content');
     getStore().set(settingsAtom, {
       languages: [
         { key: 'en', label: 'English', default: true },
@@ -88,67 +86,32 @@ describe('Entity loader with cache integration', () => {
   });
 
   describe('Plaintext loading', () => {
-    it('should fetch plaintext when not cached', async () => {
-      await loadEntity('http://localhost/entity/shared1?page=1&raw=true');
+    it('should fetch full document plaintext when not cached', async () => {
+      await loadEntity('http://localhost/entity/shared1#raw=true');
 
-      expect(files.getPagePlaintext).toHaveBeenCalledWith('doc1', 1, undefined);
+      expect(files.getDocumentPlaintext).toHaveBeenCalledWith('doc1', undefined);
     });
 
     it('should use cached plaintext and not fetch again', async () => {
-      await loadEntity('http://localhost/entity/shared1?page=1&raw=true');
-      await loadEntity('http://localhost/entity/shared1?page=1&raw=true');
+      await loadEntity('http://localhost/entity/shared1#raw=true');
+      await loadEntity('http://localhost/entity/shared1#raw=true');
 
-      expect(files.getPagePlaintext).toHaveBeenCalledTimes(1);
+      expect(files.getDocumentPlaintext).toHaveBeenCalledTimes(1);
     });
 
-    it('should use cached plaintext and not fetch again after switching pages', async () => {
-      await loadEntity('http://localhost/entity/shared1?page=1&raw=true');
-      await loadEntity('http://localhost/entity/shared1?page=2&raw=true');
-      await loadEntity('http://localhost/entity/shared1?page=1&raw=true');
+    it('should reuse full-document cache across repeated loads', async () => {
+      await loadEntity('http://localhost/entity/shared1#raw=true');
+      await loadEntity('http://localhost/entity/shared1#raw=true');
+      await loadEntity('http://localhost/entity/shared1#raw=true');
 
-      expect(files.getPagePlaintext).toHaveBeenCalledTimes(2);
+      expect(files.getDocumentPlaintext).toHaveBeenCalledTimes(1);
     });
 
     it('should not fetch if the view mode is not set for plaintext', async () => {
-      await loadEntity('http://localhost/entity/shared1?page=1');
-      await loadEntity('http://localhost/entity/shared1?page=2');
-      await loadEntity('http://localhost/entity/shared1?page=1');
+      await loadEntity('http://localhost/entity/shared1');
+      await loadEntity('http://localhost/entity/shared1');
 
-      expect(files.getPagePlaintext).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Search results loading', () => {
-    beforeEach(() => {
-      jest.spyOn(search, 'snippets').mockResolvedValue('data' as any);
-    });
-
-    it('should fetch search results when not cached', async () => {
-      await loadEntity('http://localhost/entity/shared1?searchTerm=test');
-
-      expect(search.snippets).toHaveBeenCalledWith(
-        {
-          sharedId: 'shared1',
-          limit: 0,
-          searchString: 'test',
-        },
-        undefined
-      );
-    });
-
-    it('should use cached search results and not fetch again', async () => {
-      await loadEntity('http://localhost/entity/shared1?searchTerm=query');
-      await loadEntity('http://localhost/entity/shared1?searchTerm=query');
-
-      expect(search.snippets).toHaveBeenCalledTimes(1);
-    });
-
-    it('should fetch if the search changes and cache repeated searches', async () => {
-      await loadEntity('http://localhost/entity/shared1?searchTerm=query1');
-      await loadEntity('http://localhost/entity/shared1?searchTerm=query2');
-      await loadEntity('http://localhost/entity/shared1?searchTerm=query1');
-
-      expect(search.snippets).toHaveBeenCalledTimes(2);
+      expect(files.getDocumentPlaintext).not.toHaveBeenCalled();
     });
   });
 

--- a/app/react/V2/Routes/Entity/types.ts
+++ b/app/react/V2/Routes/Entity/types.ts
@@ -1,12 +1,10 @@
 import { Entity, FileType } from '#V2/api/entities/types.js';
-import { SnippetsSearchResponse } from '#V2/api/types.js';
 
 type LoaderResponse =
   | {
       entity?: Entity;
       mainDocument?: FileType;
       pagePlaintext?: string;
-      searchResults?: SnippetsSearchResponse;
     }
   | undefined;
 

--- a/app/react/V2/api/files/index.ts
+++ b/app/react/V2/api/files/index.ts
@@ -69,6 +69,19 @@ const getPagePlaintext = async (
   }
 };
 
+const getDocumentPlaintext = async (
+  _id: string,
+  header?: IncomingHttpHeaders
+): Promise<string | FetchResponseError> => {
+  try {
+    const requestParams = new RequestParams({ _id }, header);
+    const response = await api.get('documents/fulltext', requestParams);
+    return response.json.data;
+  } catch (e) {
+    return e;
+  }
+};
+
 const postToOcr = async (filename: string): Promise<{ status: number } | FetchResponseError> => {
   try {
     const status = await api.post(`files/${filename}/ocr`);
@@ -94,4 +107,13 @@ const getOcrStatus = async (
 
 export { OcrStatus };
 export { UploadService } from './UploadService.js';
-export { getById, getByType, update, remove, getPagePlaintext, postToOcr, getOcrStatus };
+export {
+  getById,
+  getByType,
+  update,
+  remove,
+  getPagePlaintext,
+  getDocumentPlaintext,
+  postToOcr,
+  getOcrStatus,
+};


### PR DESCRIPTION
## Summary
- Moves entityv2 page, context panel (`s`), and plain-text (`raw`) into the URL hash so they do not multiply indexable URLs; omits default `?m=document`.
- Adds document fulltext API/loader path for SSR indexing, plus Helmet title/description/canonical and SSR metadata + relationship SEO content (`EntitySeo`).
- Centralizes entity URL updates via `useUpdateEntityUrl` / hash helpers.

Closes #9352
