### PR TITLE
Make yarn test workers configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,7 @@ Backend is in `app/api`
 ### Commands
 
 - **Install:** `yarn install`
-- **Test:** `yarn test app/api`
-- **Suggested Jest invocation for targeted test runs:** `DEBUG=true node --no-experimental-fetch ./node_modules/.bin/jest <path-or-pattern> -w=4`
+- **Test:** `yarn test <path-or-pattern>` defaults to 4 workers, can be overridden with `-w=`, use `yarn test --help` on how to use
 - **Run:** `yarn hot`
 - **lint:** `yarn lint --type-aware <paths>`
 - **type checking** `yarn check-types`
@@ -26,26 +25,6 @@ Backend is in `app/api`
 - **Translations CSV update:** never edit translation keys manually in CSV files; run `yarn update-translations-csv` instead.
 - **Add schema migration:**  `yarn add-migration schema <name> <description>`
 - **Add data migration:**  `yarn add-migration data <name> <description>`
-
-### Running tests (agents)
-
-Integration tests talk to whatever Mongo/Postgres the developer already has (local install **or** Docker). Prefer not to start/restart those services unless the developer asks or nothing is reachable.
-
-**Try Jest invocations in this order** (different environments need different shapes):
-
-1. **Bare allowlisted form** (often works on local WSL/desktop; stays out of the Cursor sandbox):
-   ```bash
-   DEBUG=true node --no-experimental-fetch ./node_modules/.bin/jest <path-or-pattern> -w=4
-   ```
-2. **With Node 20 on PATH** (often needed on Cursor Cloud VM, where default `node` may be v22):
-   ```bash
-   export PATH="$HOME/.nvm/versions/node/v20.19.6/bin:$PATH"
-   DEBUG=true node --no-experimental-fetch ./node_modules/.bin/jest <path-or-pattern> -w=4
-   ```
-3. **If you still get `ECONNREFUSED 127.0.0.1:27017`**, try again with unrestricted/host network permissions for the shell (`required_permissions: ["all"]`). That error is often sandbox isolation, not a missing Mongo. Do not jump straight to starting Docker.
-4. **Only if Mongo/Postgres are actually down** and this is a compose-based env (e.g. Cursor Cloud VM): bring up services per “Cursor Cloud specific instructions” below. Never assume every developer uses Docker.
-
-Paths may be relative to `app/api` (e.g. `csv/specs/csvLoaderThesauri.spec.ts`) or under `app/api/...`; both work from the repo root.
 
 ### Architecture Status
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "migrate": "node ./scripts/runner.js ./scripts/migrate.js",
     "migrate-and-reindex": "node ./scripts/runner.js ./scripts/migrate_and_reindex.js",
     "test-debug": "node --no-experimental-fetch --inspect ./node_modules/.bin/jest --watch --no-cache -i",
-    "test": "node --no-experimental-fetch ./node_modules/.bin/jest -w=50%",
+    "test": "node scripts/test.mjs",
     "e2e-puppeteer-all": "echo 'MAKE SURE UWAZI IS RUNNING WITH uwazi_e2e DATABASE AND INDEX';DATABASE_NAME=uwazi_e2e INDEX_NAME=uwazi_e2e jest --projects e2e/jest.e2e.config.ts -i --verbose true",
     "e2e-puppeteer": "yarn e2e-puppeteer-all --roots '<rootDir>/suite1' '<rootDir>/suite2'",
     "e2e-fixtures": "DATABASE_NAME=uwazi_e2e INDEX_NAME=uwazi_e2e ./uwazi-fixtures/restore.sh",

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,0 +1,28 @@
+import { spawnSync } from 'node:child_process';
+
+// Arguments to jest: whatever is passed on the CLI, otherwise the project
+// default for maxWorkers. Jest turns repeated -w/--maxWorkers flags into an
+// array, so the default can't be appended after user flags — instead it is
+// injected only when the caller didn't pick their own worker strategy
+// (-w/--maxWorkers or --runInBand/-i).
+const passed = process.argv.slice(2);
+
+const isWorkerFlag = arg =>
+  arg === '-w' ||
+  arg.startsWith('-w=') ||
+  arg.startsWith('--maxWorkers') ||
+  arg.startsWith('--max-workers');
+
+const hasWorkerChoice = passed.some(
+  arg => isWorkerFlag(arg) || arg === '--runInBand' || arg === '-i',
+);
+
+const args = hasWorkerChoice ? passed : ['-w=4', ...passed];
+
+const result = spawnSync(
+  'node',
+  ['./node_modules/.bin/jest', ...args],
+  { stdio: 'inherit' },
+);
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
Make `yarn test` default to 4 workers while allowing overrides like `yarn test -w=50%`.

Jest turns repeated `-w` flags into an array, so the default can't simply be appended after user args. `yarn test` now runs through a small wrapper script (`scripts/test.mjs`, same pattern as `scripts/eslint.mjs`) that injects `-w=4` only when the caller didn't pass their own worker flags (`-w`/`--maxWorkers`/`--runInBand`).