### PR TITLE
Skip empty lookup when library filter options already exist

### DIFF
--- a/app/react/Forms/components/LookupMultiSelect.tsx
+++ b/app/react/Forms/components/LookupMultiSelect.tsx
@@ -4,6 +4,7 @@ import { MultiSelect, MultiSelectProps, Option, defaultProps } from './MultiSele
 
 interface LookupMultiSelectProps extends MultiSelectProps<string[]> {
   lookup: Function;
+  forceUpdate?: boolean;
 }
 
 interface LookupMultiSelectState {
@@ -41,7 +42,7 @@ const aggregationOptionsSignature = (
 export const debounceTime = 200;
 
 export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupMultiSelectState> {
-  static defaultProps = { ...defaultProps, value: [] as string[] };
+  static defaultProps = { ...defaultProps, value: [] as string[], forceUpdate: false };
 
   static getDerivedStateFromProps(props: LookupMultiSelectProps) {
     return { totalPossibleOptions: props.totalPossibleOptions };
@@ -62,6 +63,11 @@ export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupM
     this.refreshPreloadedOptions = this.refreshPreloadedOptions.bind(this);
   }
 
+  shouldPreloadLookup() {
+    const { lookup, options, forceUpdate } = this.props;
+    return Boolean(lookup) && (Boolean(forceUpdate) || options.length === 0);
+  }
+
   async refreshPreloadedOptions() {
     const { lookup, options, optionsValue } = this.props;
     if (!lookup) {
@@ -79,7 +85,7 @@ export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupM
   }
 
   async componentDidMount() {
-    if (this.props.lookup) {
+    if (this.shouldPreloadLookup()) {
       await this.refreshPreloadedOptions();
     }
   }
@@ -96,9 +102,9 @@ export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupM
         this.props.optionsValue,
         this.props.optionsLabel
       );
-    const lookupChanged = prevProps.lookup !== this.props.lookup;
+    const lookupBecameAvailable = !prevProps.lookup && Boolean(this.props.lookup);
 
-    if (!optionsChanged && !lookupChanged) {
+    if (!optionsChanged && !lookupBecameAvailable) {
       return;
     }
 
@@ -109,7 +115,7 @@ export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupM
       });
     }
 
-    if (this.props.lookup) {
+    if (this.shouldPreloadLookup()) {
       await this.refreshPreloadedOptions();
     }
   }
@@ -149,7 +155,13 @@ export class LookupMultiSelect extends Component<LookupMultiSelectProps, LookupM
   }
 
   render() {
-    const { lookup, onChange, totalPossibleOptions, ...rest } = this.props;
+    const {
+      lookup,
+      onChange,
+      totalPossibleOptions,
+      forceUpdate: _forceUpdate,
+      ...rest
+    } = this.props;
     const filteredTotalPossibleOptions = this.state.totalPossibleOptions;
     return (
       <MultiSelect

--- a/app/react/Forms/components/specs/LookupMultiSelect.spec.tsx
+++ b/app/react/Forms/components/specs/LookupMultiSelect.spec.tsx
@@ -71,7 +71,6 @@ describe('LookupMultiSelect (React Testing Library)', () => {
 
   it('options should also include selectedOptions', async () => {
     render(<LookupMultiSelect {...(props as LookupMultiSelectProps)} />);
-    // Wait for lookup to complete and Option2 to be rendered
     await waitFor(() => expect(screen.getByLabelText('Selected')).toBeInTheDocument());
     // Select an option
     const optionCheckbox = screen.getByLabelText('Selected');
@@ -79,8 +78,21 @@ describe('LookupMultiSelect (React Testing Library)', () => {
     expect(props.onChange).toHaveBeenCalledWith([]);
   });
 
-  it('should call onFilter (lookup) on mount', async () => {
+  it('should not call lookup on mount when options are already provided', async () => {
     render(<LookupMultiSelect {...(props as LookupMultiSelectProps)} />);
+    await waitFor(() => expect(screen.getByLabelText('Selected')).toBeInTheDocument());
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  it('should call lookup on mount when options are empty', async () => {
+    render(<LookupMultiSelect lookup={lookupSpy} options={[]} value={[]} onChange={jest.fn()} />);
+    await waitFor(() => {
+      expect(lookupSpy).toHaveBeenCalledWith('');
+    });
+  });
+
+  it('should call lookup on mount when forceUpdate is true even if options are provided', async () => {
+    render(<LookupMultiSelect {...(props as LookupMultiSelectProps)} forceUpdate />);
     await waitFor(() => {
       expect(lookupSpy).toHaveBeenCalledWith('');
     });
@@ -111,6 +123,7 @@ describe('LookupMultiSelect (React Testing Library)', () => {
         lookup={lookup}
         value={[]}
         onChange={jest.fn()}
+        forceUpdate
       />
     );
     // Wait for lookup to complete
@@ -180,7 +193,11 @@ describe('LookupMultiSelect (React Testing Library)', () => {
       count: 2,
     });
     render(
-      <LookupMultiSelect {...(props as LookupMultiSelectProps)} lookup={lookupWithDuplicates} />
+      <LookupMultiSelect
+        {...(props as LookupMultiSelectProps)}
+        lookup={lookupWithDuplicates}
+        forceUpdate
+      />
     );
     await waitFor(() => expect(lookupWithDuplicates).toHaveBeenCalled());
     expect(screen.getAllByLabelText('Option1').length).toBe(1);
@@ -209,6 +226,7 @@ describe('LookupMultiSelect (React Testing Library)', () => {
         {...(props as LookupMultiSelectProps)}
         optionsToShow={5}
         totalPossibleOptions={8}
+        forceUpdate
       />
     );
     // Wait for the show more button to appear
@@ -277,7 +295,7 @@ describe('LookupMultiSelect (React Testing Library)', () => {
     });
   });
 
-  it('should update displayed aggregation counts when props.options change with the same lookup ref', async () => {
+  it('should update displayed aggregation counts from props.options without calling lookup', async () => {
     const lookup = jest.fn(async () => ({
       options: [{ label: 'Organization 001', value: 'org-1', results: 999 }],
       count: 1,
@@ -292,8 +310,8 @@ describe('LookupMultiSelect (React Testing Library)', () => {
       <LookupMultiSelect options={initialOptions} lookup={lookup} value={[]} onChange={jest.fn()} />
     );
 
-    await waitFor(() => expect(lookup).toHaveBeenCalledWith(''));
-    expect(screen.getByText('400')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('400')).toBeInTheDocument());
+    expect(lookup).not.toHaveBeenCalled();
     expect(screen.getByText('300')).toBeInTheDocument();
 
     rerender(
@@ -312,8 +330,64 @@ describe('LookupMultiSelect (React Testing Library)', () => {
       expect(screen.getByText('40')).toBeInTheDocument();
       expect(screen.getByText('30')).toBeInTheDocument();
     });
+    expect(lookup).not.toHaveBeenCalled();
     expect(screen.queryByText('400')).not.toBeInTheDocument();
     expect(screen.queryByText('300')).not.toBeInTheDocument();
+  });
+
+  it('should call lookup again when options change if forceUpdate is true', async () => {
+    const lookup = jest.fn(async () => ({
+      options: [{ label: 'Extra', value: 'extra', results: 1 }],
+      count: 3,
+    }));
+
+    const { rerender } = render(
+      <LookupMultiSelect
+        options={[{ label: 'Selected', value: 'selected', results: 1 }]}
+        lookup={lookup}
+        value={[]}
+        onChange={jest.fn()}
+        forceUpdate
+      />
+    );
+
+    await waitFor(() => expect(lookup).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <LookupMultiSelect
+        options={[{ label: 'Selected', value: 'selected', results: 2 }]}
+        lookup={lookup}
+        value={[]}
+        onChange={jest.fn()}
+        forceUpdate
+      />
+    );
+
+    await waitFor(() => expect(lookup).toHaveBeenCalledTimes(2));
+    expect(lookup).toHaveBeenCalledWith('');
+  });
+
+  it('should call lookup when options become empty even without forceUpdate', async () => {
+    const lookup = jest.fn(async () => ({
+      options: [{ label: 'Option1', value: 'option1', results: 1 }],
+      count: 1,
+    }));
+
+    const { rerender } = render(
+      <LookupMultiSelect
+        options={[{ label: 'Selected', value: 'selected', results: 1 }]}
+        lookup={lookup}
+        value={[]}
+        onChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Selected')).toBeInTheDocument());
+    expect(lookup).not.toHaveBeenCalled();
+
+    rerender(<LookupMultiSelect options={[]} lookup={lookup} value={[]} onChange={jest.fn()} />);
+
+    await waitFor(() => expect(lookup).toHaveBeenCalledWith(''));
   });
 
   it('should update displayed labels when props.options labels change with same value/results', async () => {
@@ -331,8 +405,8 @@ describe('LookupMultiSelect (React Testing Library)', () => {
       />
     );
 
-    await waitFor(() => expect(lookup).toHaveBeenCalledWith(''));
-    expect(screen.getByLabelText('Colombia')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('Colombia')).toBeInTheDocument());
+    expect(lookup).not.toHaveBeenCalled();
 
     rerender(
       <LookupMultiSelect

--- a/app/react/Metadata/components/MetadataFormFields.jsx
+++ b/app/react/Metadata/components/MetadataFormFields.jsx
@@ -198,6 +198,7 @@ class MetadataFormFields extends Component {
             prefix={_model}
             onChange={this.relationshipChange.bind(this, property)}
             sort
+            forceUpdate
           />
         );
       case 'newRelationship':
@@ -225,6 +226,7 @@ class MetadataFormFields extends Component {
             prefix={_model}
             onChange={this.relationshipChange.bind(this, property)}
             sort
+            forceUpdate
           />
         );
       case 'date':

--- a/app/react/Metadata/components/specs/MetadataFormFields.spec.js
+++ b/app/react/Metadata/components/specs/MetadataFormFields.spec.js
@@ -106,6 +106,7 @@ describe('MetadataFormFields with one entity to edit ', () => {
       expect(multiselect.props().options).toEqual([{ value: '1', label: 'option1' }]);
       expect(multiselect.props().optionsValue).toEqual('value');
       expect(multiselect.props().lookup).toBeDefined();
+      expect(multiselect.props().forceUpdate).toBe(true);
 
       const datepicker = component.find(DatePicker);
       expect(datepicker.length).toBe(1);
@@ -184,6 +185,7 @@ describe('MetadataFormFields with one entity to edit ', () => {
         { id: 'entity-id', label: 'Related entity', icon: relationshipIcon },
       ]);
       expect(multiselect.props().optionsValue).toBe('id');
+      expect(multiselect.props().forceUpdate).toBe(true);
     });
 
     it('should omit icon when not set', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Library select/multiselect/relationship filters were calling `lookup('')` on mount and again whenever search aggregations changed. Those buckets already come from `/api/search`, so the extra `/search/lookupaggregation` requests were redundant.

**Default (`forceUpdate` off, library):**
- Mount: skip `lookup('')` when `options.length > 0`
- Update: copy the new options into state and do not preload again
- Still lookup when options are empty, and always when the user types in the filter

**`forceUpdate` (metadata relationship / newRelationship fields):**
Selected entities in `entityThesauris` are not the catalog. Those fields keep the previous preload so the picker still loads candidates when values are already selected.

QA checklist:
- [ ] Smoke test library filters: options still render from search aggregations without extra lookupaggregation on load/search
- [ ] Typing in a library select filter still hits lookupaggregation
- [ ] Edit an entity that already has relationships: picker still lists other candidates
- [ ] New entity with empty relationship field still preloads suggestions

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bef0dba-ad45-43a2-a6e1-bc80704c0850?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bef0dba-ad45-43a2-a6e1-bc80704c0850&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

