### PR TITLE
Fix empty array filters in EntitiesDAO

### DIFF
--- a/app/api/core/infrastructure/mongodb/entity/MongoEntitiesDAO.ts
+++ b/app/api/core/infrastructure/mongodb/entity/MongoEntitiesDAO.ts
@@ -437,10 +437,12 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
     const conditions: Record<string, unknown>[] = [{ template: new ObjectId(query.templateId) }];
 
     const range: Record<string, unknown> = {};
-    if (query.from && ObjectId.isValid(query.from)) {
+    if (query.from) {
+      if (!ObjectId.isValid(query.from)) return [];
       range.$gte = new ObjectId(query.from);
     }
-    if (query.to && ObjectId.isValid(query.to)) {
+    if (query.to) {
+      if (!ObjectId.isValid(query.to)) return [];
       range.$lte = new ObjectId(query.to);
     }
     if (Object.keys(range).length > 0) {
@@ -530,6 +532,8 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
     if (filters._id) {
       if (ObjectId.isValid(filters._id)) {
         conditions.push({ _id: new ObjectId(filters._id) });
+      } else {
+        conditions.push({ _id: { $in: [] } });
       }
     }
 

--- a/app/api/core/infrastructure/mongodb/entity/MongoEntitiesDAO.ts
+++ b/app/api/core/infrastructure/mongodb/entity/MongoEntitiesDAO.ts
@@ -188,13 +188,13 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
 
   private translateGetWithFilesMatch(match: GetWithFilesMatch): Record<string, unknown> {
     const $match: Record<string, unknown> = {};
-    if (match.sharedId) {
+    if (match.sharedId !== undefined) {
       $match.sharedId = match.sharedId;
     }
     if (match.sharedIds !== undefined) {
       $match.sharedId = { $in: match.sharedIds };
     }
-    if (match.language) {
+    if (match.language !== undefined) {
       $match.language = match.language;
     }
     if (match.published !== undefined) {
@@ -265,7 +265,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
     language?: LanguageISO6391
   ): Promise<EntityDBO[] | EntityDBO | null> {
     const filter: Record<string, unknown> = { sharedId };
-    if (language) {
+    if (language !== undefined) {
       filter.language = language;
       return this.getCollection().findOne(filter);
     }
@@ -449,7 +449,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ _id: range });
     }
 
-    if (query.language) {
+    if (query.language !== undefined) {
       conditions.push({ language: query.language });
     }
 
@@ -529,7 +529,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
   private translateFilterConditions(filters: EntityFilters): Record<string, unknown>[] {
     const conditions: Record<string, unknown>[] = [];
 
-    if (filters._id) {
+    if (filters._id !== undefined) {
       if (ObjectId.isValid(filters._id)) {
         conditions.push({ _id: new ObjectId(filters._id) });
       } else {
@@ -542,7 +542,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ _id: { $in: validIds.map(id => new ObjectId(id)) } });
     }
 
-    if (filters.sharedId) {
+    if (filters.sharedId !== undefined) {
       conditions.push({ sharedId: filters.sharedId });
     }
 
@@ -550,7 +550,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ sharedId: { $in: filters.sharedIds } });
     }
 
-    if (filters.language) {
+    if (filters.language !== undefined) {
       conditions.push({ language: filters.language });
     }
 
@@ -558,15 +558,19 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ language: { $in: filters.languages } });
     }
 
-    if (filters.template) {
-      conditions.push({ template: new ObjectId(filters.template) });
+    if (filters.template !== undefined) {
+      if (ObjectId.isValid(filters.template)) {
+        conditions.push({ template: new ObjectId(filters.template) });
+      } else {
+        conditions.push({ _id: { $in: [] } });
+      }
     }
 
     if (filters.templateIds !== undefined) {
       conditions.push({ template: { $in: filters.templateIds.map(id => new ObjectId(id)) } });
     }
 
-    if (filters.title) {
+    if (filters.title !== undefined) {
       conditions.push({ title: filters.title });
     }
 

--- a/app/api/core/infrastructure/mongodb/entity/MongoEntitiesDAO.ts
+++ b/app/api/core/infrastructure/mongodb/entity/MongoEntitiesDAO.ts
@@ -191,7 +191,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
     if (match.sharedId) {
       $match.sharedId = match.sharedId;
     }
-    if (match.sharedIds && match.sharedIds.length > 0) {
+    if (match.sharedIds !== undefined) {
       $match.sharedId = { $in: match.sharedIds };
     }
     if (match.language) {
@@ -533,18 +533,16 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       }
     }
 
-    if (filters.ids && filters.ids.length > 0) {
+    if (filters.ids !== undefined) {
       const validIds = filters.ids.filter(id => ObjectId.isValid(id));
-      if (validIds.length > 0) {
-        conditions.push({ _id: { $in: validIds.map(id => new ObjectId(id)) } });
-      }
+      conditions.push({ _id: { $in: validIds.map(id => new ObjectId(id)) } });
     }
 
     if (filters.sharedId) {
       conditions.push({ sharedId: filters.sharedId });
     }
 
-    if (filters.sharedIds && filters.sharedIds.length > 0) {
+    if (filters.sharedIds !== undefined) {
       conditions.push({ sharedId: { $in: filters.sharedIds } });
     }
 
@@ -552,7 +550,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ language: filters.language });
     }
 
-    if (filters.languages && filters.languages.length > 0) {
+    if (filters.languages !== undefined) {
       conditions.push({ language: { $in: filters.languages } });
     }
 
@@ -560,7 +558,7 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ template: new ObjectId(filters.template) });
     }
 
-    if (filters.templateIds && filters.templateIds.length > 0) {
+    if (filters.templateIds !== undefined) {
       conditions.push({ template: { $in: filters.templateIds.map(id => new ObjectId(id)) } });
     }
 
@@ -576,12 +574,17 @@ class MongoEntitiesDAO extends MongoDataSource<EntityDBO> implements EntitiesDAO
       conditions.push({ published: filters.published });
     }
 
-    if (filters.metadataValueIn && filters.metadataValueIn.length > 0) {
-      conditions.push({
-        $or: filters.metadataValueIn.map(({ property, value }) => ({
-          [`metadata.${property}`]: { $elemMatch: { value } },
-        })),
-      });
+    if (filters.metadataValueIn !== undefined) {
+      if (filters.metadataValueIn.length === 0) {
+        // An empty OR list must match nothing, not everything.
+        conditions.push({ _id: { $in: [] } });
+      } else {
+        conditions.push({
+          $or: filters.metadataValueIn.map(({ property, value }) => ({
+            [`metadata.${property}`]: { $elemMatch: { value } },
+          })),
+        });
+      }
     }
 
     return conditions;

--- a/app/api/core/infrastructure/postgresql/entity/PostgresEntitiesDAO.ts
+++ b/app/api/core/infrastructure/postgresql/entity/PostgresEntitiesDAO.ts
@@ -101,7 +101,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
     q: ReturnType<typeof this.table.where>,
     filters: EntityFilters
   ): ReturnType<typeof this.table.where> {
-    if (filters._id) {
+    if (filters._id !== undefined) {
       q = q.where({ _id: filters._id });
     }
 
@@ -109,7 +109,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.whereIn('_id', filters.ids);
     }
 
-    if (filters.sharedId) {
+    if (filters.sharedId !== undefined) {
       q = q.where({ sharedId: filters.sharedId });
     }
 
@@ -117,7 +117,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.whereIn('sharedId', filters.sharedIds);
     }
 
-    if (filters.language) {
+    if (filters.language !== undefined) {
       q = q.where({ language: filters.language });
     }
 
@@ -125,7 +125,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.whereIn('language', filters.languages);
     }
 
-    if (filters.template) {
+    if (filters.template !== undefined) {
       q = q.where({ template: filters.template });
     }
 
@@ -133,7 +133,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.whereIn('template', filters.templateIds);
     }
 
-    if (filters.title) {
+    if (filters.title !== undefined) {
       q = q.where({ title: filters.title });
     }
 
@@ -220,7 +220,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.whereRaw('?? <= ?', ['_id', query.to]);
     }
 
-    if (query.language) {
+    if (query.language !== undefined) {
       q = q.where({ language: query.language });
     }
 
@@ -323,10 +323,10 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
     const filters: EntityFilters = {};
     if (match.sharedIds !== undefined) {
       filters.sharedIds = match.sharedIds;
-    } else if (match.sharedId) {
+    } else if (match.sharedId !== undefined) {
       filters.sharedId = match.sharedId;
     }
-    if (match.language) {
+    if (match.language !== undefined) {
       filters.language = match.language;
     }
     if (match.published !== undefined) {
@@ -343,7 +343,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
     sharedId: string,
     language?: LanguageISO6391
   ): Promise<EntityDBO[] | EntityDBO | null> {
-    if (language) {
+    if (language !== undefined) {
       return this.findOne({ sharedId, language });
     }
     return this.find({ sharedId });

--- a/app/api/core/infrastructure/postgresql/entity/PostgresEntitiesDAO.ts
+++ b/app/api/core/infrastructure/postgresql/entity/PostgresEntitiesDAO.ts
@@ -105,7 +105,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.where({ _id: filters._id });
     }
 
-    if (filters.ids && filters.ids.length > 0) {
+    if (filters.ids !== undefined) {
       q = q.whereIn('_id', filters.ids);
     }
 
@@ -113,7 +113,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.where({ sharedId: filters.sharedId });
     }
 
-    if (filters.sharedIds && filters.sharedIds.length > 0) {
+    if (filters.sharedIds !== undefined) {
       q = q.whereIn('sharedId', filters.sharedIds);
     }
 
@@ -121,7 +121,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.where({ language: filters.language });
     }
 
-    if (filters.languages && filters.languages.length > 0) {
+    if (filters.languages !== undefined) {
       q = q.whereIn('language', filters.languages);
     }
 
@@ -129,7 +129,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.where({ template: filters.template });
     }
 
-    if (filters.templateIds && filters.templateIds.length > 0) {
+    if (filters.templateIds !== undefined) {
       q = q.whereIn('template', filters.templateIds);
     }
 
@@ -145,11 +145,16 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       q = q.where({ published: filters.published });
     }
 
-    if (filters.metadataValueIn && filters.metadataValueIn.length > 0) {
-      q = q.whereJsonSupersetOfAny(
-        'metadata',
-        filters.metadataValueIn.map(({ property, value }) => ({ [property]: [{ value }] }))
-      );
+    if (filters.metadataValueIn !== undefined) {
+      if (filters.metadataValueIn.length === 0) {
+        // An empty OR list must match nothing, not everything.
+        q = q.whereIn('_id', []);
+      } else {
+        q = q.whereJsonSupersetOfAny(
+          'metadata',
+          filters.metadataValueIn.map(({ property, value }) => ({ [property]: [{ value }] }))
+        );
+      }
     }
 
     return q;
@@ -316,7 +321,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
     if (match.sharedId) {
       filters.sharedId = match.sharedId;
     }
-    if (match.sharedIds && match.sharedIds.length > 0) {
+    if (match.sharedIds !== undefined) {
       filters.sharedIds = match.sharedIds;
     }
     if (match.language) {

--- a/app/api/core/infrastructure/postgresql/entity/PostgresEntitiesDAO.ts
+++ b/app/api/core/infrastructure/postgresql/entity/PostgresEntitiesDAO.ts
@@ -207,6 +207,9 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
     query: FindByTemplateIdRangeQuery,
     options: FindOptions = {}
   ): Promise<EntityDBO[]> {
+    if (query.from && !ObjectId.isValid(query.from)) return [];
+    if (query.to && !ObjectId.isValid(query.to)) return [];
+
     let q = this.table.where({ template: query.templateId });
 
     if (query.from && query.to) {
@@ -240,7 +243,7 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
       }
       if (criteria.hasValues) {
         q = q.whereRaw(
-          "EXISTS (SELECT 1 FROM jsonb_array_elements(??->?) AS elem WHERE elem->>'value' IS NOT NULL AND elem->>'value' NOT IN ('', 'null'))",
+          "EXISTS (SELECT 1 FROM jsonb_array_elements(??->?) AS elem WHERE elem->>'value' IS NOT NULL AND elem->>'value' <> '')",
           ['metadata', criteria.property]
         );
       }
@@ -318,11 +321,10 @@ class PostgresEntitiesDAO extends PostgresDataSource<EntityRow> implements Entit
 
   async getWithFiles(match: GetWithFilesMatch): Promise<EntityWithFiles[]> {
     const filters: EntityFilters = {};
-    if (match.sharedId) {
-      filters.sharedId = match.sharedId;
-    }
     if (match.sharedIds !== undefined) {
       filters.sharedIds = match.sharedIds;
+    } else if (match.sharedId) {
+      filters.sharedId = match.sharedId;
     }
     if (match.language) {
       filters.language = match.language;

--- a/app/api/core/infrastructure/specs/entitiesDAO.spec.ts
+++ b/app/api/core/infrastructure/specs/entitiesDAO.spec.ts
@@ -122,13 +122,13 @@ describe('EntitiesDAO', () => {
     const distinctSharedIds = ['entity1', 'entity2', 'entity3', 'entity4', 'entity5', 'entity6'];
 
     describe('permission safety (safe by default)', () => {
-      it('returns only published entities for anonymous users', async () => {
+      it('should return only published entities for anonymous users', async () => {
         const dao = createDao(publicUser);
         const entities = await dao.find();
         expect(entities).toHaveLength(publishedEntityCount);
       });
 
-      it('returns published + explicitly shared entities for a collaborator', async () => {
+      it('should return published + explicitly shared entities for a collaborator', async () => {
         const dao = createDao(collaboratorUser);
         const entities = await dao.find();
         const sharedIds = entities.map(e => e.sharedId);
@@ -137,32 +137,32 @@ describe('EntitiesDAO', () => {
         expect(sharedIds).not.toContain('entity2');
       });
 
-      it('returns only published entities for a collaborator without matching permissions', async () => {
+      it('should return only published entities for a collaborator without matching permissions', async () => {
         const dao = createDao(otherCollaborator);
         const entities = await dao.find();
         expect(entities).toHaveLength(publishedEntityCount);
       });
 
-      it('returns all entities for editor and admin users', async () => {
+      it('should return all entities for editor and admin users', async () => {
         const editorEntities = await createDao(editorUser).find();
         const adminEntities = await createDao(adminUser).find();
         expect(editorEntities).toHaveLength(allEntityCount);
         expect(adminEntities).toHaveLength(allEntityCount);
       });
 
-      it('unrestricted() bypasses permission enforcement', async () => {
+      it('should bypass permission enforcement via unrestricted()', async () => {
         const dao = createDao(publicUser).unrestricted();
         const entities = await dao.find();
         expect(entities).toHaveLength(allEntityCount);
       });
 
-      it('does not return an unpublished entity to anonymous even when queried by sharedId', async () => {
+      it('should not return an unpublished entity to anonymous even when queried by sharedId', async () => {
         const dao = createDao(publicUser);
         expect(await dao.findOne({ sharedId: 'entity2' })).toBeNull();
         expect(await dao.getBySharedId('entity2')).toEqual([]);
       });
 
-      it('count honors the access context', async () => {
+      it('should honor the access context in count()', async () => {
         const anonymousCount = await createDao(publicUser).count();
         const editorCount = await createDao(editorUser).count();
         expect(anonymousCount).toBe(publishedEntityCount);
@@ -171,48 +171,48 @@ describe('EntitiesDAO', () => {
     });
 
     describe('find()', () => {
-      it('returns all entities with no filters', async () => {
+      it('should return all entities with no filters', async () => {
         const entities = await createDao().find();
         expect(entities).toHaveLength(allEntityCount);
       });
 
-      it('filters by sharedId', async () => {
+      it('should filter by sharedId', async () => {
         const entities = await createDao().find({ sharedId: 'entity1' });
         expect(entities).toHaveLength(2);
         expect(entities.every(e => e.sharedId === 'entity1')).toBe(true);
       });
 
-      it('filters by sharedIds', async () => {
+      it('should filter by sharedIds', async () => {
         const entities = await createDao().find({ sharedIds: ['entity1', 'entity3'] });
         expect(entities).toHaveLength(3);
       });
 
-      it('returns no entities for an empty sharedIds filter', async () => {
+      it('should return no entities for an empty sharedIds filter', async () => {
         const entities = await createDao().find({ sharedIds: [] });
         expect(entities).toEqual([]);
       });
 
-      it('filters by language and languages', async () => {
+      it('should filter by language and languages', async () => {
         expect(await createDao().find({ language: 'es' })).toHaveLength(3);
         expect(await createDao().find({ languages: ['en'] })).toHaveLength(5);
       });
 
-      it('returns no entities for an empty languages filter', async () => {
+      it('should return no entities for an empty languages filter', async () => {
         expect(await createDao().find({ languages: [] })).toEqual([]);
       });
 
-      it('filters by template and templateIds', async () => {
+      it('should filter by template and templateIds', async () => {
         expect(await createDao().find({ template: factory.idString('t1') })).toHaveLength(5);
         expect(
           await createDao().find({ templateIds: [factory.idString('t1'), factory.idString('t2')] })
         ).toHaveLength(allEntityCount);
       });
 
-      it('returns no entities for an empty templateIds filter', async () => {
+      it('should return no entities for an empty templateIds filter', async () => {
         expect(await createDao().find({ templateIds: [] })).toEqual([]);
       });
 
-      it('filters by _id and ids', async () => {
+      it('should filter by _id and ids', async () => {
         expect(await createDao().find({ _id: factory.idString('entity1-en') })).toHaveLength(1);
         expect(
           await createDao().find({
@@ -221,27 +221,31 @@ describe('EntitiesDAO', () => {
         ).toHaveLength(2);
       });
 
-      it('returns no entities for an empty ids filter', async () => {
+      it('should return no entities for an empty ids filter', async () => {
         expect(await createDao().find({ ids: [] })).toEqual([]);
       });
 
-      it('filters by title', async () => {
+      it('should return no entities for an invalid _id filter', async () => {
+        expect(await createDao().find({ _id: 'invalid' })).toEqual([]);
+      });
+
+      it('should filter by title', async () => {
         const entities = await createDao().find({ title: 'entity1' });
         expect(entities).toHaveLength(2);
       });
 
-      it('filters by titleNotEmpty', async () => {
+      it('should filter by titleNotEmpty', async () => {
         const entities = await createDao().find({ titleNotEmpty: true });
         expect(entities).toHaveLength(allEntityCount - 1);
         expect(entities.every(e => e.title !== '')).toBe(true);
       });
 
-      it('filters by published', async () => {
+      it('should filter by published', async () => {
         expect(await createDao().find({ published: true })).toHaveLength(publishedEntityCount);
         expect(await createDao().find({ published: false })).toHaveLength(2);
       });
 
-      it('filters by metadataValueIn', async () => {
+      it('should filter by metadataValueIn', async () => {
         const entities = await createDao().find({
           metadataValueIn: [{ property: 'text_prop', value: 'value1' }],
         });
@@ -249,11 +253,11 @@ describe('EntitiesDAO', () => {
         expect(entities.every(e => e.sharedId === 'entity1')).toBe(true);
       });
 
-      it('returns no entities for an empty metadataValueIn filter', async () => {
+      it('should return no entities for an empty metadataValueIn filter', async () => {
         expect(await createDao().find({ metadataValueIn: [] })).toEqual([]);
       });
 
-      it('combines multiple filters', async () => {
+      it('should combine multiple filters', async () => {
         const entities = await createDao().find({
           language: 'en',
           template: factory.idString('t1'),
@@ -261,7 +265,7 @@ describe('EntitiesDAO', () => {
         expect(entities).toHaveLength(3);
       });
 
-      it('supports select projections', async () => {
+      it('should support select projections', async () => {
         const entities = await createDao().find(
           { sharedId: 'entity1' },
           { select: ['sharedId', 'title'] }
@@ -271,7 +275,7 @@ describe('EntitiesDAO', () => {
         expect((entities[0] as any).metadata).toBeUndefined();
       });
 
-      it('supports sort', async () => {
+      it('should support sort', async () => {
         const entities = await createDao().find(
           {},
           { sort: [{ field: 'title', direction: 'asc' }] }
@@ -279,29 +283,29 @@ describe('EntitiesDAO', () => {
         expect(entities[0].title).toBe('');
       });
 
-      it('supports limit', async () => {
+      it('should support limit', async () => {
         const entities = await createDao().find({}, { limit: 2 });
         expect(entities).toHaveLength(2);
       });
     });
 
     describe('findOne()', () => {
-      it('returns a single matching entity', async () => {
+      it('should return a single matching entity', async () => {
         const entity = await createDao().findOne({ sharedId: 'entity2' });
         expect(entity).not.toBeNull();
         expect(entity!.sharedId).toBe('entity2');
       });
 
-      it('returns the matching language variant', async () => {
+      it('should return the matching language variant', async () => {
         const entity = await createDao().findOne({ sharedId: 'entity1', language: 'en' });
         expect(entity!.language).toBe('en');
       });
 
-      it('returns null when nothing matches', async () => {
+      it('should return null when nothing matches', async () => {
         expect(await createDao().findOne({ sharedId: 'nonexistent' })).toBeNull();
       });
 
-      it('supports select projections', async () => {
+      it('should support select projections', async () => {
         const entity = await createDao().findOne(
           { sharedId: 'entity1', language: 'en' },
           { select: ['sharedId', 'title'] }
@@ -312,27 +316,27 @@ describe('EntitiesDAO', () => {
     });
 
     describe('count()', () => {
-      it('counts all entities with no filters', async () => {
+      it('should count all entities with no filters', async () => {
         expect(await createDao().count()).toBe(allEntityCount);
       });
 
-      it('counts with filters', async () => {
+      it('should count with filters', async () => {
         expect(await createDao().count({ language: 'es' })).toBe(3);
         expect(await createDao().count({ sharedId: 'entity1' })).toBe(2);
       });
 
-      it('returns 0 when nothing matches', async () => {
+      it('should return 0 when nothing matches', async () => {
         expect(await createDao().count({ sharedId: 'nonexistent' })).toBe(0);
       });
     });
 
     describe('getIds()', () => {
-      it('returns all _id strings with no filters', async () => {
+      it('should return all _id strings with no filters', async () => {
         const ids = await createDao().getIds();
         expect(ids).toHaveLength(allEntityCount);
       });
 
-      it('returns _id strings with filters', async () => {
+      it('should return _id strings with filters', async () => {
         const ids = await createDao().getIds({ sharedId: 'entity1' });
         expect(ids).toHaveLength(2);
         expect(ids).toContain(factory.idString('entity1-en'));
@@ -340,7 +344,7 @@ describe('EntitiesDAO', () => {
     });
 
     describe('findByLanguagePairs()', () => {
-      it('matches (sharedId, language) tuples as an OR', async () => {
+      it('should match (sharedId, language) tuples as an OR', async () => {
         const entities = await createDao().findByLanguagePairs({
           pairs: [
             { sharedId: 'entity1', language: 'en' },
@@ -350,11 +354,11 @@ describe('EntitiesDAO', () => {
         expect(entities).toHaveLength(2);
       });
 
-      it('returns empty array for empty pairs', async () => {
+      it('should return empty array for empty pairs', async () => {
         expect(await createDao().findByLanguagePairs({ pairs: [] })).toEqual([]);
       });
 
-      it('returns empty array when nothing matches', async () => {
+      it('should return empty array when nothing matches', async () => {
         expect(
           await createDao().findByLanguagePairs({
             pairs: [{ sharedId: 'nonexistent', language: 'en' }],
@@ -362,7 +366,7 @@ describe('EntitiesDAO', () => {
         ).toEqual([]);
       });
 
-      it('supports limit', async () => {
+      it('should support limit', async () => {
         const entities = await createDao().findByLanguagePairs(
           {
             pairs: [
@@ -378,7 +382,7 @@ describe('EntitiesDAO', () => {
     });
 
     describe('findByTemplateIdRange()', () => {
-      it('returns entities within the inclusive _id range for the given template', async () => {
+      it('should return entities within the inclusive _id range for the given template', async () => {
         const result = await createDao().findByTemplateIdRange({
           templateId: factory.idString('t1'),
           from: factory.idString('entity1-en'),
@@ -391,7 +395,7 @@ describe('EntitiesDAO', () => {
         expect(result.every(e => e.template.toString() === factory.idString('t1'))).toBe(true);
       });
 
-      it('supports a from-only range', async () => {
+      it('should support a from-only range', async () => {
         const result = await createDao().findByTemplateIdRange({
           templateId: factory.idString('t1'),
           from: factory.idString('entity2-en'),
@@ -402,7 +406,7 @@ describe('EntitiesDAO', () => {
         expect(sharedIds).not.toContain('entity1');
       });
 
-      it('supports a to-only range', async () => {
+      it('should support a to-only range', async () => {
         const result = await createDao().findByTemplateIdRange({
           templateId: factory.idString('t1'),
           to: factory.idString('entity2-en'),
@@ -413,7 +417,7 @@ describe('EntitiesDAO', () => {
         expect(sharedIds).not.toContain('entity5');
       });
 
-      it('filters by language within the range', async () => {
+      it('should filter by language within the range', async () => {
         const result = await createDao().findByTemplateIdRange({
           templateId: factory.idString('t1'),
           from: factory.idString('entity1-en'),
@@ -424,7 +428,7 @@ describe('EntitiesDAO', () => {
         expect(result.every(e => e.language === 'en')).toBe(true);
       });
 
-      it('returns empty array when nothing matches', async () => {
+      it('should return empty array when nothing matches', async () => {
         expect(
           await createDao().findByTemplateIdRange({
             templateId: factory.idString('nonexistent'),
@@ -433,31 +437,80 @@ describe('EntitiesDAO', () => {
           })
         ).toEqual([]);
       });
+
+      it('should return empty array when the from bound is invalid', async () => {
+        expect(
+          await createDao().findByTemplateIdRange({
+            templateId: factory.idString('t1'),
+            from: 'invalid',
+            to: factory.idString('entity4-es'),
+          })
+        ).toEqual([]);
+      });
+
+      it('should return empty array when the to bound is invalid', async () => {
+        expect(
+          await createDao().findByTemplateIdRange({
+            templateId: factory.idString('t1'),
+            from: factory.idString('entity1-en'),
+            to: 'invalid',
+          })
+        ).toEqual([]);
+      });
+
+      it('should return empty array when both bounds are invalid', async () => {
+        expect(
+          await createDao().findByTemplateIdRange({
+            templateId: factory.idString('t1'),
+            from: 'invalid',
+            to: 'invalid',
+          })
+        ).toEqual([]);
+      });
     });
 
     describe('findByMetadataCriteria()', () => {
-      it('filters by metadata exists', async () => {
+      it('should filter by metadata exists', async () => {
         const entities = await createDao().findByMetadataCriteria({
           criteria: [{ property: 'text_prop', exists: true }],
         });
         expect(entities).toHaveLength(3);
       });
 
-      it('filters by metadata nonEmpty', async () => {
+      it('should filter by metadata nonEmpty', async () => {
         const entities = await createDao().findByMetadataCriteria({
           criteria: [{ property: 'text_prop', nonEmpty: true }],
         });
         expect(entities).toHaveLength(3);
       });
 
-      it('filters by metadata hasValues', async () => {
+      it('should filter by metadata hasValues', async () => {
         const entities = await createDao().findByMetadataCriteria({
           criteria: [{ property: 'text_prop', hasValues: true }],
         });
         expect(entities).toHaveLength(3);
       });
 
-      it('combines multiple criteria as an AND', async () => {
+      it('should treat the string "null" as a value for hasValues', async () => {
+        const fixtures = createFixtures();
+        const nullValueEntity = factory.entity(
+          'entity-null-value',
+          't1',
+          { text_prop: [factory.metadataValue('null')] },
+          { published: true }
+        );
+        await testingEnvironment.setFixtures({
+          ...fixtures,
+          entities: [...(fixtures.entities || []), nullValueEntity],
+        });
+
+        const entities = await createDao().findByMetadataCriteria({
+          criteria: [{ property: 'text_prop', hasValues: true }],
+        });
+        expect(entities.map(e => e.sharedId)).toContain('entity-null-value');
+      });
+
+      it('should combine multiple criteria as an AND', async () => {
         const entities = await createDao().findByMetadataCriteria({
           criteria: [
             { property: 'text_prop', exists: true },
@@ -468,7 +521,7 @@ describe('EntitiesDAO', () => {
         expect(entities.every(e => e.sharedId === 'entity1')).toBe(true);
       });
 
-      it('supports anchor filters combined with criteria', async () => {
+      it('should support anchor filters combined with criteria', async () => {
         const entities = await createDao().findByMetadataCriteria({
           criteria: [{ property: 'text_prop', exists: true }],
           filters: { templateIds: [factory.idString('t1')], titleNotEmpty: true },
@@ -476,7 +529,7 @@ describe('EntitiesDAO', () => {
         expect(entities).toHaveLength(3);
       });
 
-      it('supports limit', async () => {
+      it('should support limit', async () => {
         const entities = await createDao().findByMetadataCriteria(
           { criteria: [{ property: 'text_prop', exists: true }] },
           { limit: 2 }
@@ -486,7 +539,7 @@ describe('EntitiesDAO', () => {
     });
 
     describe('getWithFiles()', () => {
-      it('returns entity with documents and attachments separated', async () => {
+      it('should return entity with documents and attachments separated', async () => {
         const entities = await createDao().getWithFiles({ sharedId: 'entity1', language: 'en' });
         expect(entities).toHaveLength(1);
         expect(entities[0].documents).toHaveLength(1);
@@ -495,20 +548,28 @@ describe('EntitiesDAO', () => {
         expect(entities[0].attachments[0].filename).toBe('att1');
       });
 
-      it('supports multiple sharedIds', async () => {
+      it('should support multiple sharedIds', async () => {
         const entities = await createDao().getWithFiles({ sharedIds: ['entity1'] });
         expect(entities).toHaveLength(2);
       });
 
-      it('returns empty array for an empty sharedIds filter', async () => {
+      it('should prefer sharedIds over sharedId when both are provided', async () => {
+        const entities = await createDao().getWithFiles({
+          sharedId: 'entity1',
+          sharedIds: ['entity3'],
+        });
+        expect(entities.map(e => e.sharedId)).toEqual(['entity3']);
+      });
+
+      it('should return empty array for an empty sharedIds filter', async () => {
         expect(await createDao().getWithFiles({ sharedIds: [] })).toEqual([]);
       });
 
-      it('returns empty array when nothing matches', async () => {
+      it('should return empty array when nothing matches', async () => {
         expect(await createDao().getWithFiles({ sharedId: 'nonexistent' })).toHaveLength(0);
       });
 
-      it('returns empty documents and attachments for entities without files', async () => {
+      it('should return empty documents and attachments for entities without files', async () => {
         const entities = await createDao().getWithFiles({ sharedId: 'entity3' });
         expect(entities).toHaveLength(1);
         expect(entities[0].documents).toEqual([]);
@@ -517,22 +578,22 @@ describe('EntitiesDAO', () => {
     });
 
     describe('getByIdsWithDocuments()', () => {
-      it('returns entities with documents and attachments', async () => {
+      it('should return entities with documents and attachments', async () => {
         const entities = await createDao().getByIdsWithDocuments([factory.idString('entity1-en')]);
         expect(entities).toHaveLength(1);
         expect(entities[0].documents).toHaveLength(1);
         expect(entities[0].attachments).toHaveLength(1);
       });
 
-      it('returns empty array for empty ids', async () => {
+      it('should return empty array for empty ids', async () => {
         expect(await createDao().getByIdsWithDocuments([])).toEqual([]);
       });
 
-      it('returns empty array for non-existent ids', async () => {
+      it('should return empty array for non-existent ids', async () => {
         expect(await createDao().getByIdsWithDocuments(['nonexistent'])).toEqual([]);
       });
 
-      it('respects the limit option', async () => {
+      it('should respect the limit option', async () => {
         const entities = await createDao().getByIdsWithDocuments(
           [factory.idString('entity1-en'), factory.idString('entity2-en')],
           { limit: 1 }
@@ -540,7 +601,7 @@ describe('EntitiesDAO', () => {
         expect(entities).toHaveLength(1);
       });
 
-      it('includes fullText when documentsFullText is true and excludes it by default', async () => {
+      it('should include fullText when documentsFullText is true and excludes it by default', async () => {
         const withFullText = await createDao().getByIdsWithDocuments(
           [factory.idString('entity1-en')],
           { documentsFullText: true }
@@ -555,37 +616,37 @@ describe('EntitiesDAO', () => {
     });
 
     describe('getBySharedId()', () => {
-      it('returns the entity for the given sharedId and language', async () => {
+      it('should return the entity for the given sharedId and language', async () => {
         const entity = await createDao().getBySharedId('entity1', 'en');
         expect(entity).not.toBeNull();
         expect((entity as EntityDBO).language).toBe('en');
       });
 
-      it('returns all language variants when no language is given', async () => {
+      it('should return all language variants when no language is given', async () => {
         const entities = await createDao().getBySharedId('entity1');
         expect(Array.isArray(entities)).toBe(true);
         expect(entities).toHaveLength(2);
         expect(entities.every((e: EntityDBO) => e.sharedId === 'entity1')).toBe(true);
       });
 
-      it('returns null when language is given and nothing matches', async () => {
+      it('should return null when language is given and nothing matches', async () => {
         expect(await createDao().getBySharedId('nonexistent', 'en')).toBeNull();
       });
 
-      it('returns empty array when no language is given and nothing matches', async () => {
+      it('should return empty array when no language is given and nothing matches', async () => {
         expect(await createDao().getBySharedId('nonexistent')).toEqual([]);
       });
     });
 
     describe('getByInternalId()', () => {
-      it('returns the entity matching the provided _id', async () => {
+      it('should return the entity matching the provided _id', async () => {
         const entity = await createDao().getByInternalId(factory.idString('entity1-en'));
         expect(entity).not.toBeNull();
         expect(entity!.sharedId).toBe('entity1');
         expect(entity!.language).toBe('en');
       });
 
-      it('supports projections', async () => {
+      it('should support projections', async () => {
         const entity = await createDao().getByInternalId(factory.idString('entity1-en'), {
           title: 1,
           sharedId: 1,
@@ -594,41 +655,41 @@ describe('EntitiesDAO', () => {
         expect((entity as any).metadata).toBeUndefined();
       });
 
-      it('returns null when nothing matches', async () => {
+      it('should return null when nothing matches', async () => {
         expect(await createDao().getByInternalId(factory.idString('nonexistent'))).toBeNull();
       });
     });
 
     describe('countByTemplate()', () => {
-      it('counts distinct sharedIds for the given template', async () => {
+      it('should count distinct sharedIds for the given template', async () => {
         expect(await createDao().countByTemplate(factory.idString('t1'))).toBe(4);
         expect(await createDao().countByTemplate(factory.idString('t2'))).toBe(2);
       });
 
-      it('returns 0 for a template with no entities', async () => {
+      it('should return 0 for a template with no entities', async () => {
         expect(await createDao().countByTemplate(factory.idString('nonexistent'))).toBe(0);
       });
     });
 
     describe('countDistinctSharedIds()', () => {
-      it('counts distinct sharedIds across all entities', async () => {
+      it('should count distinct sharedIds across all entities', async () => {
         expect(await createDao().countDistinctSharedIds()).toBe(distinctSharedIds.length);
       });
     });
 
     describe('getSharedIdLabelInfo()', () => {
-      it('returns title and icon for the given sharedIds and language', async () => {
+      it('should return title and icon for the given sharedIds and language', async () => {
         const result = await createDao().getSharedIdLabelInfo(['entity1', 'entity4'], 'en');
         expect(result).toHaveLength(2);
         expect(result.map(r => r.sharedId).sort()).toEqual(['entity1', 'entity4']);
         expect(result.every(r => r.title === r.sharedId)).toBe(true);
       });
 
-      it('returns empty array for empty sharedIds', async () => {
+      it('should return empty array for empty sharedIds', async () => {
         expect(await createDao().getSharedIdLabelInfo([], 'en')).toEqual([]);
       });
 
-      it('only returns entities matching the language', async () => {
+      it('should only return entities matching the language', async () => {
         const result = await createDao().getSharedIdLabelInfo(['entity1'], 'es');
         expect(result).toHaveLength(1);
         expect(result[0].sharedId).toBe('entity1');
@@ -636,24 +697,24 @@ describe('EntitiesDAO', () => {
     });
 
     describe('getTitleLabelsBySharedIds()', () => {
-      it('returns a per-language label map', async () => {
+      it('should return a per-language label map', async () => {
         const result = await createDao().getTitleLabelsBySharedIds(['entity1'], ['en', 'es']);
         expect(result.get('entity1')).toEqual({ en: 'entity1', es: 'entity1' });
       });
 
-      it('returns an empty map for empty inputs', async () => {
+      it('should return an empty map for empty inputs', async () => {
         expect((await createDao().getTitleLabelsBySharedIds([], ['en'])).size).toBe(0);
       });
     });
 
     describe('cloneForLanguage()', () => {
-      it('clones all entities from the source language to the target language', async () => {
+      it('should clone all entities from the source language to the target language', async () => {
         await createDao().cloneForLanguage('en', 'fr');
         const cloned = await createDao().find({ language: 'fr' });
         expect(cloned).toHaveLength(5);
       });
 
-      it('is idempotent on Mongo; a second run fails on Postgres (unique index)', async () => {
+      it('should be idempotent on Mongo; a second run fails on Postgres (unique index)', async () => {
         const dao = createDao();
         await dao.cloneForLanguage('en', 'fr');
         if (usePostgres) {
@@ -667,7 +728,7 @@ describe('EntitiesDAO', () => {
         }
       });
 
-      it('rejects on Postgres when the target language already has entities; preserves them on Mongo', async () => {
+      it('should reject on Postgres when the target language already has entities; preserves them on Mongo', async () => {
         const existing = factory.entity('entity1', 't1', {}, { language: 'fr', title: 'existing' });
         const fixtures = createFixtures();
         await testingEnvironment.setFixtures({
@@ -683,7 +744,7 @@ describe('EntitiesDAO', () => {
         }
       });
 
-      it('calls onBatch with cloned entities having the target language and no _id', async () => {
+      it('should call onBatch with cloned entities having the target language and no _id', async () => {
         const onBatch = jest.fn();
         await createDao().cloneForLanguage('en', 'fr', onBatch);
         expect(onBatch).toHaveBeenCalled();
@@ -695,13 +756,13 @@ describe('EntitiesDAO', () => {
     });
 
     describe('deleteByLanguage()', () => {
-      it('deletes all entities of the given language', async () => {
+      it('should delete all entities of the given language', async () => {
         await createDao().deleteByLanguage('es');
         expect(await createDao().find({ language: 'es' })).toHaveLength(0);
         expect(await createDao().count()).toBe(allEntityCount - 3);
       });
 
-      it('calls onBatch with the deleted sharedIds', async () => {
+      it('should call onBatch with the deleted sharedIds', async () => {
         const onBatch = jest.fn();
         await createDao().deleteByLanguage('es', onBatch);
         expect(onBatch).toHaveBeenCalled();

--- a/app/api/core/infrastructure/specs/entitiesDAO.spec.ts
+++ b/app/api/core/infrastructure/specs/entitiesDAO.spec.ts
@@ -229,6 +229,23 @@ describe('EntitiesDAO', () => {
         expect(await createDao().find({ _id: 'invalid' })).toEqual([]);
       });
 
+      it('should return no entities for an empty-string sharedId filter', async () => {
+        expect(await createDao().find({ sharedId: '' })).toEqual([]);
+      });
+
+      it('should return no entities for an empty-string language filter', async () => {
+        expect(await createDao().find({ language: '' })).toEqual([]);
+      });
+
+      it('should return no entities for an empty-string template filter', async () => {
+        expect(await createDao().find({ template: '' })).toEqual([]);
+      });
+
+      it('should return only entities with an empty title for an empty-string title filter', async () => {
+        const entities = await createDao().find({ title: '' });
+        expect(entities.map(e => e.sharedId)).toEqual(['entity6']);
+      });
+
       it('should filter by title', async () => {
         const entities = await createDao().find({ title: 'entity1' });
         expect(entities).toHaveLength(2);
@@ -328,6 +345,10 @@ describe('EntitiesDAO', () => {
       it('should return 0 when nothing matches', async () => {
         expect(await createDao().count({ sharedId: 'nonexistent' })).toBe(0);
       });
+
+      it('should return 0 for an empty-string sharedId filter', async () => {
+        expect(await createDao().count({ sharedId: '' })).toBe(0);
+      });
     });
 
     describe('getIds()', () => {
@@ -340,6 +361,10 @@ describe('EntitiesDAO', () => {
         const ids = await createDao().getIds({ sharedId: 'entity1' });
         expect(ids).toHaveLength(2);
         expect(ids).toContain(factory.idString('entity1-en'));
+      });
+
+      it('should return no ids for an empty-string sharedId filter', async () => {
+        expect(await createDao().getIds({ sharedId: '' })).toEqual([]);
       });
     });
 
@@ -467,6 +492,15 @@ describe('EntitiesDAO', () => {
           })
         ).toEqual([]);
       });
+
+      it('should return empty array for an empty-string language filter', async () => {
+        expect(
+          await createDao().findByTemplateIdRange({
+            templateId: factory.idString('t1'),
+            language: '',
+          })
+        ).toEqual([]);
+      });
     });
 
     describe('findByMetadataCriteria()', () => {
@@ -565,6 +599,14 @@ describe('EntitiesDAO', () => {
         expect(await createDao().getWithFiles({ sharedIds: [] })).toEqual([]);
       });
 
+      it('should return empty array for an empty-string sharedId', async () => {
+        expect(await createDao().getWithFiles({ sharedId: '' })).toEqual([]);
+      });
+
+      it('should return empty array for an empty-string language', async () => {
+        expect(await createDao().getWithFiles({ language: '' as any })).toEqual([]);
+      });
+
       it('should return empty array when nothing matches', async () => {
         expect(await createDao().getWithFiles({ sharedId: 'nonexistent' })).toHaveLength(0);
       });
@@ -636,6 +678,14 @@ describe('EntitiesDAO', () => {
       it('should return empty array when no language is given and nothing matches', async () => {
         expect(await createDao().getBySharedId('nonexistent')).toEqual([]);
       });
+
+      it('should return empty array for an empty-string sharedId', async () => {
+        expect(await createDao().getBySharedId('')).toEqual([]);
+      });
+
+      it('should return null for an empty-string language', async () => {
+        expect(await createDao().getBySharedId('entity1', '' as any)).toBeNull();
+      });
     });
 
     describe('getByInternalId()', () => {
@@ -657,6 +707,10 @@ describe('EntitiesDAO', () => {
 
       it('should return null when nothing matches', async () => {
         expect(await createDao().getByInternalId(factory.idString('nonexistent'))).toBeNull();
+      });
+
+      it('should return null for an empty-string id', async () => {
+        expect(await createDao().getByInternalId('')).toBeNull();
       });
     });
 

--- a/app/api/core/infrastructure/specs/entitiesDAO.spec.ts
+++ b/app/api/core/infrastructure/specs/entitiesDAO.spec.ts
@@ -187,9 +187,18 @@ describe('EntitiesDAO', () => {
         expect(entities).toHaveLength(3);
       });
 
+      it('returns no entities for an empty sharedIds filter', async () => {
+        const entities = await createDao().find({ sharedIds: [] });
+        expect(entities).toEqual([]);
+      });
+
       it('filters by language and languages', async () => {
         expect(await createDao().find({ language: 'es' })).toHaveLength(3);
         expect(await createDao().find({ languages: ['en'] })).toHaveLength(5);
+      });
+
+      it('returns no entities for an empty languages filter', async () => {
+        expect(await createDao().find({ languages: [] })).toEqual([]);
       });
 
       it('filters by template and templateIds', async () => {
@@ -199,6 +208,10 @@ describe('EntitiesDAO', () => {
         ).toHaveLength(allEntityCount);
       });
 
+      it('returns no entities for an empty templateIds filter', async () => {
+        expect(await createDao().find({ templateIds: [] })).toEqual([]);
+      });
+
       it('filters by _id and ids', async () => {
         expect(await createDao().find({ _id: factory.idString('entity1-en') })).toHaveLength(1);
         expect(
@@ -206,6 +219,10 @@ describe('EntitiesDAO', () => {
             ids: [factory.idString('entity1-en'), factory.idString('entity2-en')],
           })
         ).toHaveLength(2);
+      });
+
+      it('returns no entities for an empty ids filter', async () => {
+        expect(await createDao().find({ ids: [] })).toEqual([]);
       });
 
       it('filters by title', async () => {
@@ -230,6 +247,10 @@ describe('EntitiesDAO', () => {
         });
         expect(entities).toHaveLength(2);
         expect(entities.every(e => e.sharedId === 'entity1')).toBe(true);
+      });
+
+      it('returns no entities for an empty metadataValueIn filter', async () => {
+        expect(await createDao().find({ metadataValueIn: [] })).toEqual([]);
       });
 
       it('combines multiple filters', async () => {
@@ -477,6 +498,10 @@ describe('EntitiesDAO', () => {
       it('supports multiple sharedIds', async () => {
         const entities = await createDao().getWithFiles({ sharedIds: ['entity1'] });
         expect(entities).toHaveLength(2);
+      });
+
+      it('returns empty array for an empty sharedIds filter', async () => {
+        expect(await createDao().getWithFiles({ sharedIds: [] })).toEqual([]);
       });
 
       it('returns empty array when nothing matches', async () => {


### PR DESCRIPTION
## Summary

`find({ sharedIds: [] })` was translated into `find({})`, returning every entity instead of none. The same bug affected all empty array filters in the entities DAO on both backends.

## Changes

- **MongoEntitiesDAO**: emit `$in` conditions whenever an array filter key is present, even when empty (`$in: []` matches nothing). `metadataValueIn: []` now emits a no-match condition instead of an invalid `$or: []`. `getWithFiles({ sharedIds: [] })` now matches nothing.
- **PostgresEntitiesDAO**: same fix using `whereIn(col, [])` (Knex renders `where 1 = 0`). `metadataValueIn: []` adds a no-match condition. `getWithFiles({ sharedIds: [] })` now passes the empty filter through.
- **Tests**: added empty-array coverage for `sharedIds`, `languages`, `templateIds`, `ids`, `metadataValueIn`, and `getWithFiles({ sharedIds: [] })` in `entitiesDAO.spec.ts` (runs against both Mongo and Postgres).
