### PR TITLE
Dataviz refresh: local time hint + randomized scheduled default

### DIFF
--- a/app/react/V2/Dataviz/editor/components/tabs/RefreshTab.tsx
+++ b/app/react/V2/Dataviz/editor/components/tabs/RefreshTab.tsx
@@ -40,9 +40,54 @@ const REFRESH_OPTIONS: {
 
 const SNAPSHOT_MODES = new Set<RefreshMode>(['snapshot_manual', 'snapshot_scheduled']);
 
-const SCHEDULED_REFRESH_DEFAULTS: Partial<DatavizDefinition['refresh']> = {
+const SCHEDULE_TIME_STEP_MINUTES = 15;
+const LOCAL_DEFAULT_START_HOUR = 1;
+const LOCAL_DEFAULT_END_HOUR = 8;
+
+const formatTimeHHMM = (hours: number, minutes: number) =>
+  `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+
+const localTimeToUtcTime = (localTime: string) => {
+  const [hours, minutes] = localTime.split(':').map(Number);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return localTime;
+  }
+
+  const localDate = new Date();
+  localDate.setHours(hours, minutes, 0, 0);
+  return formatTimeHHMM(localDate.getUTCHours(), localDate.getUTCMinutes());
+};
+
+const utcTimeToLocalTime = (utcTime?: string) => {
+  if (!utcTime) {
+    return null;
+  }
+
+  const [hours, minutes] = utcTime.split(':').map(Number);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return null;
+  }
+
+  const utcDate = new Date();
+  utcDate.setUTCHours(hours, minutes, 0, 0);
+  return formatTimeHHMM(utcDate.getHours(), utcDate.getMinutes());
+};
+
+const randomScheduledUtcTime = () => {
+  const totalLocalMinutes =
+    (LOCAL_DEFAULT_END_HOUR - LOCAL_DEFAULT_START_HOUR) * 60 + SCHEDULE_TIME_STEP_MINUTES;
+  const totalSlots = Math.floor(totalLocalMinutes / SCHEDULE_TIME_STEP_MINUTES);
+  const randomSlot = Math.floor(Math.random() * totalSlots);
+  const minutesFromStart = randomSlot * SCHEDULE_TIME_STEP_MINUTES;
+  const localHours = LOCAL_DEFAULT_START_HOUR + Math.floor(minutesFromStart / 60);
+  const localMinutes = minutesFromStart % 60;
+  const localTime = formatTimeHHMM(localHours, localMinutes);
+
+  return localTimeToUtcTime(localTime);
+};
+
+const SCHEDULED_REFRESH_DEFAULTS: Omit<DatavizDefinition['refresh'], 'refreshMode'> = {
   schedule: 'daily',
-  scheduleTime: '02:00',
   cronTimezone: 'UTC',
 };
 
@@ -75,6 +120,7 @@ const RefreshTab = ({ definition, constraints, onPatchRefresh }: RefreshTabProps
   const { notify } = useRequestStatus();
   const [refreshing, setRefreshing] = useState(false);
   const [cooldownTick, setCooldownTick] = useState(0);
+  const defaultScheduledTime = useMemo(randomScheduledUtcTime, []);
   const { refresh } = definition;
   const canRefreshSnapshot = isPersistedId(definition.id);
   const recentlyRefreshed = useMemo(
@@ -155,8 +201,7 @@ const RefreshTab = ({ definition, constraints, onPatchRefresh }: RefreshTabProps
                         ...(option.value === 'snapshot_scheduled'
                           ? {
                               schedule: refresh.schedule ?? SCHEDULED_REFRESH_DEFAULTS.schedule,
-                              scheduleTime:
-                                refresh.scheduleTime ?? SCHEDULED_REFRESH_DEFAULTS.scheduleTime,
+                              scheduleTime: refresh.scheduleTime ?? defaultScheduledTime,
                               cronTimezone: SCHEDULED_REFRESH_DEFAULTS.cronTimezone,
                             }
                           : {}),
@@ -261,10 +306,16 @@ const RefreshTab = ({ definition, constraints, onPatchRefresh }: RefreshTabProps
             <input
               id="schedule-time"
               type="time"
-              value={refresh.scheduleTime || '02:00'}
+              value={refresh.scheduleTime || defaultScheduledTime}
               onChange={e => onPatchRefresh({ scheduleTime: e.target.value })}
               className="rounded-lg border border-border bg-paper px-3 py-2 text-sm text-ink"
             />
+            {utcTimeToLocalTime(refresh.scheduleTime || defaultScheduledTime) && (
+              <p className="text-xs text-ink-muted">
+                {utcTimeToLocalTime(refresh.scheduleTime || defaultScheduledTime)}{' '}
+                <Translate>Local time</Translate>
+              </p>
+            )}
           </label>
           <p className="text-xs text-ink-secondary">
             <Translate>Schedules run in UTC (Coordinated Universal Time).</Translate>

--- a/contents/ui-translations/ar.csv
+++ b/contents/ui-translations/ar.csv
@@ -631,6 +631,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,تسجيل الدخول
 Login button,زر تسجيل الدخول
 Login failed,فشل عملية الدخول

--- a/contents/ui-translations/el.csv
+++ b/contents/ui-translations/el.csv
@@ -633,6 +633,7 @@ Live preview,Live preview
 Live translate,Ζωντανή μετάφραση
 Load example,Load example
 Loading,Φόρτωση
+Local time,Local time
 Login,Σύνδεση
 Login button,Σύνδεση
 Login failed,Η σύνδεση απέτυχε

--- a/contents/ui-translations/en.csv
+++ b/contents/ui-translations/en.csv
@@ -634,6 +634,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,Login
 Login button,Login
 Login failed,Login failed

--- a/contents/ui-translations/es.csv
+++ b/contents/ui-translations/es.csv
@@ -630,6 +630,7 @@ Live preview,Live preview
 Live translate,Traducción en vivo
 Load example,Load example
 Loading,Cargando
+Local time,Local time
 Login,Acceder
 Login button,Inicio de Sesión
 Login failed,Error de inicio de sesión

--- a/contents/ui-translations/fr.csv
+++ b/contents/ui-translations/fr.csv
@@ -631,6 +631,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,Connexion
 Login button,Bouton de Connexion
 Login failed,Échec de la connexion

--- a/contents/ui-translations/ko.csv
+++ b/contents/ui-translations/ko.csv
@@ -632,6 +632,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,로그인
 Login button,로그인 버튼
 Login failed,로그인 실패

--- a/contents/ui-translations/my.csv
+++ b/contents/ui-translations/my.csv
@@ -632,6 +632,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,လော့ဂ်အင်ဝင်ရန်
 Login button,လော့ဂ်အင်ဝင်ရန် ခလုတ်
 Login failed,လော့ဂ်အင်ဝင်၍ မရပါ

--- a/contents/ui-translations/ru.csv
+++ b/contents/ui-translations/ru.csv
@@ -629,6 +629,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,Войти
 Login button,Кнопка входа
 Login failed,Ошибка авторизации

--- a/contents/ui-translations/th.csv
+++ b/contents/ui-translations/th.csv
@@ -632,6 +632,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,เข้าสู่ระบบ
 Login button,กดเพื่อเข้าสู่ระบบ
 Login failed,การเข้าสู่ระบบล้มเหลว

--- a/contents/ui-translations/tr.csv
+++ b/contents/ui-translations/tr.csv
@@ -632,6 +632,7 @@ Live preview,Live preview
 Live translate,Live translate
 Load example,Load example
 Loading,Loading
+Local time,Local time
 Login,Giriş
 Login button,Giriş
 Login failed,Giriş başarısız

--- a/contents/ui-translations/uk.csv
+++ b/contents/ui-translations/uk.csv
@@ -634,6 +634,7 @@ Live preview,Live preview
 Live translate,Прямий переклад
 Load example,Load example
 Loading,Завантаження
+Local time,Local time
 Login,Увійти
 Login button,Кнопка входу
 Login failed,Помилка авторизації


### PR DESCRIPTION
## What
- show a local-time note under the scheduled UTC time input in Dataviz refresh settings
- replace fixed default 02:00 UTC with a randomized default window to spread scheduled jobs

## Details
- when snapshot_scheduled is selected, default time is now picked randomly between 01:00 and 08:00 local time in 15-minute steps, then converted to UTC for persistence
- under the Time (UTC) input, the UI now displays HH:mm Local time to make the UTC value clearer for users
- existing saved scheduleTime values are preserved and not overridden

## Why
Avoid creating a concentrated server load at 02:00 UTC from many newly created dataviz schedules.