### PR TITLE
Fix duplicated words in an error message and a test title

### DIFF
--- a/app/api/core/infrastructure/files/InputFile.ts
+++ b/app/api/core/infrastructure/files/InputFile.ts
@@ -111,7 +111,7 @@ export class InputFile {
         return new URLAttachment({ ...urlProps, url: fileProps.url });
       }
       case 'raw':
-        throw new Error('raw is not a valid inputFile type to to map to an entityFile');
+        throw new Error('raw is not a valid inputFile type to map to an entityFile');
       default:
         throw new Error(`${this.type} is not a valid inputFile type`);
     }

--- a/app/api/csv/specs/__snapshots__/importFile.spec.ts.snap
+++ b/app/api/csv/specs/__snapshots__/importFile.spec.ts.snap
@@ -10,7 +10,7 @@ title3, header with dots value 3, text value 3, 2020, ______________, thesauri2 
 "
 `;
 
-exports[`importFile readStream when file is a a zip should return a stream for a file that should be called import.csv by default 1`] = `
+exports[`importFile readStream when file is a zip should return a stream for a file that should be called import.csv by default 1`] = `
 "Title , file , attachments
 
 file1, 1.pdf, att1.doc
@@ -19,7 +19,7 @@ file3, 3.pdf,
 "
 `;
 
-exports[`importFile readStream when file is a a zip when passing a filename should return a read stream for that file 1`] = `
+exports[`importFile readStream when file is a zip when passing a filename should return a read stream for that file 1`] = `
 "file1.txt
 "
 `;

--- a/app/api/csv/specs/importFile.spec.ts
+++ b/app/api/csv/specs/importFile.spec.ts
@@ -28,7 +28,7 @@ describe('importFile', () => {
       expect(fileContents).toMatchSnapshot();
     });
 
-    describe('when file is a a zip', () => {
+    describe('when file is a zip', () => {
       it('should return a stream for a file that should be called import.csv by default', async () => {
         const file = importFile(path.join(__dirname, '/zipData/ImportFile.zip'));
         const fileContents = await streamToString(await file.readStream());


### PR DESCRIPTION
fixes # (none - noticed while reading the code)

Two duplicated words: the raw-type error in InputFile.ts said "to to map
to an entityFile", and the csv importFile spec described "when file is a a
zip". The spec title is part of two snapshot keys, so those were renamed
to match.

PR checklist:
- [ ] Update READ.me ? Not needed.
- [ ] Update API documentation ? Not needed.

QA checklist:
- [x] Code review - the only non-test change is the wording of one error message.
- [ ] Smoke test the functionality described in the issue - no functional change to smoke test.
- [ ] Test for side effects - the old strings appear nowhere else in app/.
- [ ] UI responsiveness - not applicable.
- [ ] Cross browser testing - not applicable.
