### PR TITLE
fix(dataviz): switch to Info tab on duplicate name error

### DIFF
--- a/app/react/V2/Dataviz/editor/DatavizEditor.tsx
+++ b/app/react/V2/Dataviz/editor/DatavizEditor.tsx
@@ -15,6 +15,7 @@ import { DatavizEditorConfigPanel } from './components/layout/DatavizEditorConfi
 import { DatavizPreviewPanel } from './components/preview/DatavizPreviewPanel.js';
 import { isManualDataSource } from '#shared/dataviz/manualData.js';
 import { isEchartsChartType } from '#V2/Dataviz/types/chartTypes.js';
+import { isDatavizDuplicateNameError } from '#V2/Dataviz/utils/isDatavizDuplicateNameError.js';
 
 type DatavizEditorProps = {
   initialDefinition: DatavizDefinition;
@@ -41,6 +42,7 @@ const DatavizEditor = ({ initialDefinition, onDeleteRequest }: DatavizEditorProp
   );
   const [previewTab, setPreviewTab] = useState<PreviewTabId>('preview');
   const [saving, setSaving] = useState(false);
+  const [nameError, setNameError] = useState(false);
 
   useEffect(() => {
     if (isManualDataSource(definition.dataSource)) {
@@ -58,18 +60,40 @@ const DatavizEditor = ({ initialDefinition, onDeleteRequest }: DatavizEditorProp
 
   const breadcrumbPath = useMemo(() => new Map([['Data visualizations', '/settings/dataviz']]), []);
 
+  const handlePatch = (patchValue: Partial<DatavizDefinition>) => {
+    if ('name' in patchValue) {
+      setNameError(false);
+    }
+    patch(patchValue);
+  };
+
   const handleSave = async () => {
     setSaving(true);
     const isFirstSave = !isPersistedId(definition.id);
     try {
       const saved = await api.saveDefinition(definition);
+      setNameError(false);
       replace(saved);
       if (isFirstSave) {
         await navigate(`/settings/dataviz/edit/${saved.id}`, { replace: true });
       }
       notify('success', t('System', 'Saved successfully.', null, false));
-    } catch {
-      notify('error', t('System', 'An error occurred', null, false));
+    } catch (error) {
+      if (isDatavizDuplicateNameError(error)) {
+        setNameError(true);
+        setActiveTab('info');
+        notify(
+          'error',
+          t(
+            'System',
+            'Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.',
+            null,
+            false
+          )
+        );
+      } else {
+        notify('error', t('System', 'An error occurred', null, false));
+      }
     } finally {
       setSaving(false);
     }
@@ -98,12 +122,13 @@ const DatavizEditor = ({ initialDefinition, onDeleteRequest }: DatavizEditorProp
             <DatavizEditorConfigPanel
               definition={definition}
               activeTab={activeTab}
+              nameError={nameError}
               previewData={data}
               previewLoading={loading}
               previewError={error}
               refreshConstraints={refreshConstraints}
               onTabChange={setActiveTab}
-              onPatch={patch}
+              onPatch={handlePatch}
               onPatchQuery={patchQuery}
               onPatchChart={patchChart}
               onPatchAppearance={patchAppearance}

--- a/app/react/V2/Dataviz/editor/DatavizEditor.tsx
+++ b/app/react/V2/Dataviz/editor/DatavizEditor.tsx
@@ -78,8 +78,8 @@ const DatavizEditor = ({ initialDefinition, onDeleteRequest }: DatavizEditorProp
         await navigate(`/settings/dataviz/edit/${saved.id}`, { replace: true });
       }
       notify('success', t('System', 'Saved successfully.', null, false));
-    } catch (error) {
-      if (isDatavizDuplicateNameError(error)) {
+    } catch (saveError) {
+      if (isDatavizDuplicateNameError(saveError)) {
         setNameError(true);
         setActiveTab('info');
         notify(

--- a/app/react/V2/Dataviz/editor/DatavizEditor.tsx
+++ b/app/react/V2/Dataviz/editor/DatavizEditor.tsx
@@ -82,15 +82,6 @@ const DatavizEditor = ({ initialDefinition, onDeleteRequest }: DatavizEditorProp
       if (isDatavizDuplicateNameError(saveError)) {
         setNameError(true);
         setActiveTab('info');
-        notify(
-          'error',
-          t(
-            'System',
-            'Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.',
-            null,
-            false
-          )
-        );
       } else {
         notify('error', t('System', 'An error occurred', null, false));
       }

--- a/app/react/V2/Dataviz/editor/components/layout/DatavizEditorConfigPanel.tsx
+++ b/app/react/V2/Dataviz/editor/components/layout/DatavizEditorConfigPanel.tsx
@@ -13,6 +13,7 @@ import { RefreshTab } from '../tabs/RefreshTab.js';
 type DatavizEditorConfigPanelProps = {
   definition: DatavizDefinition;
   activeTab: EditorTabId;
+  nameError?: boolean;
   previewData?: DatavizDataDTO | null;
   previewLoading?: boolean;
   previewError?: string | null;
@@ -28,6 +29,7 @@ type DatavizEditorConfigPanelProps = {
 const DatavizEditorConfigPanel = ({
   definition,
   activeTab,
+  nameError = false,
   previewData,
   refreshConstraints,
   onTabChange,
@@ -42,7 +44,7 @@ const DatavizEditorConfigPanel = ({
   const tabElements = useMemo(() => {
     const tabs = [
       <Tabs.Tab key="info" id="info" label="Info">
-        <InfoTab definition={definition} onChange={onPatch} />
+        <InfoTab definition={definition} nameError={nameError} onChange={onPatch} />
       </Tabs.Tab>,
       <Tabs.Tab key="data" id="data" label="Data">
         <DataTab
@@ -79,6 +81,7 @@ const DatavizEditorConfigPanel = ({
     return tabs;
   }, [
     definition,
+    nameError,
     onPatch,
     onPatchAppearance,
     onPatchChart,

--- a/app/react/V2/Dataviz/editor/components/tabs/InfoTab.tsx
+++ b/app/react/V2/Dataviz/editor/components/tabs/InfoTab.tsx
@@ -1,19 +1,29 @@
 import React from 'react';
+import { Translate } from '#app/I18N/index.js';
 import { InputField } from '#V2/Components/Forms/InputField.js';
 import type { DatavizDefinition } from '#V2/Dataviz/types/definition.js';
 import { DatavizInfoPanel } from '../preview/DatavizInfoPanel.js';
 
 type InfoTabProps = {
   definition: DatavizDefinition;
+  nameError?: boolean;
   onChange: (patch: Partial<DatavizDefinition>) => void;
 };
 
-const InfoTab = ({ definition, onChange }: InfoTabProps) => (
+const InfoTab = ({ definition, nameError = false, onChange }: InfoTabProps) => (
   <div className="flex flex-col gap-6 p-4">
     <InputField
       id="dataviz-name"
       label="Name"
       value={definition.name}
+      hasErrors={nameError}
+      errorMessage={
+        nameError ? (
+          <Translate>This data visualization name already exists. Enter a unique name.</Translate>
+        ) : (
+          ''
+        )
+      }
       onChange={e => onChange({ name: e.target.value })}
     />
     <DatavizInfoPanel definition={definition} onChange={onChange} />

--- a/app/react/V2/Dataviz/editor/specs/DatavizEditor.spec.tsx
+++ b/app/react/V2/Dataviz/editor/specs/DatavizEditor.spec.tsx
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { FetchResponseError } from '#shared/JSONRequest.js';
+import { TestAtomStoreProvider } from '#V2/testing/TestAtomStoreProvider.js';
+import {
+  relationshipTypesAtom,
+  settingsAtom,
+  templatesAtom,
+  thesauriAtom,
+} from '#V2/atoms/index.js';
+import { DatavizApiProvider } from '#V2/Dataviz/api/DatavizApiContext.js';
+import type { DatavizApi } from '#V2/Dataviz/api/contracts.js';
+import { DatavizEditor } from '../DatavizEditor.js';
+import {
+  carsByColorDto,
+  createDefaultDatavizDefinition,
+  datavizRelationTypes,
+  datavizTemplates,
+  datavizThesauri,
+} from '../../fixtures/datavizFixtures.js';
+import { DATAVIZ_DUPLICATE_NAME_CODE } from '../../utils/isDatavizDuplicateNameError.js';
+
+const mockNotify = jest.fn();
+
+jest.mock('#V2/atoms/requestStatusAtom.js', () => ({
+  useRequestStatus: () => ({ notify: mockNotify }),
+}));
+
+jest.mock('../components/preview/DatavizPreviewPanel.js', () => ({
+  DatavizPreviewPanel: () => <div data-testid="dataviz-preview-panel" />,
+}));
+
+const duplicateNameError = new FetchResponseError('Request failed', {
+  status: 409,
+  json: {
+    code: DATAVIZ_DUPLICATE_NAME_CODE,
+    error: 'A dataviz named "Cars by color" already exists',
+  },
+});
+
+const renderEditor = (apiOverrides: Partial<DatavizApi> = {}) => {
+  const api: DatavizApi = {
+    getDefinition: jest.fn(),
+    saveDefinition: jest.fn().mockResolvedValue(createDefaultDatavizDefinition()),
+    deleteDefinition: jest.fn(),
+    getData: jest.fn().mockResolvedValue(carsByColorDto),
+    refreshSnapshot: jest.fn(),
+    ...apiOverrides,
+  };
+
+  render(
+    <MemoryRouter>
+      <TestAtomStoreProvider
+        initialValues={[
+          [templatesAtom, datavizTemplates],
+          [thesauriAtom, datavizThesauri],
+          [relationshipTypesAtom, datavizRelationTypes],
+          [settingsAtom, { private: false, languages: [{ key: 'en', default: true }] }],
+        ]}
+      >
+        <DatavizApiProvider api={api}>
+          <DatavizEditor initialDefinition={createDefaultDatavizDefinition()} />
+        </DatavizApiProvider>
+      </TestAtomStoreProvider>
+    </MemoryRouter>
+  );
+
+  return api;
+};
+
+const getEditorTab = (name: string) => screen.getByRole('tab', { name });
+
+describe('DatavizEditor duplicate name validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should switch to the Info tab and mark the name field when the name already exists', async () => {
+    renderEditor({
+      saveDefinition: jest.fn().mockRejectedValue(duplicateNameError),
+    });
+
+    expect(getEditorTab('Data')).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(getEditorTab('Info')).toHaveAttribute('aria-selected', 'true');
+    });
+
+    expect(
+      screen.getByText('This data visualization name already exists. Enter a unique name.')
+    ).toBeVisible();
+    expect(mockNotify).toHaveBeenCalledWith(
+      'error',
+      'Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.'
+    );
+  });
+
+  it('should keep the current tab and show a generic error for other save failures', async () => {
+    renderEditor({
+      saveDefinition: jest.fn().mockRejectedValue(new Error('network')),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith('error', 'An error occurred');
+    });
+
+    expect(getEditorTab('Data')).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.queryByText('This data visualization name already exists. Enter a unique name.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should clear the name error when the user changes the name', async () => {
+    renderEditor({
+      saveDefinition: jest.fn().mockRejectedValue(duplicateNameError),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('This data visualization name already exists. Enter a unique name.')
+      ).toBeVisible();
+    });
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Unique chart' } });
+
+    expect(
+      screen.queryByText('This data visualization name already exists. Enter a unique name.')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/react/V2/Dataviz/editor/specs/DatavizEditor.spec.tsx
+++ b/app/react/V2/Dataviz/editor/specs/DatavizEditor.spec.tsx
@@ -95,10 +95,7 @@ describe('DatavizEditor duplicate name validation', () => {
     expect(
       screen.getByText('This data visualization name already exists. Enter a unique name.')
     ).toBeVisible();
-    expect(mockNotify).toHaveBeenCalledWith(
-      'error',
-      'Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.'
-    );
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it('should keep the current tab and show a generic error for other save failures', async () => {

--- a/app/react/V2/Dataviz/editor/specs/DatavizEditor.spec.tsx
+++ b/app/react/V2/Dataviz/editor/specs/DatavizEditor.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('#V2/atoms/requestStatusAtom.js', () => ({
   useRequestStatus: () => ({ notify: mockNotify }),
 }));
 
-jest.mock('../components/preview/DatavizPreviewPanel.js', () => ({
+jest.mock('../components/preview/DatavizPreviewPanel', () => ({
   DatavizPreviewPanel: () => <div data-testid="dataviz-preview-panel" />,
 }));
 

--- a/app/react/V2/Dataviz/utils/isDatavizDuplicateNameError.ts
+++ b/app/react/V2/Dataviz/utils/isDatavizDuplicateNameError.ts
@@ -1,0 +1,19 @@
+import { FetchResponseError } from '#shared/JSONRequest.js';
+
+const DATAVIZ_DUPLICATE_NAME_CODE = 'DATAVIZ_DUPLICATE_NAME';
+
+type FetchResponseErrorBody = {
+  json?: {
+    code?: string;
+  };
+};
+
+const isDatavizDuplicateNameError = (error: unknown): boolean => {
+  if (!(error instanceof FetchResponseError)) {
+    return false;
+  }
+
+  return (error as FetchResponseErrorBody).json?.code === DATAVIZ_DUPLICATE_NAME_CODE;
+};
+
+export { DATAVIZ_DUPLICATE_NAME_CODE, isDatavizDuplicateNameError };

--- a/app/react/V2/Dataviz/utils/specs/isDatavizDuplicateNameError.spec.ts
+++ b/app/react/V2/Dataviz/utils/specs/isDatavizDuplicateNameError.spec.ts
@@ -1,0 +1,34 @@
+import { FetchResponseError } from '#shared/JSONRequest.js';
+import {
+  DATAVIZ_DUPLICATE_NAME_CODE,
+  isDatavizDuplicateNameError,
+} from '../isDatavizDuplicateNameError.js';
+
+describe('isDatavizDuplicateNameError', () => {
+  it('should detect a 409 response with the duplicate name code', () => {
+    const error = new FetchResponseError('Request failed', {
+      status: 409,
+      json: {
+        code: DATAVIZ_DUPLICATE_NAME_CODE,
+        error: 'A dataviz named "Test" already exists',
+      },
+    });
+
+    expect(isDatavizDuplicateNameError(error)).toBe(true);
+  });
+
+  it('should ignore other API errors', () => {
+    const error = new FetchResponseError('Request failed', {
+      status: 500,
+      json: { error: 'Unexpected error' },
+    });
+
+    expect(isDatavizDuplicateNameError(error)).toBe(false);
+  });
+
+  it('should ignore non-fetch errors', () => {
+    expect(isDatavizDuplicateNameError(new Error('A dataviz named "Test" already exists'))).toBe(
+      false
+    );
+  });
+});

--- a/contents/ui-translations/ar.csv
+++ b/contents/ui-translations/ar.csv
@@ -178,6 +178,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1271,6 +1272,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,أنشئ هذا المحتوى تلقائياً
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata",لا يتوافر مستند لهذا الكيان (الإدخال)، ربما ترغب في رؤية البيانات الوصفية
 This entity is restricted from public view.,هذا الكيان (الإدخال) ممنوع من المعاينة العامة
 This field is required,This field is required

--- a/contents/ui-translations/ar.csv
+++ b/contents/ui-translations/ar.csv
@@ -178,7 +178,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/el.csv
+++ b/contents/ui-translations/el.csv
@@ -180,6 +180,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Ενεργοποιήστε αυτή την επιλογή για να κάνετε αυτή την εγκατάσταση δημόσια (οι μη συνδεδεμένοι χρήστες μπορούν να δουν δημόσια έγγραφα και οντότητες)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1273,6 +1274,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,Αυτό το περιεχόμενο δημιουργείται αυτόματα
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","Αυτή η οντότητα δεν έχει έγγραφο, πιθανώς θέλετε να δείτε τα μεταδεδομένα"
 This entity is restricted from public view.,Αυτή η οντότητα δεν είναι ορατή στο κοινό.
 This field is required,Αυτό το πεδίο είναι υποχρεωτικό

--- a/contents/ui-translations/el.csv
+++ b/contents/ui-translations/el.csv
@@ -180,7 +180,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Ενεργοποιήστε αυτή την επιλογή για να κάνετε αυτή την εγκατάσταση δημόσια (οι μη συνδεδεμένοι χρήστες μπορούν να δουν δημόσια έγγραφα και οντότητες)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/en.csv
+++ b/contents/ui-translations/en.csv
@@ -181,6 +181,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1274,6 +1275,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,This content is automatically generated
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","This entity has no document, you probably want to see the metadata"
 This entity is restricted from public view.,This entity is restricted from public view.
 This field is required,This field is required

--- a/contents/ui-translations/en.csv
+++ b/contents/ui-translations/en.csv
@@ -181,7 +181,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/es.csv
+++ b/contents/ui-translations/es.csv
@@ -177,7 +177,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Seleccionar
 Choose relation type,Seleccionar tipo de relación

--- a/contents/ui-translations/es.csv
+++ b/contents/ui-translations/es.csv
@@ -177,6 +177,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Seleccionar
 Choose relation type,Seleccionar tipo de relación
@@ -1268,6 +1269,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,Este contenido se genera automáticamente.
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","Esta entidad no tiene ningún documento, es probable que quieras ver los metadatos."
 This entity is restricted from public view.,Esta entidad está restringida de la vista pública.
 This field is required,Este campo es obligatorio

--- a/contents/ui-translations/fr.csv
+++ b/contents/ui-translations/fr.csv
@@ -178,6 +178,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1271,6 +1272,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,Ce contenu est généré automatiquement
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","Cette entité n'a pas de document, vous voulez probablement voir les métadonnées."
 This entity is restricted from public view.,Cette entité n'est pas accessible au public.
 This field is required,This field is required

--- a/contents/ui-translations/fr.csv
+++ b/contents/ui-translations/fr.csv
@@ -178,7 +178,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/ko.csv
+++ b/contents/ui-translations/ko.csv
@@ -179,7 +179,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/ko.csv
+++ b/contents/ui-translations/ko.csv
@@ -179,6 +179,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1272,6 +1273,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,콘텐츠가 자동으로 생성되었습니다.
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata",이 엔티티에는 문서가 없습니다. 메타데이터를 확인하십시오.
 This entity is restricted from public view.,이 엔티티는 공개 모드에서 제한됩니다.
 This field is required,This field is required

--- a/contents/ui-translations/my.csv
+++ b/contents/ui-translations/my.csv
@@ -179,7 +179,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/my.csv
+++ b/contents/ui-translations/my.csv
@@ -179,6 +179,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1272,6 +1273,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,ဤအကြောင်းအရာကို အလိုအလျောက် ထုတ်လုပ်ထားသည်
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata",ဤဖြည့်သွင်းချက်တွင် စာရွက်စာတမ်းမရှိပါ၊ မီတာဒေတာကို သင်ကြည့်လိုက ကြည့်နိုင်သည်
 This entity is restricted from public view.,ဤဖြည့်သွင်းချက်ကို အများမမြင်နိုင်အောင် ကန့်သတ်ထားသည်။
 This field is required,This field is required

--- a/contents/ui-translations/ru.csv
+++ b/contents/ui-translations/ru.csv
@@ -176,6 +176,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1269,6 +1270,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,Этот контент генерируется автоматически
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","У этого объекта нет документов, вы наверняка хотите увидеть метаданные"
 This entity is restricted from public view.,Этот объект ограничен для общедоступного просмотра.
 This field is required,This field is required

--- a/contents/ui-translations/ru.csv
+++ b/contents/ui-translations/ru.csv
@@ -176,7 +176,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/th.csv
+++ b/contents/ui-translations/th.csv
@@ -179,6 +179,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1272,6 +1273,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,เนื้อหานี้ถูกสร้างขึ้นโดยอัตโนมัติ
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata",รายการนี้ไม่มีเอกสาร คุณอาจจะอยากดูข้อมูลเมตาดาตาเพิ่มเติม
 This entity is restricted from public view.,รายการนี้ถูกจำกัดการเข้าถึงแบบสาธารณะ
 This field is required,This field is required

--- a/contents/ui-translations/th.csv
+++ b/contents/ui-translations/th.csv
@@ -179,7 +179,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/tr.csv
+++ b/contents/ui-translations/tr.csv
@@ -179,7 +179,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/tr.csv
+++ b/contents/ui-translations/tr.csv
@@ -179,6 +179,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),Check to make this instance public (non-logged in users can see public documents and entities)
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1272,6 +1273,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,Bu içerik otomatik olarak oluşturulur
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","Bu varlığın belgesi yok, muhtemelen meta verileri görmek isteyebilirsiniz"
 This entity is restricted from public view.,Bu varlığın genel görünümü kısıtlanmıştır.
 This field is required,This field is required

--- a/contents/ui-translations/uk.csv
+++ b/contents/ui-translations/uk.csv
@@ -181,7 +181,6 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),"Установіть прапорець, щоб зробити цей екземпляр загальнодоступним (неавторизовані користувачі можуть бачити загальнодоступні документи та сутності)"
-Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type

--- a/contents/ui-translations/uk.csv
+++ b/contents/ui-translations/uk.csv
@@ -181,6 +181,7 @@ Chart theme,Chart theme
 Chart type,Chart type
 Chart type uses a custom view,Chart type uses a custom view
 Check to make this instance public (non-logged in users can see public documents and entities),"Установіть прапорець, щоб зробити цей екземпляр загальнодоступним (неавторизовані користувачі можуть бачити загальнодоступні документи та сутності)"
+Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.,Check your submission. Some information was missing or incorrect. Review the highlighted fields and try again.
 Checking which images fit the requirements,Checking which images fit the requirements...
 Choose,Choose
 Choose relation type,Choose relation type
@@ -1274,6 +1275,7 @@ This chart type cannot display the current data.,This chart type cannot display 
             legend, labels, or data filters.","This chart type has no extra options. Select another chart type above if you need
             legend, labels, or data filters."
 This content is automatically generated,Цей контент генерується автоматично
+This data visualization name already exists. Enter a unique name.,This data visualization name already exists. Enter a unique name.
 "This entity has no document, you probably want to see the metadata","Цей об'єкт не має документів, ви, певно, хочете переглянути метадані"
 This entity is restricted from public view.,Цей об'єкт обмежений для загальнодоступного перегляду.
 This field is required,Це поле обов'язкове для заповнення


### PR DESCRIPTION
fixes #9550

When saving a data visualization with a name that already exists, the editor now:
- Switches to the Info tab if the user is on another tab
- Marks the name field with: "This data visualization name already exists. Enter a unique name."

No notification is shown for this form error. The field error clears when the user changes the name. Other save failures still show the generic error without changing tabs.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review