### PR TITLE
Set up Cursor Cloud dev environment + document startup caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,7 @@ Non-obvious caveats for running this repo in the Cursor Cloud VM. Standard comma
 ### Running the app
 - No `.env` file is needed — `config.ts` defaults target Mongo/ES on localhost, Redis off (CLUSTER_MODE=false), and local-filesystem storage. Do **not** copy `.env.example` verbatim, as it enables `EXTERNAL_SERVICES`/AI-assistant which expect extra services.
 - `yarn hot` serves the app on http://localhost:3000. Default login: `admin` / `change this password now`. First webpack build takes ~40s.
+
+### Viewing the app through the Cursor Cloud proxy (single-port ingress)
+- `yarn hot` serves HTML on port 3000 but references CSS/JS as absolute URLs to the **webpack dev server on port 8080** (a separate origin). This works via `localhost` inside the VM, but through the public per-port ingress (`p-3000-...agent.cvm.dev`) the browser cannot reach port 8080, so the page loads **unstyled**. The port-8080 ingress does not share the login session with the port-3000 ingress, so pointing `WEBPACK_PUBLIC_URL` at it does not fix this.
+- To share a working preview link, serve everything from the single port-3000 origin with a production build: `yarn build-production` then `yarn run-production` (uses relative, same-origin asset paths; connects to the same `uwazi_development` DB/index). Trade-off: no hot reload — rebuild to see changes. Use `yarn hot` for active local development.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,32 @@ Code shared between frontend and backend is in `app/shared/`:
 
 - Import alias: `#shared/*` (configured in package.json imports)
 - Used for common types, utilities, or constants needed by both layers
+
+## Cursor Cloud specific instructions
+
+Non-obvious caveats for running this repo in the Cursor Cloud VM. Standard commands (`yarn hot`, `yarn test`, lint) live in the sections above and in `package.json`.
+
+### Node version
+- Use Node **20.19.6** via nvm. The VM has a default `/exec-daemon/node` (v22) that wins on `PATH` in non-interactive shells, so prefix commands with `export PATH="$HOME/.nvm/versions/node/v20.19.6/bin:$PATH"` (already done in interactive shells via `~/.bashrc`). The update script also does this before `yarn install`.
+
+### Backing services (Docker)
+- No systemd: start the Docker daemon manually once per VM boot with `sudo dockerd` (run it in a background/tmux session), then wait a few seconds for it to be ready.
+- Infra is defined in `docker-compose.yml` (`./run start`). Mongo (replica set, auto-initialized), Postgres, Redis, and MinIO start fine.
+- **ElasticSearch caveat:** the `elasticsearch` service has `mem_limit: 4g`, which fails in this nested VM because the root cgroup is in threaded mode and the `memory` controller isn't delegated (`cannot enter cgroupv2 ... it is in threaded mode`). Bring up the other services with `sudo docker compose up -d mongo mongoreplicaset_start_script redis postgres minio`, then run the ES image **without** `mem_limit`:
+  ```
+  sudo docker run -d --name uwazi-elasticsearch --network workspace_default -p 9200:9200 \
+    --ulimit memlock=-1:-1 -e bootstrap.memory_lock=true -e discovery.type=single-node \
+    -e xpack.security.enabled=false -e cluster.routing.allocation.disk.threshold_enabled=false \
+    -e "ES_JAVA_OPTS=-Xms2g -Xmx2g" -e indices.query.bool.max_clause_count=2048 \
+    -v workspace_esdata01:/usr/share/elasticsearch/data workspace-elasticsearch:latest
+  ```
+  If `mongoreplicaset_start_script` didn't run (was left in `Created`), start it with `sudo docker start mongoreplicaset_start_script` to initialize the single-node replica set.
+
+### Database initialization
+- `blank-state` / `dump`/`restore` scripts and `yarn hot` run on the host and need `mongosh` + `mongodb-database-tools` (installed via the MongoDB 7.0 `jammy` apt repo) plus `pdftotext` (poppler-utils).
+- **Migrations are coupled to the Postgres schema.** Plain `yarn migrate` (and therefore `yarn blank-state`) gets **blocked** (`{"blocked":{"delta":...,"requiresSchema":5}}`) until the Postgres schema migrations are applied. Use the new flow instead: `yarn migrate --new` (applies PG schema migrations 1-5 + pending Mongo data migrations), then `yarn reindex` to (re)build the ES index. So a full blank init is: `yarn blank-state` → `yarn migrate --new` → `yarn reindex`.
+- Postgres is provisioned automatically by the compose init scripts (creates `migrator_user` / `app_user`); `config.ts` defaults (`migrator_user`) match, so no `.env` is required.
+
+### Running the app
+- No `.env` file is needed — `config.ts` defaults target Mongo/ES on localhost, Redis off (CLUSTER_MODE=false), and local-filesystem storage. Do **not** copy `.env.example` verbatim, as it enables `EXTERNAL_SERVICES`/AI-assistant which expect extra services.
+- `yarn hot` serves the app on http://localhost:3000. Default login: `admin` / `change this password now`. First webpack build takes ~40s.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Uwazi development environment in the Cursor Cloud VM and documents the non-obvious startup caveats discovered during setup so future agents can run the app and tests reliably.

The only code change is to `AGENTS.md` (a new `## Cursor Cloud specific instructions` section). No application code was modified.

## Environment setup performed

- **Node 20.19.6** via nvm (the VM's default `/exec-daemon/node` is v22 and wins on `PATH` otherwise).
- **yarn 4.13.0** via corepack; `yarn install`.
- System deps: `libpng-dev`, `poppler-utils`, `libjpeg-dev`, `mongosh`, `mongodb-database-tools`.
- **Docker** (engine + compose) configured for this nested VM (fuse-overlayfs, iptables-legacy); backing services from `docker-compose.yml` (Mongo replica set, Postgres, Redis, MinIO).
- ElasticSearch run **without** `mem_limit` (its `mem_limit` fails due to the VM's threaded root cgroup).
- DB init: `yarn blank-state` → `yarn migrate --new` (PG schema + Mongo data) → `yarn reindex`.

## Verification

| Check | Command | Result |
|---|---|---|
| Lint | `eslint app/api/config.ts` | pass (exit 0) |
| Unit test | `jest .../Thumbnail.spec.ts` | 4/4 pass |
| Integration test (Mongo + PG) | `jest .../CreateTemplate.spec.ts` | 9/9 pass |
| Dev build/run | `yarn hot` | app on :3000, `api/version` → `{"version":"development-1.229.96"}` |

## Hello-world task

Logged in as `admin` and created an entity ("Hello World Test Entity") via the UI; verified it persisted in MongoDB.

[uwazi_create_entity_hello_world.mp4](https://cursor.com/agents/bc-c9af5cd2-accc-4cf2-bd20-caa5088f7bad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuwazi_create_entity_hello_world.mp4)

[Create entity form](https://cursor.com/agents/bc-c9af5cd2-accc-4cf2-bd20-caa5088f7bad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuwazi_create_entity_form.webp)
[Entity created](https://cursor.com/agents/bc-c9af5cd2-accc-4cf2-bd20-caa5088f7bad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuwazi_entity_created.webp)

## Update script

```
export PATH="$HOME/.nvm/versions/node/v20.19.6/bin:$PATH"
yarn install
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9af5cd2-accc-4cf2-bd20-caa5088f7bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9af5cd2-accc-4cf2-bd20-caa5088f7bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

