### PR TITLE
fix(shutdown): closeSockets must run before http.close()

### DIFF
--- a/app/api/infrastructure/shutdown/HttpServerGracefulShutdown.ts
+++ b/app/api/infrastructure/shutdown/HttpServerGracefulShutdown.ts
@@ -7,6 +7,7 @@ interface HttpServerGracefulShutdownOptions {
   server: Server;
   app: Application;
   cleanup: () => Promise<void>;
+  closeSockets?: () => void;
   timeout?: number;
   exit?: (code: number) => void;
   logger?: Logger;
@@ -15,13 +16,14 @@ interface HttpServerGracefulShutdownOptions {
 /**
  * Manages graceful HTTP server shutdown:
  *
- * 1. Sets a flag — the 503 middleware rejects new requests on
+ * 1. Closes socket.io connections (if any) — must happen before http.close()
+ *    or persistent WebSocket connections keep http.close() from firing.
+ * 2. Sets a flag — the 503 middleware rejects new requests on
  *    already-established connections and destroys the socket.
- * 2. Closes idle keep-alive connections immediately.
- * 3. Stops accepting new TCP connections (http.close).
- * 4. Runs cleanup (DB, Redis, ES, socket.io) once all connections
- *    are drained.
- * 5. Force-exits after a configurable timeout if shutdown stalls.
+ * 3. Closes idle keep-alive connections immediately.
+ * 4. Stops accepting new TCP connections (http.close).
+ * 5. Runs cleanup (DB, Redis, ES) once all connections are drained.
+ * 6. Force-exits after a configurable timeout if shutdown stalls.
  */
 export class HttpServerGracefulShutdown {
   private isShuttingDown = false;
@@ -29,6 +31,8 @@ export class HttpServerGracefulShutdown {
   private server: Server;
 
   private cleanup: () => Promise<void>;
+
+  private closeSockets: () => void;
 
   private timeout: number;
 
@@ -41,6 +45,9 @@ export class HttpServerGracefulShutdown {
   constructor(options: HttpServerGracefulShutdownOptions) {
     this.server = options.server;
     this.cleanup = options.cleanup;
+    this.closeSockets =
+      options.closeSockets ?? // eslint-disable-next-line no-empty-function
+      (() => {});
     this.timeout = options.timeout ?? 10000;
     this.exit = options.exit ?? (code => process.exit(code));
     this.logger = options.logger ?? LoggerFactory.systemLogger();
@@ -56,6 +63,8 @@ export class HttpServerGracefulShutdown {
     if (this.isShuttingDown) {
       return;
     }
+
+    this.closeSockets();
 
     this.isShuttingDown = true;
     this.logger.info('SIGINT signal received.');

--- a/app/api/infrastructure/shutdown/specs/HttpServerGracefulShutdown.spec.ts
+++ b/app/api/infrastructure/shutdown/specs/HttpServerGracefulShutdown.spec.ts
@@ -43,7 +43,12 @@ interface TestContext {
   url(): string;
 }
 
-function createTestServer({ delay = 50, timeout = 500 } = {}): TestContext {
+function createTestServer({
+  delay = 50,
+  timeout = 500,
+  // eslint-disable-next-line no-empty-function
+  closeSockets = () => {},
+} = {}): TestContext {
   const app = express();
   const server = http.createServer(app);
 
@@ -57,6 +62,7 @@ function createTestServer({ delay = 50, timeout = 500 } = {}): TestContext {
     cleanup: async () => {
       cleanupCalls.push('cleanup');
     },
+    closeSockets,
     timeout,
     exit: code => {
       exitCalls.push(code);
@@ -229,6 +235,36 @@ describe('HttpServerGracefulShutdown', () => {
       await sleep(600);
       expect(t.exitCalls).toContain(1);
       socket.destroy();
+    });
+
+    it('completes shutdown even with persistent connections', async () => {
+      let persistentSocket: net.Socket | null = null;
+
+      const oldT = t;
+      t = createTestServer({
+        closeSockets: () => {
+          persistentSocket?.destroy();
+        },
+      });
+      t._baseUrl = await startServer(t);
+
+      // Simulate a socket.io-like persistent connection:
+      // open TCP, send partial HTTP (parser becomes active, not idle)
+      persistentSocket = await openSocket(t);
+      persistentSocket.write('GET /slow HTTP/1.1\r\n'); // incomplete request
+
+      t.shutdown.shutdown();
+
+      // With closeSockets() called BEFORE http.close(),
+      // persistent connections are destroyed immediately.
+      // http.close() fires its callback, cleanup runs, exit is 0.
+      await sleep(600);
+
+      expect(t.cleanupCalls).toContain('cleanup');
+      expect(t.exitCalls).toEqual([0]);
+
+      stopServer(t);
+      t = oldT;
     });
 
     it('logs each step of the shutdown sequence', async () => {

--- a/app/server.js
+++ b/app/server.js
@@ -64,8 +64,6 @@ const shutdown = new HttpServerGracefulShutdown({
   app,
   timeout: 30000,
   cleanup: async () => {
-    closeSockets();
-
     const logger = LoggerFactory.systemLogger();
     const disconnect = async (name, fn) => {
       try {
@@ -83,6 +81,7 @@ const shutdown = new HttpServerGracefulShutdown({
       disconnect('Elasticsearch', () => elasticClient.close()),
     ]);
   },
+  closeSockets: () => closeSockets(),
 });
 
 const uncaughtError = error => {


### PR DESCRIPTION
Without closeSockets() before http.close(), persistent connections
(e.g. socket.io WebSockets) keep http.close() callback from firing,
causing the force-exit timeout to trigger instead of graceful cleanup.

- Add injectable closeSockets option to HttpServerGracefulShutdown
- closeSockets() runs first in shutdown(), before http.close()
- Add regression test demonstrating the bug and fix
- Update server.js to pass closeSockets explicitly
