### PR TITLE
Fix dataviz external iframe embed blank chart (vendor chunk)

### DIFF
--- a/app/api/dataviz.v2/infrastructure/http/DatavizEmbedHtmlController.ts
+++ b/app/api/dataviz.v2/infrastructure/http/DatavizEmbedHtmlController.ts
@@ -1,7 +1,7 @@
 import { DatavizController } from './DatavizController.js';
 import { DatavizFactory } from '#api/dataviz.v2/infrastructure/factories/DatavizFactory.js';
 import { renderDatavizEmbedHtml } from '#shared/dataviz/embed/renderDatavizEmbedHtml.js';
-import { resolveDatavizEmbedScriptUrl } from './resolveDatavizEmbedScriptUrl.js';
+import { resolveDatavizEmbedScriptUrls } from './resolveDatavizEmbedScriptUrl.js';
 import { mapDatavizEmbedHtmlErrors } from './mapDatavizEmbedHtmlErrors.js';
 
 class DatavizEmbedHtmlController extends DatavizController {
@@ -30,7 +30,7 @@ class DatavizEmbedHtmlController extends DatavizController {
       language: this.language,
       datavizId: id,
       parentOrigin,
-      embedScriptUrl: resolveDatavizEmbedScriptUrl(),
+      embedScriptUrls: resolveDatavizEmbedScriptUrls(),
     });
     this.response.status(200).type('html').send(html);
   }

--- a/app/api/dataviz.v2/infrastructure/http/resolveDatavizEmbedScriptUrl.ts
+++ b/app/api/dataviz.v2/infrastructure/http/resolveDatavizEmbedScriptUrl.ts
@@ -3,6 +3,14 @@ import { fileURLToPath } from 'url';
 // eslint-disable-next-line node/no-restricted-import
 import fs from 'fs';
 
+type WebpackAssets = {
+  vendor?: { js?: string };
+  'dataviz-embed'?: { js?: string };
+};
+
+/** Webpack entrypoints that wait for shared chunks use `.O(void 0,[chunkIds], ...)`. */
+const WEBPACK_SHARED_CHUNK_BOOTSTRAP = /\.O\s*\(\s*void\s*0\s*,\s*\[\s*\d+/;
+
 const webpackDevScriptUrl = (): string => {
   const webpackPort = process.env.WEBPACK_PORT || 8080;
   const webpackURL =
@@ -12,29 +20,63 @@ const webpackDevScriptUrl = (): string => {
   return `${webpackURL.replace(/\/$/, '')}/dataviz-embed.js`;
 };
 
-const distAssetsPath = (): string => {
+const distRootPath = (): string => {
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(moduleDir, '../../../../../dist/webpack-assets.json');
+  return path.resolve(moduleDir, '../../../../../dist');
 };
 
-const readHashedScriptFromAssets = (): string | undefined => {
+const distAssetsPath = (): string => path.join(distRootPath(), 'webpack-assets.json');
+
+const readWebpackAssets = (): WebpackAssets | undefined => {
   try {
-    const assets = JSON.parse(fs.readFileSync(distAssetsPath(), 'utf8')) as {
-      'dataviz-embed'?: { js?: string };
-    };
-    const js = assets['dataviz-embed']?.js;
-    return typeof js === 'string' ? js : undefined;
+    return JSON.parse(fs.readFileSync(distAssetsPath(), 'utf8')) as WebpackAssets;
   } catch {
     return undefined;
   }
 };
 
-const resolveDatavizEmbedScriptUrl = (): string => {
-  if (process.env.HOT) {
-    return webpackDevScriptUrl();
+const embedBundleRequiresVendorChunk = (embedScriptPath: string): boolean => {
+  try {
+    const absolutePath = path.join(distRootPath(), embedScriptPath.replace(/^\//, ''));
+    const bundle = fs.readFileSync(absolutePath, 'utf8');
+    return WEBPACK_SHARED_CHUNK_BOOTSTRAP.test(bundle);
+  } catch {
+    return false;
   }
-
-  return readHashedScriptFromAssets() ?? '/dataviz-embed.js';
 };
 
-export { resolveDatavizEmbedScriptUrl, webpackDevScriptUrl };
+const resolveProductionEmbedScriptUrls = (): string[] => {
+  const assets = readWebpackAssets();
+  const embedScript = assets?.['dataviz-embed']?.js;
+  if (!embedScript) {
+    return ['/dataviz-embed.js'];
+  }
+
+  const vendorScript = assets?.vendor?.js;
+  if (vendorScript && embedBundleRequiresVendorChunk(embedScript)) {
+    return [vendorScript, embedScript];
+  }
+
+  return [embedScript];
+};
+
+const resolveDatavizEmbedScriptUrls = (): string[] => {
+  if (process.env.HOT) {
+    return [webpackDevScriptUrl()];
+  }
+
+  return resolveProductionEmbedScriptUrls();
+};
+
+/** @deprecated Prefer resolveDatavizEmbedScriptUrls — kept for callers that need a single URL. */
+const resolveDatavizEmbedScriptUrl = (): string => {
+  const urls = resolveDatavizEmbedScriptUrls();
+  return urls[urls.length - 1] ?? '/dataviz-embed.js';
+};
+
+export {
+  resolveDatavizEmbedScriptUrl,
+  resolveDatavizEmbedScriptUrls,
+  webpackDevScriptUrl,
+  WEBPACK_SHARED_CHUNK_BOOTSTRAP,
+};

--- a/app/api/dataviz.v2/infrastructure/http/specs/resolveDatavizEmbedScriptUrl.spec.ts
+++ b/app/api/dataviz.v2/infrastructure/http/specs/resolveDatavizEmbedScriptUrl.spec.ts
@@ -2,7 +2,9 @@
 import fs from 'fs';
 import {
   resolveDatavizEmbedScriptUrl,
+  resolveDatavizEmbedScriptUrls,
   webpackDevScriptUrl,
+  WEBPACK_SHARED_CHUNK_BOOTSTRAP,
 } from '../resolveDatavizEmbedScriptUrl.js';
 
 describe('resolveDatavizEmbedScriptUrl', () => {
@@ -33,6 +35,7 @@ describe('resolveDatavizEmbedScriptUrl', () => {
     process.env.HOT = 'true';
     process.env.WEBPACK_PORT = '8080';
 
+    expect(resolveDatavizEmbedScriptUrls()).toEqual(['http://localhost:8080/dataviz-embed.js']);
     expect(resolveDatavizEmbedScriptUrl()).toBe('http://localhost:8080/dataviz-embed.js');
   });
 
@@ -40,6 +43,7 @@ describe('resolveDatavizEmbedScriptUrl', () => {
     process.env.HOT = 'true';
     process.env.WEBPACK_PUBLIC_URL = 'http://webpack.example';
 
+    expect(resolveDatavizEmbedScriptUrls()).toEqual(['http://webpack.example/dataviz-embed.js']);
     expect(resolveDatavizEmbedScriptUrl()).toBe('http://webpack.example/dataviz-embed.js');
   });
 
@@ -49,21 +53,55 @@ describe('resolveDatavizEmbedScriptUrl', () => {
       throw new Error('missing');
     });
 
+    expect(resolveDatavizEmbedScriptUrls()).toEqual(['/dataviz-embed.js']);
     expect(resolveDatavizEmbedScriptUrl()).toBe('/dataviz-embed.js');
   });
 
   it('should read the hashed script path from webpack-assets.json when not in HOT mode', () => {
     delete process.env.HOT;
-    jest
-      .spyOn(fs, 'readFileSync')
-      .mockReturnValue(JSON.stringify({ 'dataviz-embed': { js: '/dataviz-embed.abc123.js' } }));
+    jest.spyOn(fs, 'readFileSync').mockImplementation((filePath: fs.PathOrFileDescriptor) => {
+      if (String(filePath).endsWith('webpack-assets.json')) {
+        return JSON.stringify({ 'dataviz-embed': { js: '/dataviz-embed.abc123.js' } });
+      }
+      return 'let __webpack_exports__=__webpack_require__(44510);';
+    });
 
+    expect(resolveDatavizEmbedScriptUrls()).toEqual(['/dataviz-embed.abc123.js']);
     expect(resolveDatavizEmbedScriptUrl()).toBe('/dataviz-embed.abc123.js');
+  });
+
+  it('should prepend vendor.js when the embed bundle waits on a shared chunk', () => {
+    delete process.env.HOT;
+    jest.spyOn(fs, 'readFileSync').mockImplementation((filePath: fs.PathOrFileDescriptor) => {
+      if (String(filePath).endsWith('webpack-assets.json')) {
+        return JSON.stringify({
+          vendor: { js: '/vendor.def456.js' },
+          'dataviz-embed': { js: '/dataviz-embed.abc123.js' },
+        });
+      }
+      return 'let __webpack_exports__=__webpack_require__.O(void 0,[4121],(()=>__webpack_require__(44510)));';
+    });
+
+    expect(resolveDatavizEmbedScriptUrls()).toEqual([
+      '/vendor.def456.js',
+      '/dataviz-embed.abc123.js',
+    ]);
   });
 
   it('should expose the webpack dev URL helper', () => {
     process.env.WEBPACK_PORT = '9000';
 
     expect(webpackDevScriptUrl()).toBe('http://localhost:9000/dataviz-embed.js');
+  });
+
+  it('should detect webpack shared-chunk bootstrap markers', () => {
+    expect(
+      WEBPACK_SHARED_CHUNK_BOOTSTRAP.test(
+        'let __webpack_exports__=__webpack_require__.O(void 0,[4121],(()=>__webpack_require__(44510)));'
+      )
+    ).toBe(true);
+    expect(
+      WEBPACK_SHARED_CHUNK_BOOTSTRAP.test('let __webpack_exports__=__webpack_require__(44510);')
+    ).toBe(false);
   });
 });

--- a/app/shared/dataviz/embed/renderDatavizEmbedHtml.ts
+++ b/app/shared/dataviz/embed/renderDatavizEmbedHtml.ts
@@ -71,9 +71,12 @@ const renderMetricHtml = (payload: DatavizEmbedPayload): string => {
   return `<div class="metric"${style ? ` style="${style}"` : ''}><div class="metric-value">${escapeHtml(String(value.toLocaleString()))}</div><div class="metric-label">${escapeHtml(String(label))}</div></div>`;
 };
 
+const renderScriptTags = (scriptUrls: string[]): string =>
+  scriptUrls.map(url => `<script src="${url}"></script>`).join('\n    ');
+
 const renderBootstrapScripts = (
   bootstrap: DatavizEmbedBootstrap,
-  embedScriptUrl: string,
+  embedScriptUrls: string[],
   option?: EChartsOption | null
 ): string => {
   const optionScript =
@@ -87,7 +90,7 @@ const renderBootstrapScripts = (
     <script>window.__DATAVIZ_EMBED__ = ${serialize(bootstrap, { isJSON: true })};</script>
     ${optionScript}
     ${echartsScript}
-    <script src="${embedScriptUrl}"></script>
+    ${renderScriptTags(embedScriptUrls)}
   `;
 };
 
@@ -95,6 +98,8 @@ type RenderDatavizEmbedHtmlInput = {
   payload: DatavizEmbedPayload;
   language: string;
   datavizId: string;
+  embedScriptUrls?: string[];
+  /** @deprecated Use embedScriptUrls */
   embedScriptUrl?: string;
   /** Parent page origin allowed to postMessage filters (cross-origin embeds). */
   parentOrigin?: string;
@@ -116,9 +121,11 @@ const renderDatavizEmbedHtml = ({
   payload,
   language,
   datavizId,
+  embedScriptUrls,
   embedScriptUrl = '/dataviz-embed.js',
   parentOrigin,
 }: RenderDatavizEmbedHtmlInput): string => {
+  const scriptUrls = embedScriptUrls ?? [embedScriptUrl];
   const chartType = payload.chart.type;
   const bootstrap: DatavizEmbedBootstrap = {
     id: datavizId,
@@ -148,7 +155,7 @@ const renderDatavizEmbedHtml = ({
 
   const scripts =
     body.includes('dataviz-embed-root') || option
-      ? renderBootstrapScripts(bootstrap, embedScriptUrl, option)
+      ? renderBootstrapScripts(bootstrap, scriptUrls, option)
       : '';
 
   return `<!DOCTYPE html>

--- a/app/shared/dataviz/embed/specs/renderDatavizEmbedHtml.spec.ts
+++ b/app/shared/dataviz/embed/specs/renderDatavizEmbedHtml.spec.ts
@@ -60,7 +60,7 @@ describe('renderDatavizEmbedHtml', () => {
       payload: manualBarPayload,
       language: 'en',
       datavizId: 'dv-embed-bar',
-      embedScriptUrl: 'http://localhost:8080/dataviz-embed.js',
+      embedScriptUrls: ['http://localhost:8080/dataviz-embed.js'],
       parentOrigin: 'https://partner.example',
     });
 
@@ -72,5 +72,17 @@ describe('renderDatavizEmbedHtml', () => {
     expect(html).toContain('echarts.min.js');
     expect(html).toContain('http://localhost:8080/dataviz-embed.js');
     expect(html).not.toContain('main.js');
+  });
+
+  it('should render multiple embed script tags when provided', () => {
+    const html = renderDatavizEmbedHtml({
+      payload: manualBarPayload,
+      language: 'en',
+      datavizId: 'dv-embed-bar',
+      embedScriptUrls: ['/vendor.abc123.js', '/dataviz-embed.abc123.js'],
+    });
+
+    expect(html).toContain('<script src="/vendor.abc123.js"></script>');
+    expect(html).toContain('<script src="/dataviz-embed.abc123.js"></script>');
   });
 });

--- a/webpack/config.cjs
+++ b/webpack/config.cjs
@@ -91,7 +91,13 @@ module.exports = production => {
             test: /[\\/]node_modules[\\/]/,
             name: 'vendor',
             chunks(chunk) {
-              return chunk.name && !chunk.name.match(/LazyLoad/);
+              // Keep the public embed bundle self-contained: it is loaded alone in
+              // iframe HTML and cannot rely on the main app's vendor chunk.
+              return (
+                chunk.name &&
+                !chunk.name.match(/LazyLoad/) &&
+                chunk.name !== 'dataviz-embed'
+              );
             },
           },
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
fixes #9544

## Problem

External dataviz iframe embeds (`/embed/dataviz/:id`) rendered a blank area with no chart and no console errors. The embed HTML only loads `dataviz-embed.js`, but webpack can split shared `node_modules` (e.g. lodash, before #9535) into `vendor.js`. The embed bundle then bootstraps with `__webpack_require__.O(void 0,[vendorChunkId], ...)` and waits forever for the missing script.

## Fix

- **Webpack:** exclude the `dataviz-embed` entry from the shared `vendor` splitChunks cache group so the public embed bundle stays self-contained.
- **Server HTML:** resolve all required script URLs for the embed page. If a built bundle still references shared chunks, prepend `vendor.js` before `dataviz-embed.js`.
- **Tests:** cover multi-script HTML rendering and vendor-chunk detection in script URL resolution.

This complements #9535 (lodash → local `deepMerge`) with a defensive guard against future regressions.

## QA

- [x] Smoke test the functionality described in the issue
- [x] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review

Verified locally:
- Production build: `dataviz-embed` bundle is self-contained (no shared-chunk bootstrap)
- Integration test: `GET /embed/dataviz/:id` returns HTML with bootstrap globals + ECharts CDN + embed script (no `main.js`)
- Manual test: cross-origin iframe from `http://localhost:8888` embedding `http://localhost:3000/embed/dataviz/:id` renders the bar chart

[Cross-origin iframe embed showing bar chart](https://cursor.com/agents/bc-dc05ae7e-c4f7-41e3-bcbd-da262950459d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcross_origin_embed_chart.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc05ae7e-c4f7-41e3-bcbd-da262950459d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc05ae7e-c4f7-41e3-bcbd-da262950459d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

