### PR TITLE
Fix SortDropdown dropping includeUnpublished on home (#9301)

### DIFF
--- a/app/react/Library/components/SortDropdown.tsx
+++ b/app/react/Library/components/SortDropdown.tsx
@@ -10,7 +10,7 @@ import { wrapDispatch } from '#app/Multireducer/index.js';
 import { IStore } from '#app/istore.js';
 import { IImmutable } from '#shared/types/Immutable.js';
 import { useOnClickOutsideElement } from '#app/utils/useOnClickOutsideElementHook.js';
-import { encodeSearch } from '../actions/libraryActions.js';
+import { encodeSearch, processFilters } from '../actions/libraryActions.js';
 
 import {
   getCurrentSortOption,
@@ -26,8 +26,26 @@ interface SortDropdownOwnProps {
   selectedTemplates: IImmutable<string[]>;
 }
 
-const getOptionUrl = (option: SortType, path: string, location: Location) => {
-  const currentQuery: SearchOptions = searchParamsFromLocationSearch(location);
+type LibrarySearchQuery = SearchOptions & Record<string, unknown>;
+
+const buildCurrentQuery = (
+  search: IStore['library']['search'],
+  filters: IStore['library']['filters'],
+  location: Pick<Location, 'search'>
+): LibrarySearchQuery => {
+  const urlQuery = searchParamsFromLocationSearch(location) || {};
+  const { treatAs: _treatAs, userSelectedSorting: _userSelectedSorting, ...reduxQuery } =
+    processFilters(search, filters.toJS());
+  const definedReduxQuery = Object.fromEntries(
+    Object.entries(reduxQuery).filter(([, value]) => value !== undefined)
+  );
+
+  // Redux reflects the filters currently applied (including home defaults that are not in the URL).
+  // URL params still contribute values such as limit that are not stored in search state.
+  return { ...urlQuery, ...definedReduxQuery };
+};
+
+const getOptionUrl = (option: SortType, path: string, currentQuery: LibrarySearchQuery) => {
   const type = getPropertySortType(option);
   return `${path}${encodeSearch(
     { ...currentQuery, order: type === 'string' ? 'asc' : 'desc', sort: option.value, from: 0 },
@@ -45,6 +63,8 @@ const mapStateToProps = (state: IStore, ownProps: SortDropdownOwnProps) => {
   return {
     templates,
     locale: state.locale,
+    search: state.library.search,
+    filters: state.library.filters,
   };
 };
 
@@ -56,12 +76,12 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type mappedProps = ConnectedProps<typeof connector>;
 
 // eslint-disable-next-line max-statements
-const SortDropdownComponent = ({ templates, locale }: mappedProps) => {
+const SortDropdownComponent = ({ templates, locale, search, filters }: mappedProps) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const menuRef = useRef(null);
   const location = useLocation();
 
-  const currentQuery: SearchOptions = searchParamsFromLocationSearch(location);
+  const currentQuery = buildCurrentQuery(search, filters, location);
   const path = location.pathname.replace(new RegExp(`^/?${locale}/|^/?${locale}$`), '');
   const sortButtonLink = `${path}${encodeSearch(
     { ...currentQuery, order: currentQuery.order === 'asc' ? 'desc' : 'asc', from: 0 },
@@ -95,7 +115,7 @@ const SortDropdownComponent = ({ templates, locale }: mappedProps) => {
 
         <ul className={`dropdown-menu ${dropdownOpen ? 'expanded' : ''}`}>
           {sortOptions.map(option => {
-            const url = getOptionUrl(option, path, location);
+            const url = getOptionUrl(option, path, currentQuery);
             return (
               <li key={option.value}>
                 <I18NLink to={url} href={url}>
@@ -137,4 +157,4 @@ const SortDropdownComponent = ({ templates, locale }: mappedProps) => {
 };
 
 const container = connector(SortDropdownComponent);
-export { container as SortDropdown };
+export { container as SortDropdown, buildCurrentQuery };

--- a/app/react/Library/components/SortDropdown.tsx
+++ b/app/react/Library/components/SortDropdown.tsx
@@ -34,8 +34,11 @@ const buildCurrentQuery = (
   location: Pick<Location, 'search'>
 ): LibrarySearchQuery => {
   const urlQuery = searchParamsFromLocationSearch(location) || {};
-  const { treatAs: _treatAs, userSelectedSorting: _userSelectedSorting, ...reduxQuery } =
-    processFilters(search, filters.toJS());
+  const {
+    treatAs: _treatAs,
+    userSelectedSorting: _userSelectedSorting,
+    ...reduxQuery
+  } = processFilters(search, filters.toJS());
   const definedReduxQuery = Object.fromEntries(
     Object.entries(reduxQuery).filter(([, value]) => value !== undefined)
   );

--- a/app/react/Library/components/specs/SortDropdown.spec.tsx
+++ b/app/react/Library/components/specs/SortDropdown.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import Immutable from 'immutable';
 import { RenderResult, screen } from '@testing-library/react';
 import { defaultState, renderConnectedContainer } from '#app/utils/test/renderConnected.js';
-import { SortDropdown } from '../SortDropdown.js';
+import { SortDropdown, buildCurrentQuery } from '../SortDropdown.js';
 
 describe('Sort dropdown', () => {
   let props: any;
@@ -43,27 +43,37 @@ describe('Sort dropdown', () => {
     },
   ];
 
+  const librarySearch = {
+    order: 'desc' as const,
+    sort: 'creationDate',
+    searchTerm: '',
+    filters: {},
+    publishedStatus: { values: ['published', 'restricted'] },
+  };
+
+  const libraryFilters = Immutable.fromJS({
+    properties: [],
+    documentTypes: [],
+  });
+
   beforeEach(() => {
     props = {
       locale: 'en',
       templates: Immutable.fromJS(templates),
-      search: {
-        order: 'asc',
-        sort: 'creationDate',
-        searchTerm: '',
-      },
+      search: librarySearch,
+      filters: libraryFilters,
     };
     search = '(from:0,includeUnpublished:!t,limit:30,order:desc)';
   });
 
-  const render = () => {
+  const render = (location = `/en/library/?q=${search}`) => {
     ({ renderResult } = renderConnectedContainer(
       <SortDropdown.WrappedComponent {...props} />,
       () => ({
         ...defaultState,
       }),
       'MemoryRouter',
-      [`/en/library/?q=${search}`]
+      [location]
     ));
   };
 
@@ -73,19 +83,19 @@ describe('Sort dropdown', () => {
     expect(sortButton.parentElement).toHaveClass('dropdown-button');
     expect(listOption.closest('a')).toHaveAttribute(
       'href',
-      '/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:creationDate)'
+      '/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:creationDate,unpublished:!f)'
     );
   });
 
   it.each`
     option             | link
-    ${'Title'}         | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:title)'}
-    ${'Date modified'} | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:editDate)'}
-    ${'Date'}          | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:metadata.date)'}
-    ${'Number'}        | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:metadata.number)'}
-    ${'My select'}     | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:metadata.my_select)'}
-    ${'Sortable name'} | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:metadata.sortable_name)'}
-    ${'Inherited 1'}   | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:metadata.inherited_1.inheritedValue)'}
+    ${'Title'}         | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:title,unpublished:!f)'}
+    ${'Date modified'} | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:editDate,unpublished:!f)'}
+    ${'Date'}          | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:metadata.date,unpublished:!f)'}
+    ${'Number'}        | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:metadata.number,unpublished:!f)'}
+    ${'My select'}     | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:metadata.my_select,unpublished:!f)'}
+    ${'Sortable name'} | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:metadata.sortable_name,unpublished:!f)'}
+    ${'Inherited 1'}   | ${'/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,sort:metadata.inherited_1.inheritedValue,unpublished:!f)'}
   `(
     'should display the sortable option $option with the link, and correct sort and order',
     ({ option, link }) => {
@@ -135,6 +145,11 @@ describe('Sort dropdown', () => {
   describe('when there is an active search term', () => {
     it('should display sort by search relevance option in the button and in the list, and disable the sort button', () => {
       search = "(searchTerm:'my search',sort:_score)";
+      props.search = {
+        ...librarySearch,
+        searchTerm: 'my search',
+        sort: '_score',
+      };
       render();
       const byRelevanceText = screen.getAllByText('Search relevance');
       expect(byRelevanceText).toHaveLength(2);
@@ -147,15 +162,53 @@ describe('Sort dropdown', () => {
       render();
       expect(screen.getByText('Sort ascending').parentElement?.parentElement).toHaveAttribute(
         'href',
-        '/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc)'
+        '/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:asc,sort:creationDate,unpublished:!f)'
       );
 
       search = "(from:0,includeUnpublished:!t,limit:30,order:asc,searchTerm:'some search')";
+      props.search = {
+        ...librarySearch,
+        order: 'asc',
+        searchTerm: 'some search',
+      };
       render();
       expect(screen.getByText('Sort descending').parentElement?.parentElement).toHaveAttribute(
         'href',
-        "/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,searchTerm:'some search')"
+        "/en/library/?q=(from:0,includeUnpublished:!t,limit:30,order:desc,searchTerm:'some search',sort:creationDate,unpublished:!f)"
       );
+    });
+
+    it('should preserve includeUnpublished from Redux when the home URL has no query params', () => {
+      render('/en/');
+      expect(screen.getByText('Sort ascending').parentElement?.parentElement).toHaveAttribute(
+        'href',
+        '/en/?q=(from:0,includeUnpublished:!t,order:asc,sort:creationDate,unpublished:!f)'
+      );
+      expect(screen.getByText('Title').closest('a')).toHaveAttribute(
+        'href',
+        '/en/?q=(from:0,includeUnpublished:!t,order:asc,sort:title,unpublished:!f)'
+      );
+    });
+  });
+
+  describe('buildCurrentQuery', () => {
+    it('should keep includeUnpublished from Redux when the location search is empty', () => {
+      const query = buildCurrentQuery(librarySearch, libraryFilters, { search: '' });
+      expect(query.includeUnpublished).toBe(true);
+      expect(query.unpublished).toBe(false);
+    });
+
+    it('should keep limit from the URL while taking published status from Redux', () => {
+      const query = buildCurrentQuery(librarySearch, libraryFilters, {
+        search: '?q=(from:0,limit:30,order:desc)',
+      });
+      expect(query).toMatchObject({
+        from: 0,
+        limit: 30,
+        includeUnpublished: true,
+        unpublished: false,
+        order: 'desc',
+      });
     });
   });
 });

--- a/app/react/Library/components/specs/__snapshots__/SortDropdown.spec.tsx.snap
+++ b/app/react/Library/components/specs/__snapshots__/SortDropdown.spec.tsx.snap
@@ -38,7 +38,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:asc,searchTerm:'my search',sort:title)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:asc,searchTerm:'my search',sort:title,unpublished:!f)"
           >
             Title
           </a>
@@ -47,7 +47,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:desc,searchTerm:'my search',sort:creationDate)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:desc,searchTerm:'my search',sort:creationDate,unpublished:!f)"
           >
             Date added
           </a>
@@ -56,7 +56,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:desc,searchTerm:'my search',sort:editDate)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:desc,searchTerm:'my search',sort:editDate,unpublished:!f)"
           >
             Date modified
           </a>
@@ -65,7 +65,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:desc,searchTerm:'my search',sort:_score)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:desc,searchTerm:'my search',sort:_score,unpublished:!f)"
           >
             Search relevance
           </a>
@@ -74,7 +74,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:desc,searchTerm:'my search',sort:metadata.date)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:desc,searchTerm:'my search',sort:metadata.date,unpublished:!f)"
           >
             Date
           </a>
@@ -83,7 +83,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:desc,searchTerm:'my search',sort:metadata.number)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:desc,searchTerm:'my search',sort:metadata.number,unpublished:!f)"
           >
             Number
           </a>
@@ -92,7 +92,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:asc,searchTerm:'my search',sort:metadata.my_select)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:asc,searchTerm:'my search',sort:metadata.my_select,unpublished:!f)"
           >
             My select
           </a>
@@ -101,7 +101,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:asc,searchTerm:'my search',sort:metadata.sortable_name)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:asc,searchTerm:'my search',sort:metadata.sortable_name,unpublished:!f)"
           >
             Sortable name
           </a>
@@ -110,7 +110,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
           <a
             aria-current="page"
             data-discover="true"
-            href="/en/library/?q=(from:0,order:desc,searchTerm:'my search',sort:metadata.inherited_1.inheritedValue)"
+            href="/en/library/?q=(from:0,includeUnpublished:!t,order:desc,searchTerm:'my search',sort:metadata.inherited_1.inheritedValue,unpublished:!f)"
           >
             Inherited 1
           </a>
@@ -121,7 +121,7 @@ exports[`Sort dropdown when there is an active search term should display sort b
       aria-current="page"
       data-discover="true"
       disable="true"
-      href="/en/library/?q=(from:0,order:asc,searchTerm:'my search',sort:_score)"
+      href="/en/library/?q=(from:0,includeUnpublished:!t,order:asc,searchTerm:'my search',sort:_score,unpublished:!f)"
     >
       <button
         class="sorting-toggle"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
fixes #9301

## Summary
- `SortDropdown` now builds sort URLs from Redux `library.search` via `processFilters` (same pattern as the Library menu), merged with URL params.
- Preserves `includeUnpublished` (and other applied filters) when changing sort order from the home page, where those defaults live in route params/Redux but not in the URL.
- Adds regression coverage for the empty home URL case.

## Test plan
- [x] Unit tests for `SortDropdown` / `buildCurrentQuery`
- [x] Smoke: open home as logged-in user with Published + Restricted selected → change sort order → Restricted results and `includeUnpublished` remain in the URL/API request
- [x] Smoke: from `/library/?q=(...,includeUnpublished:!t,...)` sorting still preserves existing query params
- [x] Smoke: logged-out / published-only library still sorts without forcing unpublished results


