### PR TITLE
fix: remove fake user grants from mismatched entity permissions

### DIFF
--- a/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/index.ts
+++ b/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/index.ts
@@ -1,0 +1,215 @@
+/* eslint-disable no-await-in-loop */
+import { Db, Document, ObjectId, UpdateFilter } from 'mongodb';
+
+const normalizeStages = [
+  { $set: { perms: { $ifNull: ['$permissions', []] } } },
+  {
+    $set: {
+      perms: {
+        $map: {
+          input: '$perms',
+          in: {
+            $let: {
+              vars: {
+                refId: { $toString: { $ifNull: ['$$this.refId', null] } },
+                type: { $ifNull: ['$$this.type', ''] },
+                level: { $ifNull: ['$$this.level', ''] },
+              },
+              in: { r: '$$refId', t: '$$type', l: '$$level' },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    $set: {
+      perms: { $sortArray: { input: '$perms', sortBy: { r: 1, t: 1, l: 1 } } },
+    },
+  },
+  {
+    $set: {
+      sig: {
+        $reduce: {
+          input: '$perms',
+          initialValue: '',
+          in: { $concat: ['$$value', '|', '$$this.r', '|', '$$this.t', '|', '$$this.l', ';'] },
+        },
+      },
+    },
+  },
+];
+
+const mismatchStages = [
+  ...normalizeStages,
+
+  // Collect the user-type refIds of THIS copy.
+  {
+    $set: {
+      userRefs: {
+        $map: {
+          input: {
+            $filter: { input: '$perms', as: 'p', cond: { $eq: ['$$p.t', 'user'] } },
+          },
+          as: 'p',
+          in: '$$p.r',
+        },
+      },
+    },
+  },
+
+  { $project: { sharedId: 1, sig: 1, userRefs: 1 } },
+
+  {
+    $group: {
+      _id: '$sharedId',
+      sigs: { $push: '$sig' },
+      userRefs: { $push: '$userRefs' },
+      copies: { $sum: 1 },
+    },
+  },
+
+  { $match: { copies: { $gt: 1 } } },
+
+  // Keep only groups where not every copy has the same signature.
+  {
+    $match: {
+      $expr: {
+        $not: [
+          {
+            $allElementsTrue: {
+              $map: {
+                input: '$sigs',
+                as: 's',
+                in: { $eq: ['$$s', { $arrayElemAt: ['$sigs', 0] }] },
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+
+  // Distinct user refIds across all copies of the group.
+  {
+    $set: {
+      userRefs: {
+        $reduce: {
+          input: '$userRefs',
+          initialValue: [],
+          in: { $setUnion: ['$$value', '$$this'] },
+        },
+      },
+    },
+  },
+
+  { $project: { _id: 0, sharedId: '$_id', userRefs: 1 } },
+];
+
+type MismatchedGroup = {
+  sharedId: string;
+  userRefs: string[];
+};
+
+// Keep each write small (short lock hold, well under MongoDB's 16MB BSON
+// document limit for the $in array).
+const WRITE_CHUNK = 10000;
+
+const chunkArray = <T>(arr: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+};
+
+export default {
+  delta: 206,
+
+  name: 'clear-mismatched-entity-permissions',
+
+  description:
+    'Removes spurious admin/deleted/commandId user grants from entity language copies whose ' +
+    'permissions arrays diverged (legacy V1 addLanguage bug stamped the installer grant onto ' +
+    'new language copies only). Only the known-bad user grants are pulled — group grants and ' +
+    'grants for live non-admin users are never touched.',
+
+  reindex: false,
+
+  requiresSchema: 14,
+
+  async up(db: Db) {
+    process.stdout.write(`${this.name}...\r\n`);
+
+    const groups = await db
+      .collection('entities')
+      .aggregate<MismatchedGroup>(
+        [{ $match: { sharedId: { $exists: true, $ne: null } } }, ...mismatchStages],
+        { allowDiskUse: true }
+      )
+      .toArray();
+
+    if (groups.length === 0) {
+      process.stdout.write(`${this.name}: no mismatched groups found.\r\n`);
+      this.reindex = false;
+      return;
+    }
+
+    const allRefs = new Set<string>();
+    for (const group of groups) {
+      group.userRefs.filter((ref): ref is string => Boolean(ref)).forEach(ref => allRefs.add(ref));
+    }
+
+    const validRefs = [...allRefs].filter(ref => ObjectId.isValid(ref));
+    const users =
+      validRefs.length > 0
+        ? await db
+            .collection('users')
+            .find({ _id: { $in: validRefs.map(ref => new ObjectId(ref)) } })
+            .toArray()
+        : [];
+    const userByRef = new Map(users.map(u => [u._id.toString(), u]));
+
+    const badRefs = new Set<string>();
+    for (const ref of allRefs) {
+      const user = ObjectId.isValid(ref) ? userByRef.get(ref) : undefined;
+      if (!user || user.deletedAt != null || user.role === 'admin') {
+        badRefs.add(ref);
+      }
+    }
+
+    if (badRefs.size === 0) {
+      process.stdout.write(`${this.name}: no bad grants to remove.\r\n`);
+      this.reindex = false;
+      return;
+    }
+
+    // Match refId in both storage formats: V1 stored `user._id.toString()`
+    // (string), V2 stores ObjectIds. Mongo's $in is type-strict, so each bad
+    // ref must be included in both forms.
+    const refIdValuesToPull: (ObjectId | string)[] = [];
+    for (const ref of badRefs) {
+      refIdValuesToPull.push(ref);
+      if (ObjectId.isValid(ref)) refIdValuesToPull.push(new ObjectId(ref));
+    }
+
+    const sharedIds = groups.map(group => group.sharedId);
+
+    let cleared = 0;
+    for (const chunk of chunkArray(sharedIds, WRITE_CHUNK)) {
+      const result = await db.collection('entities').updateMany({ sharedId: { $in: chunk } }, {
+        $pull: {
+          permissions: { refId: { $in: refIdValuesToPull }, type: 'user' },
+        },
+      } as unknown as UpdateFilter<Document>);
+      cleared += result.modifiedCount;
+    }
+
+    this.reindex = cleared > 0;
+
+    process.stdout.write(
+      `${this.name}: removed ${badRefs.size} bad grant ref(s) from ${cleared} entity document(s) ` +
+        `across ${groups.length} sharedId group(s).\r\n`
+    );
+  },
+};

--- a/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/specs/206-clear-mismatched-entity-permissions.spec.ts
+++ b/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/specs/206-clear-mismatched-entity-permissions.spec.ts
@@ -1,0 +1,153 @@
+import { Db } from 'mongodb';
+
+import testingDB, { DBFixture } from '#api/utils/testing_db.js';
+import migration from '../index.js';
+import { Entity } from '../types.js';
+import {
+  fixtures,
+  noMismatchesFixture,
+  noBadGrantsFixture,
+  adminId,
+  collaboratorId,
+  collaborator2Id,
+  editorId,
+  groupId,
+} from './fixtures.js';
+
+let db: Db | null;
+
+const initTest = async (fixture: DBFixture) => {
+  await testingDB.setupFixturesAndContext(fixture);
+  db = testingDB.mongodb!;
+  migration.reindex = false;
+  await migration.up(db);
+};
+
+const getCopies = async (sharedId: string): Promise<Entity[]> => {
+  const copies = await db!
+    .collection('entities')
+    .find({ sharedId })
+    .sort({ language: 1 })
+    .toArray();
+  return copies as Entity[];
+};
+
+const getReqIds = (copy: Entity) => (copy.permissions ?? []).map(p => p.refId?.toString() ?? '');
+
+beforeAll(async () => {
+  jest.spyOn(process.stdout, 'write').mockImplementation((_str: string | Uint8Array) => true);
+});
+
+afterAll(async () => {
+  await testingDB.tearDown();
+});
+
+describe('migration clear-mismatched-entity-permissions', () => {
+  beforeAll(async () => {
+    await initTest(fixtures);
+  });
+
+  it('should have a delta number', () => {
+    expect(migration.delta).toBe(206);
+  });
+
+  describe('groups whose divergence is caused only by bad grants', () => {
+    it.each([
+      ['admin-grant', 'spurious admin grant'],
+      ['deleted-user-grant', 'hard-deleted user grant'],
+      ['commandid-grant', 'commandId sentinel grant'],
+      ['soft-deleted-admin-grant', 'soft-deleted admin grant'],
+      ['soft-deleted-collab-grant', 'soft-deleted collaborator grant'],
+      ['string-refid-grant', 'legacy string-stored refId'],
+    ])('should remove the %s (%s)', async (sharedId, _label) => {
+      const copies = await getCopies(sharedId);
+      expect(copies.length).toBeGreaterThan(1);
+      copies.forEach(copy => expect(getReqIds(copy)).toEqual([]));
+    });
+  });
+
+  it('should NOT remove a live non-admin (collaborator) grant', async () => {
+    const copies = await getCopies('non-admin-grant');
+    const zh = copies.find(c => c.language === 'zh')!;
+    expect(getReqIds(zh)).toEqual([collaboratorId.toString()]);
+  });
+
+  it('should NOT remove a group grant', async () => {
+    const copies = await getCopies('group-grant');
+    const zh = copies.find(c => c.language === 'zh')!;
+    expect(getReqIds(zh)).toEqual([groupId.toString()]);
+    expect(zh.permissions![0].type).toBe('group');
+  });
+
+  it('should leave consistent (non-mismatched) groups untouched', async () => {
+    const copies = await getCopies('consistent-admin');
+    expect(copies).toHaveLength(3);
+    copies.forEach(copy => expect(getReqIds(copy)).toEqual([adminId.toString()]));
+  });
+
+  it('should remove only the bad grant from a group that also has a legit collaborator grant', async () => {
+    const copies = await getCopies('mixed-grants');
+    const en = copies.find(c => c.language === 'en')!;
+    const zh = copies.find(c => c.language === 'zh')!;
+
+    expect(getReqIds(en)).toEqual([collaboratorId.toString()]);
+    expect(getReqIds(zh)).toEqual([collaboratorId.toString()]);
+
+    expect(en.permissions).toEqual(zh.permissions);
+  });
+
+  it('should remove a bad admin user grant but preserve a group grant in the same group', async () => {
+    const copies = await getCopies('mixed-with-group');
+    const en = copies.find(c => c.language === 'en')!;
+    const zh = copies.find(c => c.language === 'zh')!;
+
+    expect(getReqIds(en)).toEqual([groupId.toString()]);
+    expect(getReqIds(zh)).toEqual([groupId.toString()]);
+    expect(zh.permissions![0].type).toBe('group');
+    expect(en.permissions).toEqual(zh.permissions);
+  });
+
+  it('should NOT remove a live editor grant (conservative: only known-bad refs are pulled)', async () => {
+    const copies = await getCopies('live-editor-grant');
+    const zh = copies.find(c => c.language === 'zh')!;
+    expect(getReqIds(zh)).toEqual([editorId.toString()]);
+  });
+
+  it('should request a reindex because permissions were modified', () => {
+    expect(migration.reindex).toBe(true);
+  });
+});
+
+describe('migration clear-mismatched-entity-permissions with no mismatched groups', () => {
+  beforeAll(async () => {
+    await initTest(noMismatchesFixture);
+  });
+
+  it('should be a no-op and not request a reindex', () => {
+    expect(migration.reindex).toBe(false);
+  });
+
+  it('should leave the consistent copies untouched', async () => {
+    const copies = await getCopies('consistent');
+    expect(copies).toHaveLength(2);
+    copies.forEach(copy => expect(getReqIds(copy)).toEqual([adminId.toString()]));
+  });
+});
+
+describe('migration clear-mismatched-entity-permissions with no bad grants to remove', () => {
+  beforeAll(async () => {
+    await initTest(noBadGrantsFixture);
+  });
+
+  it('should be a no-op and not request a reindex', () => {
+    expect(migration.reindex).toBe(false);
+  });
+
+  it('should leave the legitimately divergent copies untouched', async () => {
+    const copies = await getCopies('legit-diff');
+    const en = copies.find(c => c.language === 'en')!;
+    const zh = copies.find(c => c.language === 'zh')!;
+    expect(getReqIds(en)).toEqual([collaboratorId.toString()]);
+    expect(getReqIds(zh)).toEqual([collaborator2Id.toString()]);
+  });
+});

--- a/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/specs/fixtures.ts
+++ b/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/specs/fixtures.ts
@@ -1,0 +1,298 @@
+import { ObjectId } from 'mongodb';
+
+import { UserRole } from '#api/core/domain/user/User.js';
+import { DBFixture } from '#api/utils/testing_db.js';
+import { PermissionSchema } from '#shared/types/permissionType.js';
+
+const adminId = new ObjectId();
+const collaboratorId = new ObjectId();
+const collaborator2Id = new ObjectId();
+const editorId = new ObjectId();
+const softDeletedAdminId = new ObjectId();
+const softDeletedCollabId = new ObjectId();
+const hardDeletedUserId = new ObjectId();
+const groupId = new ObjectId();
+
+const adminGrant: PermissionSchema = { refId: adminId, type: 'user', level: 'write' };
+const collaboratorGrant: PermissionSchema = { refId: collaboratorId, type: 'user', level: 'write' };
+const collaborator2Grant: PermissionSchema = {
+  refId: collaborator2Id,
+  type: 'user',
+  level: 'write',
+};
+const editorGrant: PermissionSchema = { refId: editorId, type: 'user', level: 'write' };
+const softDeletedAdminGrant: PermissionSchema = {
+  refId: softDeletedAdminId,
+  type: 'user',
+  level: 'write',
+};
+const softDeletedCollabGrant: PermissionSchema = {
+  refId: softDeletedCollabId,
+  type: 'user',
+  level: 'write',
+};
+const hardDeletedUserGrant: PermissionSchema = {
+  refId: hardDeletedUserId,
+  type: 'user',
+  level: 'write',
+};
+const commandIdGrant: PermissionSchema = { refId: 'commandId', type: 'user', level: 'write' };
+const groupGrant: PermissionSchema = { refId: groupId, type: 'group', level: 'read' };
+
+const fixtures: DBFixture = {
+  users: [
+    { _id: adminId, username: 'admin', role: UserRole.ADMIN, email: 'admin@test.com' },
+    {
+      _id: collaboratorId,
+      username: 'collab',
+      role: UserRole.COLLABORATOR,
+      email: 'collab@test.com',
+    },
+    {
+      _id: collaborator2Id,
+      username: 'collab2',
+      role: UserRole.COLLABORATOR,
+      email: 'collab2@test.com',
+    },
+    { _id: editorId, username: 'editor', role: UserRole.EDITOR, email: 'editor@test.com' },
+    {
+      _id: softDeletedAdminId,
+      username: 'gone-admin',
+      role: UserRole.ADMIN,
+      email: 'gone-admin@test.com',
+      deletedAt: new Date(),
+    },
+    {
+      _id: softDeletedCollabId,
+      username: 'gone-collab',
+      role: UserRole.COLLABORATOR,
+      email: 'gone-collab@test.com',
+      deletedAt: new Date(),
+    },
+    // hardDeletedUserId is intentionally absent from `users` (hard-deleted).
+  ],
+  entities: [
+    // 1. admin grant stamped on the new copy only -> must be cleared
+    { _id: new ObjectId(), sharedId: 'admin-grant', language: 'en', title: 'A en' },
+    { _id: new ObjectId(), sharedId: 'admin-grant', language: 'fr', title: 'A fr' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'admin-grant',
+      language: 'zh',
+      title: 'A zh',
+      permissions: [adminGrant],
+    },
+
+    // 2. hard-deleted user grant -> must be cleared
+    { _id: new ObjectId(), sharedId: 'deleted-user-grant', language: 'en', title: 'B en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'deleted-user-grant',
+      language: 'fr',
+      title: 'B fr',
+      permissions: [hardDeletedUserGrant],
+    },
+
+    // 3. commandId sentinel grant -> must be cleared
+    { _id: new ObjectId(), sharedId: 'commandid-grant', language: 'en', title: 'C en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'commandid-grant',
+      language: 'zh',
+      title: 'C zh',
+      permissions: [commandIdGrant],
+    },
+
+    // 4. soft-deleted admin grant -> must be cleared
+    { _id: new ObjectId(), sharedId: 'soft-deleted-admin-grant', language: 'en', title: 'D en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'soft-deleted-admin-grant',
+      language: 'zh',
+      title: 'D zh',
+      permissions: [softDeletedAdminGrant],
+    },
+
+    // 5. live non-admin user grant -> must be SKIPPED (left untouched)
+    { _id: new ObjectId(), sharedId: 'non-admin-grant', language: 'en', title: 'E en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'non-admin-grant',
+      language: 'zh',
+      title: 'E zh',
+      permissions: [collaboratorGrant],
+    },
+
+    // 6. group grant -> must be SKIPPED (left untouched)
+    { _id: new ObjectId(), sharedId: 'group-grant', language: 'en', title: 'F en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'group-grant',
+      language: 'zh',
+      title: 'F zh',
+      permissions: [groupGrant],
+    },
+
+    // 7. consistent admin grant across all copies -> NOT mismatched, left untouched
+    {
+      _id: new ObjectId(),
+      sharedId: 'consistent-admin',
+      language: 'en',
+      title: 'G en',
+      permissions: [adminGrant],
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'consistent-admin',
+      language: 'fr',
+      title: 'G fr',
+      permissions: [adminGrant],
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'consistent-admin',
+      language: 'zh',
+      title: 'G zh',
+      permissions: [adminGrant],
+    },
+
+    // 8. mixed legit collaborator grant + spurious admin grant -> the admin grant
+    //    is pulled, the collaborator grant is kept, and the group becomes consistent
+    {
+      _id: new ObjectId(),
+      sharedId: 'mixed-grants',
+      language: 'en',
+      title: 'H en',
+      permissions: [collaboratorGrant],
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'mixed-grants',
+      language: 'zh',
+      title: 'H zh',
+      permissions: [collaboratorGrant, adminGrant],
+    },
+
+    // 9. mismatched group grant + spurious admin user grant -> the admin user
+    //    grant is pulled, the GROUP grant is preserved
+    {
+      _id: new ObjectId(),
+      sharedId: 'mixed-with-group',
+      language: 'en',
+      title: 'I en',
+      permissions: [groupGrant],
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'mixed-with-group',
+      language: 'zh',
+      title: 'I zh',
+      permissions: [groupGrant, adminGrant],
+    },
+
+    // 10. live editor grant -> NOT removed (conservative: only known-bad refs
+    //     are pulled; live non-admin grants are left for review)
+    { _id: new ObjectId(), sharedId: 'live-editor-grant', language: 'en', title: 'J en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'live-editor-grant',
+      language: 'zh',
+      title: 'J zh',
+      permissions: [editorGrant],
+    },
+
+    // 11. legacy V1 shape: refId stored as a STRING (V1 appendPermissionData
+    //     stores user._id.toString()) -> must be cleared via the string match
+    { _id: new ObjectId(), sharedId: 'string-refid-grant', language: 'en', title: 'K en' },
+    {
+      _id: new ObjectId(),
+      sharedId: 'string-refid-grant',
+      language: 'zh',
+      title: 'K zh',
+      permissions: [{ refId: adminId.toString(), type: 'user', level: 'write' }],
+    },
+
+    // 12. soft-deleted NON-admin (collaborator) grant -> must be cleared (same
+    //     deletedAt code path as the soft-deleted admin)
+    {
+      _id: new ObjectId(),
+      sharedId: 'soft-deleted-collab-grant',
+      language: 'en',
+      title: 'L en',
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'soft-deleted-collab-grant',
+      language: 'zh',
+      title: 'L zh',
+      permissions: [softDeletedCollabGrant],
+    },
+  ],
+};
+
+// No sharedId appears more than once -> no candidate group, migration is a no-op.
+const noMismatchesFixture: DBFixture = {
+  users: [{ _id: adminId, username: 'admin', role: UserRole.ADMIN, email: 'admin@test.com' }],
+  entities: [
+    {
+      _id: new ObjectId(),
+      sharedId: 'consistent',
+      language: 'en',
+      title: 'consistent en',
+      permissions: [adminGrant],
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'consistent',
+      language: 'fr',
+      title: 'consistent fr',
+      permissions: [adminGrant],
+    },
+  ],
+};
+
+// Mismatched group whose refs are ALL live non-admin users -> no bad grants to
+// remove, migration is a no-op (leaves the divergence for manual review).
+const noBadGrantsFixture: DBFixture = {
+  users: [
+    {
+      _id: collaboratorId,
+      username: 'collab',
+      role: UserRole.COLLABORATOR,
+      email: 'collab@test.com',
+    },
+    {
+      _id: collaborator2Id,
+      username: 'collab2',
+      role: UserRole.COLLABORATOR,
+      email: 'collab2@test.com',
+    },
+  ],
+  entities: [
+    {
+      _id: new ObjectId(),
+      sharedId: 'legit-diff',
+      language: 'en',
+      title: 'legit en',
+      permissions: [collaboratorGrant],
+    },
+    {
+      _id: new ObjectId(),
+      sharedId: 'legit-diff',
+      language: 'zh',
+      title: 'legit zh',
+      permissions: [collaborator2Grant],
+    },
+  ],
+};
+
+export {
+  fixtures,
+  noMismatchesFixture,
+  noBadGrantsFixture,
+  adminId,
+  collaboratorId,
+  collaborator2Id,
+  editorId,
+  groupId,
+};

--- a/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/types.ts
+++ b/app/api/migrations/migrations/206-clear-mismatched-entity-permissions/types.ts
@@ -1,0 +1,18 @@
+import { ObjectId } from 'mongodb';
+
+interface EntityPermission {
+  refId?: string | ObjectId;
+  type?: 'user' | 'group' | 'public';
+  level?: 'read' | 'write' | 'mixed';
+}
+
+interface Entity {
+  _id: ObjectId;
+  sharedId: string;
+  language: string;
+  title?: string;
+  permissions?: EntityPermission[];
+  [k: string]: unknown | undefined;
+}
+
+export type { Entity };


### PR DESCRIPTION
## Summary

Adds data migration **206** (`clear-mismatched-entity-permissions`) to fix entity language copies whose `permissions` arrays diverged across languages.

### Root cause

The legacy V1 `addLanguage` route (admin-only) stamped the **installer's write grant** onto each new language copy via `appendPermissionData` → `saveMultiple`, while the original copies were left untouched. This produced `sharedId` groups where some language copies carry a spurious grant (an admin user, a since-deleted user, or the `commandId` CLI sentinel) and others don't.

### What the migration does

Removes all the admin/deleted users from the permissions array when they diverge over the other entities languages copies.

**Never touched:** group grants, public grants, and grants for live editor/collaborator users. Copies that end up with no grants are left as `permissions: []`, which is behaviorally equivalent to a missing field.

Sets `reindex: true` when any document is modified.