### PR TITLE
Update outdated documentation links (#9470)

### DIFF
--- a/AI Contexts/CSV/csv-v2-context-02.md
+++ b/AI Contexts/CSV/csv-v2-context-02.md
@@ -87,7 +87,7 @@ Follow-up to csv-v2-context-01.md consolidating decisions for Job 1 (file extrac
 
 - Rationale for CSV copy:
   - Policy expects ZIPs to contain a flat root with `import.csv`. To keep downstream logic identical, when the upload is a single CSV we normalize by copying it to `extracted/import.csv` so the next stage always looks in one place.
-  - See Admin Guide for bulk CSV import conventions (root-level `import.csv` alongside supporting files) — reference: `https://uwazi.readthedocs.io/en/latest/admin-docs/working-with-entities-in-your-collection.html#how-to-add-entities-in-bulk-with-csv-import`.
+  - See Admin Guide for bulk CSV import conventions (root-level `import.csv` alongside supporting files) — reference: `https://docs.uwazi.io/docs/reference/csv-import/#files-inside-a-zip-upload`.
 
 ### Dispatch and transaction hook
 
@@ -376,4 +376,4 @@ Follow-up to csv-v2-context-01.md consolidating decisions for Job 1 (file extrac
 
 ### References
 
-- Admin guide re: CSV ZIP contents and `import.csv` naming: https://uwazi.readthedocs.io/en/latest/admin-docs/working-with-entities-in-your-collection.html#how-to-add-entities-in-bulk-with-csv-import
+- Admin guide re: CSV ZIP contents and `import.csv` naming: https://docs.uwazi.io/docs/reference/csv-import/#files-inside-a-zip-upload

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Uwazi is a flexible database application to capture and organise collections of 
 
 [Uwazi](https://www.uwazi.io/) | [Uwazi Docs](https://docs.uwazi.io) | [HURIDOCS](https://huridocs.org/)
 
-Read the [user guide](https://uwazi.io/page/9852italrtk/support)
+Read the [user guide](https://docs.uwazi.io)
 
 # Installation guide
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Uwazi CI
 
 Uwazi is a flexible database application to capture and organise collections of information with a particular focus on document management. HURIDOCS started Uwazi and is supporting dozens of human rights organisations globally to use the tool.
 
-[Uwazi](https://www.uwazi.io/) | [HURIDOCS](https://huridocs.org/)
+[Uwazi](https://www.uwazi.io/) | [Uwazi Docs](https://docs.uwazi.io) | [HURIDOCS](https://huridocs.org/)
 
 Read the [user guide](https://uwazi.io/page/9852italrtk/support)
 

--- a/app/react/Layout/components/Welcome.tsx
+++ b/app/react/Layout/components/Welcome.tsx
@@ -10,8 +10,12 @@ export class Welcome extends Component {
         <h4>
           <Translate>Welcome to Uwazi</Translate>
         </h4>
-        <a href="https://uwazi.io/page/9852italrtk/support" target="_blank" rel="noreferrer">
-          <Translate>Learn more</Translate>
+        <a
+          href="https://docs.uwazi.io/docs/tutorials/build-your-first-collection/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <Translate>Learn how to build your first collection</Translate>
         </a>
       </div>
     );

--- a/app/react/Library/components/FiltersForm.jsx
+++ b/app/react/Library/components/FiltersForm.jsx
@@ -113,7 +113,7 @@ class FiltersForm extends Component {
                   </Translate>
                 </p>
                 <a
-                  href="https://github.com/huridocs/uwazi/wiki/Filter"
+                  href="https://docs.uwazi.io/docs/how-to/working-with-content/search-filter-and-sort-the-library/"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/app/react/V2/Routes/Settings/Collection/collectionSettingsTips.tsx
+++ b/app/react/V2/Routes/Settings/Collection/collectionSettingsTips.tsx
@@ -55,17 +55,14 @@ export const receivingEmail = (
       submissions.
     </Translate>
     &nbsp;
-    <Translate>Click</Translate>&nbsp;
     <a
-      href="https://uwazi.readthedocs.io/en/latest/admin-docs/managing-settings.html#how-to-configure-a-contact-form-or-submission-form"
+      href="https://docs.uwazi.io/docs/how-to/managing-your-instance/create-and-manage-pages/#add-a-contact-form-to-a-page"
       target="_blank"
       rel="noreferrer"
       className="underline text-(--color-theme-action-primary) hover:text-ink visited:text-(--color-theme-action-primary)"
     >
-      <Translate>here</Translate>
+      <Translate>Learn how to add and configure a contact form on a webpage.</Translate>
     </a>
-    &nbsp;
-    <Translate>to learn how to add and configure a contact form on a webpage.</Translate>
   </>
 );
 export const emails = [

--- a/app/react/V2/Routes/Settings/Pages/components/PageEditorComponents.tsx
+++ b/app/react/V2/Routes/Settings/Pages/components/PageEditorComponents.tsx
@@ -24,10 +24,10 @@ const HTMLNotification = ({ useLegacyMarkdown = true }: { useLegacyMarkdown?: bo
         <Link
           className="underline hover:text-primary-800"
           target="_blank"
-          to="https://uwazi.readthedocs.io/en/latest/admin-docs/analysing-and-visualising-your-collection.html"
+          to="https://docs.uwazi.io/docs/reference/page-visualization-components/"
           rel="noopener noreferrer"
         >
-          <Translate>Documentation</Translate>
+          <Translate>Learn more about the components.</Translate>
         </Link>
       </div>
     </div>
@@ -50,13 +50,11 @@ const HTMLNotification = ({ useLegacyMarkdown = true }: { useLegacyMarkdown?: bo
         <Link
           className="underline hover:text-primary-800"
           target="_blank"
-          to="https://uwazi.readthedocs.io/en/latest/admin-docs/analysing-and-visualising-your-collection.html"
+          to="https://docs.uwazi.io/docs/reference/page-visualization-components/"
           rel="noopener noreferrer"
         >
-          <Translate>Click here</Translate>
+          <Translate>Learn more about the components.</Translate>
         </Link>
-        &nbsp;
-        <Translate>to learn more about the components.</Translate>
       </div>
     </div>
   );

--- a/app/react/V2/Routes/Settings/Preserve/Preserve.tsx
+++ b/app/react/V2/Routes/Settings/Preserve/Preserve.tsx
@@ -43,14 +43,7 @@ const Preserve = () => {
             <div className="flex flex-col gap-4">
               <div>
                 <span>1. </span>
-                <a
-                  href="https://uwazi.io/page/9852italrtk/support"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary-700 font-semibold hover:text-primary-800 mt-2 inline"
-                >
-                  <Translate>Install the browser extension.</Translate>
-                </a>
+                <Translate>Install the browser extension.</Translate>
               </div>
               <div>
                 <span>2. </span>

--- a/app/react/V2/Routes/Settings/SettingsNavigation.tsx
+++ b/app/react/V2/Routes/Settings/SettingsNavigation.tsx
@@ -126,12 +126,12 @@ const SettingsNavigation = () => {
           </NeedAuthorization>
           <li>
             <a
-              href="https://uwazi.io/page/9852italrtk/support"
+              href="https://docs.uwazi.io"
               target="_blank"
               rel="noopener noreferrer"
               className="settings-nav-link inline-flex items-center gap-1 whitespace-nowrap"
             >
-              <Translate>Documentation</Translate> <Icon icon="external-link-alt" />
+              <Translate>Uwazi Docs</Translate> <Icon icon="external-link-alt" />
             </a>
           </li>
         </ul>

--- a/contents/ui-translations/ar.csv
+++ b/contents/ui-translations/ar.csv
@@ -189,7 +189,6 @@ Clear Filters,مسح عوامل التصفية
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,انقر هنا
 Click to fill,انقر للتعبئة
 Close,غلق
 Code,Code
@@ -629,7 +628,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,خط العرض
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,اعرف المزيد
+Learn more about the components.,Learn more about the components.
 Legend,مفتاح مصطلحات الخريطة
 Lengthy reindex process,Lengthy reindex process
 Library,مكتبة
@@ -1293,8 +1295,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.",لكي تستمتع بتجربة أفضل، يستخدم هذا الموقع ملفات تعريف الارتباط
 "To complete the account creation process, please create a password for your account",لإكمال عملية إنشاء الحساب، يرجى إنشاء كلمة مرور لحسابك
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,لمعرفة المزيد حول المكونات
 to view your authentication code and verify your identity.,لمعاينة رمز المصادقة الخاص بك والتحقق من هويتك.
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1393,6 +1393,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,أوازي من إعداد:
 Uwazi UI,واجهة استخدام أوازي
 Validating,Validating

--- a/contents/ui-translations/el.csv
+++ b/contents/ui-translations/el.csv
@@ -191,7 +191,6 @@ Clear Filters,Εκκαθάριση φίλτρων
 Clear PDF selection,Εκκαθάριση επιλογής PDF
 Clear search,Clear search
 Click,Κάντε κλικ
-Click here,Κάντε κλικ εδώ
 Click to fill,Κάντε κλικ για να συμπληρώσετε
 Close,Κλείσιμο
 Code,Code
@@ -631,7 +630,10 @@ Last updated,Τελευταία ενημέρωση
 Last updated from collection:,Last updated from collection:
 Latitude,Γεωγραφικό πλάτος
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Μάθετε περισσότερα
+Learn more about the components.,Learn more about the components.
 Legend,Υπόμνημα
 Lengthy reindex process,Χρονοβόρα διαδικασία επαναευρετηριοποίησης
 Library,Βιβλιοθήκη
@@ -1295,8 +1297,6 @@ To,Έως
 To add references you can start by selecting text in the document,"Για να προσθέσετε αναφορές, μπορείτε να ξεκινήσετε επιλέγοντας κείμενο στο έγγραφο."
 "To bring you a better experience, this site uses cookies.","Για να σας προσφέρουμε καλύτερη εμπειρία, αυτός ο ιστότοπος χρησιμοποιεί cookies."
 "To complete the account creation process, please create a password for your account","Για να ολοκληρώσετε τη διαδικασία δημιουργίας λογαριασμού, δημιουργήστε έναν κωδικό πρόσβασης για το λογαριασμό σας."
-to learn how to add and configure a contact form on a webpage.,για να μάθετε πώς να προσθέσετε και να ρυθμίσετε μια φόρμα επικοινωνίας σε μια ιστοσελίδα.
-to learn more about the components.,για να μάθετε περισσότερα για τα στοιχεία.
 to view your authentication code and verify your identity.,για να δείτε τον κωδικό πιστοποίησης και να επαληθεύσετε την ταυτότητά σας.
 Today,Σήμερα
 Toggle timeline mode,Toggle timeline mode
@@ -1395,6 +1395,7 @@ Users & Groups,Χρήστες & Ομάδες
 Using Authenticator,Χρήση της εφαρμογής πιστοποίησης ταυτότητας
 Using URLs,Χρήση URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Το Uwazi έχει αναπτυχθεί από
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/en.csv
+++ b/contents/ui-translations/en.csv
@@ -192,7 +192,6 @@ Clear Filters,Clear Filters
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,Click here
 Click to fill,Click to fill
 Close,Close
 Code,Code
@@ -632,7 +631,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,Latitude
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Learn more
+Learn more about the components.,Learn more about the components.
 Legend,Legend
 Lengthy reindex process,Lengthy reindex process
 Library,Library
@@ -1296,8 +1298,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.","To bring you a better experience, this site uses cookies."
 "To complete the account creation process, please create a password for your account","To complete the account creation process, please create a password for your account"
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,to learn more about the components.
 to view your authentication code and verify your identity.,to view your authentication code and verify your identity.
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1396,6 +1396,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi is developed by
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/es.csv
+++ b/contents/ui-translations/es.csv
@@ -188,7 +188,6 @@ Clear Filters,Limpiar filtros
 Clear PDF selection,Limpiar la selección PDF
 Clear search,Limpiar búsqueda
 Click,Click
-Click here,Haz click aquí
 Click to fill,Click para completar
 Close,Cerrar
 Code,Code
@@ -628,7 +627,10 @@ Last updated,Última actualización
 Last updated from collection:,Last updated from collection:
 Latitude,Latitud
 Latitude must be between -90 and 90,Latitud debe estar entre -90 y 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Aprender más
+Learn more about the components.,Learn more about the components.
 Legend,Leyenda
 Lengthy reindex process,Proceso de reindexación largo
 Library,Colección
@@ -1291,8 +1293,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.","Para una mejor experiencia de usuario, este sitio utiliza cookies."
 "To complete the account creation process, please create a password for your account","Para completar este proceso de creación de cuenta, por favor crea una contraseña."
-to learn how to add and configure a contact form on a webpage.,para aprender a añadir y configurar un contacto desde una página web.
-to learn more about the components.,para aprender más sobre los componentes.
 to view your authentication code and verify your identity.,para ver el código de autenticación y verificar tu identidad.
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1391,6 +1391,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi es desarrollado por
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/fr.csv
+++ b/contents/ui-translations/fr.csv
@@ -189,7 +189,6 @@ Clear Filters,Effacer les filtres
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,Cliquez ici
 Click to fill,Cliquez pour remplir
 Close,Fermer
 Code,Code
@@ -629,7 +628,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,Latitude
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Learn more
+Learn more about the components.,Learn more about the components.
 Legend,Legend
 Lengthy reindex process,Lengthy reindex process
 Library,Bibliothèque
@@ -1293,8 +1295,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.","Pour vous apporter une meilleure expérience, ce site utilise des cookies."
 "To complete the account creation process, please create a password for your account","Pour compléter le processus de création de compte, veuillez créer un mot de passe pour votre compte."
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,Pour en savoir plus sur les composants.
 to view your authentication code and verify your identity.,Pour afficher votre code d'authentification et vérifier votre identité.
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1393,6 +1393,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi est développé par
 Uwazi UI,Interface utilisateur d'Uwazi
 Validating,Validating

--- a/contents/ui-translations/ko.csv
+++ b/contents/ui-translations/ko.csv
@@ -190,7 +190,6 @@ Clear Filters,필터 초기화
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,여기를 클릭하십시오
 Click to fill,텍스트 자동 채우기
 Close,닫기
 Code,Code
@@ -630,7 +629,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,위도
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,더 알아보기
+Learn more about the components.,Learn more about the components.
 Legend,범례
 Lengthy reindex process,Lengthy reindex process
 Library,라이브러리
@@ -1294,8 +1296,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.",이 사이트는 사용자 편의를 위해 쿠키를 사용합니다.
 "To complete the account creation process, please create a password for your account",계정 생성을 마치려면 계정 비밀번호를 설정하십시오.
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,구성 요소에 대해 더 자세히 알기
 to view your authentication code and verify your identity.,코드 확인하고 인증하기
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1394,6 +1394,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi 제작 및 개발:
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/my.csv
+++ b/contents/ui-translations/my.csv
@@ -190,7 +190,6 @@ Clear Filters,စစ်ထုတ်မှုများကို ရှင်�
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,ဒီမှာ နှိပ်ပါ
 Click to fill,ဖြည့်ရန် နှိပ်ပါ
 Close,ပိတ်ရန်
 Code,Code
@@ -630,7 +629,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,လတ္တီကျု
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,ပိုမိုလေ့လာရန်
+Learn more about the components.,Learn more about the components.
 Legend,ဒဏ္ဍာရီ
 Lengthy reindex process,Lengthy reindex process
 Library,စာကြည့်တိုက်
@@ -1294,8 +1296,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.",သင့်အား ပိုမိုကောင်းမွန်သော အတွေ့အကြုံ ရရှိစေရန် ဤဝက်ဘ်ဆိုက်တွင် ကွတ်ကီးများ အသုံးပြုသည်။
 "To complete the account creation process, please create a password for your account",အကောင့်ဖန်တီးခြင်း လုပ်ငန်းစဉ် ပြီးမြောက်စေရန် ကျေးဇူးပြု၍ သင့်အကောင့်အတွက် စကားဝှက် ဖန်တီးပါ
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,အစိတ်အပိုင်းများအကြောင်း ပိုမိုလေ့လာရန်။
 to view your authentication code and verify your identity.,သင်၏ စစ်မှန်ကြောင်း အတည်ပြုကုဒ်ကို ကြည့်ရန်နှင့် သင့်ကိုယ်ပိုင်သင်္ကေတကို မှန်ကန်ကြောင်း စစ်ဆေးရန်။
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1394,6 +1394,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi ကို တီထွင်ရေးသားသူမှာ
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/ru.csv
+++ b/contents/ui-translations/ru.csv
@@ -187,7 +187,6 @@ Clear Filters,Очистить фильтры
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,Нажмите сюда
 Click to fill,"Нажмите, чтобы заполнить"
 Close,Закрыть
 Code,Code
@@ -627,7 +626,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,Широта
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Узнать больше
+Learn more about the components.,Learn more about the components.
 Legend,Подпись
 Lengthy reindex process,Lengthy reindex process
 Library,Библиотека
@@ -1291,8 +1293,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.","Этот сайт использует файлы cookie для того, чтобы улучшить ваш опыт взаимодействия с сайтом."
 "To complete the account creation process, please create a password for your account","Пожалуйста, создайте пароль для того, чтобы завершить процесс создания своей учетной записи."
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,"для того, чтобы узнать больше о компонентах."
 to view your authentication code and verify your identity.,чтобы просмотреть свой код аутентификации и подтвердить свою личность.
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1391,6 +1391,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi разработан
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/th.csv
+++ b/contents/ui-translations/th.csv
@@ -190,7 +190,6 @@ Clear Filters,ล้างตัวกรอง
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,คลิกที่นี่
 Click to fill,คลิกเพื่อใส่ค่า
 Close,ปิด
 Code,Code
@@ -630,7 +629,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,พิกัดละติจูด
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,เรียนรู้เพิ่มเติม
+Learn more about the components.,Learn more about the components.
 Legend,กลุ่ม
 Lengthy reindex process,Lengthy reindex process
 Library,ไลบรารี่
@@ -1294,8 +1296,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.",เพื่อประสบการณ์ที่ดีของคุณ เว็บไซต์ของเราจะทำการเก็บคุกกี้
 "To complete the account creation process, please create a password for your account",เพื่อให้การสร้างบัญชีเสร็จสมบูรณ์กรุณาสร้างรหัสผ่านสำหรับบัญชีของคุณ
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,ในกรณีที่ต้องการเรียนรู้เพิ่มเติมเกี่ยวกับส่วนประกอบ
 to view your authentication code and verify your identity.,ในกรณีที่ต้องการดูรหัสผ่านและยืนยันตัวตน
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1394,6 +1394,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi ได้รับการพัฒนาโดย
 Uwazi UI,uwazi ui
 Validating,Validating

--- a/contents/ui-translations/tr.csv
+++ b/contents/ui-translations/tr.csv
@@ -190,7 +190,6 @@ Clear Filters,Filtreleri Temizle
 Clear PDF selection,Clear PDF selection
 Clear search,Clear search
 Click,Click
-Click here,Buraya tıklayın
 Click to fill,Doldurmak için tıklayın
 Close,Kapat
 Code,Code
@@ -630,7 +629,10 @@ Last updated,Last updated
 Last updated from collection:,Last updated from collection:
 Latitude,Enlem
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Daha fazla bilgi edin
+Learn more about the components.,Learn more about the components.
 Legend,Gösterge
 Lengthy reindex process,Lengthy reindex process
 Library,Kütüphane
@@ -1294,8 +1296,6 @@ To,To
 To add references you can start by selecting text in the document,To add references you can start by selecting text in the document
 "To bring you a better experience, this site uses cookies.",Size daha iyi bir deneyim sunmak için bu site çerezleri kullanır.
 "To complete the account creation process, please create a password for your account",Hesap oluşturma işlemini tamamlamak için lütfen hesabınız için bir parola oluşturun
-to learn how to add and configure a contact form on a webpage.,to learn how to add and configure a contact form on a webpage.
-to learn more about the components.,bileşenleri hakkında daha fazla bilgi edinmek için.
 to view your authentication code and verify your identity.,kimlik doğrulama kodunuzu görüntülemek ve kimliğinizi doğrulamak için.
 Today,Today
 Toggle timeline mode,Toggle timeline mode
@@ -1394,6 +1394,7 @@ Users & Groups,Users & Groups
 Using Authenticator,Using Authenticator
 Using URLs,Using URLs
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi tarafından geliştirildi
 Uwazi UI,Uwazi UI
 Validating,Validating

--- a/contents/ui-translations/uk.csv
+++ b/contents/ui-translations/uk.csv
@@ -192,7 +192,6 @@ Clear Filters,Очистити фільтри
 Clear PDF selection,Очистити вибір PDF
 Clear search,Clear search
 Click,Клац!
-Click here,Натисніть сюди
 Click to fill,"Натисніть, щоб заповнити"
 Close,Закрити
 Code,Code
@@ -632,7 +631,10 @@ Last updated,Останнє оновлення
 Last updated from collection:,Last updated from collection:
 Latitude,Широта
 Latitude must be between -90 and 90,Latitude must be between -90 and 90
+Learn how to add and configure a contact form on a webpage.,Learn how to add and configure a contact form on a webpage.
+Learn how to build your first collection,Learn how to build your first collection
 Learn more,Дізнатися більше
+Learn more about the components.,Learn more about the components.
 Legend,Підпис
 Lengthy reindex process,Тривалий процес реіндексації
 Library,Бібліотека
@@ -1296,8 +1298,6 @@ To,До
 To add references you can start by selecting text in the document,"Щоб додати посилання, спочатку виділіть текст у документі"
 "To bring you a better experience, this site uses cookies.",Цей сайт використовує файли cookie для покращення вашого досвіду взаємодії з сайтом.
 "To complete the account creation process, please create a password for your account","Будь ласка, створіть пароль, щоб завершити процес створення облікового запису."
-to learn how to add and configure a contact form on a webpage.,"дізнатися, як додати та налаштувати контактну форму на веб-сторінці."
-to learn more about the components.,"для того, щоб дізнатися більше про компоненти."
 to view your authentication code and verify your identity.,щоб переглянути свій код автентифікації та підтвердити свою особу.
 Today,Сьогодні
 Toggle timeline mode,Toggle timeline mode
@@ -1396,6 +1396,7 @@ Users & Groups,Користувачі та групи
 Using Authenticator,Використання автентифікатора
 Using URLs,Використання URL-адрес
 Uwazi,Uwazi
+Uwazi Docs,Uwazi Docs
 Uwazi is developed by,Uwazi розроблений
 Uwazi UI,Uwazi UI
 Validating,Validating


### PR DESCRIPTION
## Description

Fixes outdated and broken documentation links across the app after the new Uwazi Docs site launch ([#9470](https://github.com/huridocs/uwazi/issues/9470)).

### Changes
- Settings nav: Documentation → [Uwazi Docs](https://docs.uwazi.io)
- Preserve settings: remove the broken extension install link (keep instructional text)
- Welcome blank state: point to first-collection tutorial with updated copy
- README: add Uwazi Docs to the top links; update user guide URL to docs.uwazi.io
- Page editor banners: point to page visualization components docs
- Collection contact-form tip: point to create-and-manage-pages docs
- Library filters blank state: point to search/filter/sort docs
- CSV AI context: point ZIP/`import.csv` references to the new CSV import reference page
- Synced UI translation CSVs for new/removed keys

Left unchanged: `SELF_HOSTED_INSTRUCTIONS.md` wiki install link.




