### PR TITLE
Add instance SEO settings to Collection

### DIFF
--- a/app/api/settings/publicSettings.ts
+++ b/app/api/settings/publicSettings.ts
@@ -7,6 +7,7 @@ const PUBLIC_ALLOWED_FIELDS: (keyof Settings)[] = [
   '_id',
   'project',
   'site_name',
+  'seo',
   'favicon',
   'site_logo',
   'themeAssets',

--- a/app/api/settings/specs/publicSettings.spec.ts
+++ b/app/api/settings/specs/publicSettings.spec.ts
@@ -23,6 +23,13 @@ describe('publicSettings', () => {
     customJS: 'console.log(1)',
     allowcustomJS: true,
     features: { newHeader: true, ocr: { url: 'http://ocr' } },
+    seo: {
+      title: 'Public title',
+      description: 'Public description',
+      ogTitle: 'OG title',
+      ogDescription: 'OG description',
+      ogImage: '/assets/og.png',
+    },
   } as unknown as Settings;
 
   describe('pickPublicFields', () => {
@@ -31,6 +38,7 @@ describe('publicSettings', () => {
       expect(result.site_name).toBe('Uwazi');
       expect(result.customCSS).toBe('body { color: red; }');
       expect(result.allowcustomJS).toBe(true);
+      expect(result.seo).toEqual(fullSettings.seo);
       expect((result as Settings).mailerConfig).toBeUndefined();
       expect((result as Settings).contactEmail).toBeUndefined();
       expect((result as Settings).features).toBeUndefined();

--- a/app/api/settings/specs/settings.spec.ts
+++ b/app/api/settings/specs/settings.spec.ts
@@ -45,6 +45,20 @@ describe('settings', () => {
       expect(createdDocument.allowedPublicTemplates?.[1]).toBe('id2');
     });
 
+    it('should persist instance SEO metadata', async () => {
+      const seo = {
+        title: 'Human rights database',
+        description: 'A collection of documents and cases.',
+        ogTitle: 'Share this collection',
+        ogDescription: 'Open data on human rights.',
+        ogImage: '/assets/og-image.png',
+      };
+
+      await settings.save({ site_name: 'My collection', seo });
+      const result = await settings.get();
+      expect(result.seo).toEqual(seo);
+    });
+
     describe('when there are Links', () => {
       const baseLink = { title: 'Page one', type: 'link' as 'link', url: 'url' };
       const baseConfig = {

--- a/app/react/App/App.jsx
+++ b/app/react/App/App.jsx
@@ -11,6 +11,7 @@ import { TranslateModal } from '#app/I18N/index.js';
 import { inlineEditAtom } from '#V2/atoms/index.js';
 import { NotificationsPanel } from '#V2/Components/UI/Notifications/NotificationsPanel.js';
 import { Header } from '#app/V2/Components/UI/Header/Header.js';
+import { InstanceSeo } from '#app/App/InstanceSeo.js';
 import { BertHost } from '#app/V2/Components/AIAssistant/BertHost.js';
 import { Confirm } from './Confirm.js';
 import { AppMainContext } from './AppMainContext.js';
@@ -82,6 +83,7 @@ const App = ({ customParams }) => {
 
   return (
     <div id="app" className={appClassName}>
+      <InstanceSeo />
       <div className="content">
         {shellSharedTheme ? (
           <ThemeProvider

--- a/app/react/App/InstanceSeo.tsx
+++ b/app/react/App/InstanceSeo.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useAtomValue } from 'jotai';
+import { Helmet } from 'react-helmet';
+import { requestOriginAtom, settingsAtom } from '#V2/atoms/index.js';
+import { getInstanceSeoMeta } from './instanceSeo.js';
+
+const getBrowserOrigin = () => (typeof window !== 'undefined' ? window.location.origin : '');
+
+const InstanceSeo = () => {
+  const settings = useAtomValue(settingsAtom);
+  const requestOrigin = useAtomValue(requestOriginAtom);
+  const { defaultTitle, titleTemplate, meta } = getInstanceSeoMeta(
+    settings,
+    requestOrigin || getBrowserOrigin()
+  );
+
+  return <Helmet defaultTitle={defaultTitle} titleTemplate={titleTemplate} meta={meta} />;
+};
+
+export { InstanceSeo };

--- a/app/react/App/SiteName.tsx
+++ b/app/react/App/SiteName.tsx
@@ -77,8 +77,6 @@ export const SiteName: React.FC<SiteNameProps> = ({
   return (
     <>
       <Helmet
-        titleTemplate={`%s • ${siteName}`}
-        meta={[{ charSet: 'utf-8' }, { name: 'description', content: 'Uwazi docs' }]}
         link={
           faviconUrl
             ? [

--- a/app/react/App/instanceSeo.ts
+++ b/app/react/App/instanceSeo.ts
@@ -1,0 +1,63 @@
+import type { ClientSettings } from '#app/apiResponseTypes.js';
+
+type SeoMetaTag = {
+  charSet?: string;
+  name?: string;
+  property?: string;
+  content?: string;
+};
+
+type InstanceSeoMeta = {
+  defaultTitle: string;
+  titleTemplate: string;
+  meta: SeoMetaTag[];
+};
+
+const DEFAULT_SITE_NAME = 'Uwazi';
+
+const toAbsoluteUrl = (url: string, origin: string): string => {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) {
+    return url;
+  }
+  if (!origin) {
+    return url;
+  }
+  try {
+    return new URL(url, origin.endsWith('/') ? origin : `${origin}/`).href;
+  } catch {
+    return url;
+  }
+};
+
+const getInstanceSeoMeta = (
+  settings: Pick<ClientSettings, 'site_name' | 'seo'>,
+  origin = ''
+): InstanceSeoMeta => {
+  const siteName = settings.site_name?.trim() || DEFAULT_SITE_NAME;
+  const title = settings.seo?.title?.trim() || siteName;
+  const description = settings.seo?.description?.trim() || '';
+  const ogTitle = settings.seo?.ogTitle?.trim() || title;
+  const ogDescription = settings.seo?.ogDescription?.trim() || description;
+  const ogImage = settings.seo?.ogImage?.trim()
+    ? toAbsoluteUrl(settings.seo.ogImage.trim(), origin)
+    : undefined;
+
+  const meta: SeoMetaTag[] = [
+    { charSet: 'utf-8' },
+    { property: 'og:type', content: 'website' },
+    { property: 'og:site_name', content: siteName },
+    { property: 'og:title', content: ogTitle },
+    ...(description ? [{ name: 'description', content: description }] : []),
+    ...(ogDescription ? [{ property: 'og:description', content: ogDescription }] : []),
+    ...(ogImage ? [{ property: 'og:image', content: ogImage }] : []),
+  ];
+
+  return {
+    defaultTitle: title,
+    titleTemplate: `%s • ${siteName}`,
+    meta,
+  };
+};
+
+export { getInstanceSeoMeta };
+export type { InstanceSeoMeta, SeoMetaTag };

--- a/app/react/App/specs/instanceSeo.spec.ts
+++ b/app/react/App/specs/instanceSeo.spec.ts
@@ -1,0 +1,78 @@
+import { getInstanceSeoMeta } from '../instanceSeo.js';
+
+describe('getInstanceSeoMeta', () => {
+  it('should fall back to the collection name when SEO fields are empty', () => {
+    const result = getInstanceSeoMeta({ site_name: 'My collection' });
+
+    expect(result.defaultTitle).toBe('My collection');
+    expect(result.titleTemplate).toBe('%s • My collection');
+    expect(result.meta).toEqual(
+      expect.arrayContaining([
+        { charSet: 'utf-8' },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:site_name', content: 'My collection' },
+        { property: 'og:title', content: 'My collection' },
+      ])
+    );
+    expect(result.meta.find(tag => tag.name === 'description')).toBeUndefined();
+    expect(result.meta.find(tag => tag.property === 'og:image')).toBeUndefined();
+  });
+
+  it('should use configured page title, description and Open Graph fields', () => {
+    const result = getInstanceSeoMeta(
+      {
+        site_name: 'My collection',
+        seo: {
+          title: 'Human rights database',
+          description: 'Documents and cases from the archive.',
+          ogTitle: 'Share title',
+          ogDescription: 'Share description',
+          ogImage: '/assets/og.png',
+        },
+      },
+      'https://example.org'
+    );
+
+    expect(result.defaultTitle).toBe('Human rights database');
+    expect(result.titleTemplate).toBe('%s • My collection');
+    expect(result.meta).toEqual(
+      expect.arrayContaining([
+        { name: 'description', content: 'Documents and cases from the archive.' },
+        { property: 'og:title', content: 'Share title' },
+        { property: 'og:description', content: 'Share description' },
+        { property: 'og:image', content: 'https://example.org/assets/og.png' },
+      ])
+    );
+  });
+
+  it('should fall og title and description back to page title and meta description', () => {
+    const result = getInstanceSeoMeta({
+      site_name: 'My collection',
+      seo: {
+        title: 'Human rights database',
+        description: 'Documents and cases from the archive.',
+      },
+    });
+
+    expect(result.meta).toEqual(
+      expect.arrayContaining([
+        { property: 'og:title', content: 'Human rights database' },
+        { property: 'og:description', content: 'Documents and cases from the archive.' },
+      ])
+    );
+  });
+
+  it('should keep absolute Open Graph image URLs unchanged', () => {
+    const result = getInstanceSeoMeta(
+      {
+        site_name: 'My collection',
+        seo: { ogImage: 'https://cdn.example.org/share.jpg' },
+      },
+      'https://example.org'
+    );
+
+    expect(result.meta.find(tag => tag.property === 'og:image')?.content).toBe(
+      'https://cdn.example.org/share.jpg'
+    );
+  });
+});

--- a/app/react/Entities/components/EntityViewer.jsx
+++ b/app/react/Entities/components/EntityViewer.jsx
@@ -140,6 +140,10 @@ class EntityViewer extends Component {
       <div className="row">
         <Helmet>
           <title>{entity.get('title') ? entity.get('title') : 'Entity'}</title>
+          <meta
+            property="og:title"
+            content={entity.get('title') ? entity.get('title') : 'Entity'}
+          />
         </Helmet>
 
         {selectedTab !== 'page' && (
@@ -274,11 +278,11 @@ class EntityViewer extends Component {
                     aria-label={t('System', 'Info', null, false)}
                     component="div"
                   >
-                      <I18NLink
-                        className={this.linkClassNames(['info', ''])}
-                        to={`${entityBasePath}/${rawEntity.sharedId}/info`}
-                        replace
-                      >
+                    <I18NLink
+                      className={this.linkClassNames(['info', ''])}
+                      to={`${entityBasePath}/${rawEntity.sharedId}/info`}
+                      replace
+                    >
                       <Icon icon="info-circle" />
                       <span className="tab-link-tooltip">{t('System', 'Info')}</span>
                     </I18NLink>
@@ -292,11 +296,11 @@ class EntityViewer extends Component {
                     aria-label={t('System', 'Relationships', null, false)}
                     component="div"
                   >
-                      <I18NLink
-                        className={this.linkClassNames(['relationships'])}
-                        to={`${entityBasePath}/${rawEntity.sharedId}/relationships`}
-                        replace
-                      >
+                    <I18NLink
+                      className={this.linkClassNames(['relationships'])}
+                      to={`${entityBasePath}/${rawEntity.sharedId}/relationships`}
+                      replace
+                    >
                       <Icon icon="exchange-alt" />
                       <span className="connectionsNumber">{summary.totalConnections}</span>
                       <span className="tab-link-tooltip">{t('System', 'Relationships')}</span>

--- a/app/react/Pages/components/PageViewer.jsx
+++ b/app/react/Pages/components/PageViewer.jsx
@@ -106,6 +106,10 @@ class PageViewer extends Component {
               {setBrowserTitle && (
                 <Helmet>
                   <title>{page.get('title') ? page.get('title') : 'Page'}</title>
+                  <meta
+                    property="og:title"
+                    content={page.get('title') ? page.get('title') : 'Page'}
+                  />
                 </Helmet>
               )}
               <main className="page-viewer document-viewer">

--- a/app/react/V2/Routes/Entity/Components/shared/EntitySeo.tsx
+++ b/app/react/V2/Routes/Entity/Components/shared/EntitySeo.tsx
@@ -116,6 +116,8 @@ const EntitySeo = ({ entity }: EntitySeoProps) => {
       <Helmet>
         <title>{entity.title}</title>
         <meta name="description" content={description} />
+        <meta property="og:title" content={entity.title} />
+        <meta property="og:description" content={description} />
         <link rel="canonical" href={canonicalPath} />
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Helmet>

--- a/app/react/V2/Routes/Settings/Collection/Collection.tsx
+++ b/app/react/V2/Routes/Settings/Collection/Collection.tsx
@@ -20,6 +20,7 @@ import { ClientSettings, Template } from '#app/apiResponseTypes.js';
 import { apiErrorToRequestError } from '#V2/shared/errorUtils.js';
 import * as tips from './collectionSettingsTips.js';
 import { CollectionOptionToggle } from './CollectionOptionToggle.js';
+import { SeoSettingsCard } from './SeoSettingsCard.js';
 import { CustomUploadImagePicker } from './Theming/CustomUploadImagePicker.js';
 import { FileType } from '#shared/types/fileType.js';
 import { ThemeSelectionCard } from './Theming/ThemeSelectionCard.js';
@@ -112,6 +113,7 @@ const Collection = () => {
       ...formData,
       themeAssets: formData.themeAssets ?? {},
       themeVars: formData.themeVars ?? {},
+      seo: formData.seo ?? {},
     },
     mode: 'onSubmit',
   });
@@ -304,6 +306,12 @@ const Collection = () => {
                 )}
               </div>
             </Card>
+            <SeoSettingsCard
+              register={register}
+              watch={watch}
+              setValue={setValue}
+              customUploadFiles={customUploadFiles}
+            />
             <Card
               className="mb-4"
               title={

--- a/app/react/V2/Routes/Settings/Collection/SeoSettingsCard.tsx
+++ b/app/react/V2/Routes/Settings/Collection/SeoSettingsCard.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { QuestionMarkCircleIcon } from '@heroicons/react/20/solid';
+import { UseFormRegister, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { InputField, Textarea } from '#V2/Components/Forms/index.js';
+import { Card, SectionHeading, Tooltip } from '#V2/Components/UI/index.js';
+import { Translate } from '#app/I18N/index.js';
+import { ClientSettings } from '#app/apiResponseTypes.js';
+import { FileType } from '#shared/types/fileType.js';
+import * as tips from './collectionSettingsTips.js';
+import { CustomUploadImagePicker } from './Theming/CustomUploadImagePicker.js';
+import { ogImageSizeRule } from './Theming/brandImageUploadRules.js';
+
+type SeoSettingsCardProps = {
+  register: UseFormRegister<ClientSettings>;
+  watch: UseFormWatch<ClientSettings>;
+  setValue: UseFormSetValue<ClientSettings>;
+  customUploadFiles: FileType[];
+};
+
+const labelWithTip = (label: React.ReactNode, tip: React.ReactNode) => (
+  <span className="flex gap-4">
+    {label}
+    <Tooltip content={tip} placement="right">
+      <QuestionMarkCircleIcon className="h-5 w-5 text-ink-muted" />
+    </Tooltip>
+  </span>
+);
+
+const SeoSettingsCard = ({
+  register,
+  watch,
+  setValue,
+  customUploadFiles,
+}: SeoSettingsCardProps) => (
+  <div data-testid="settings-seo">
+    <Card className="mb-4" title={<Translate>SEO</Translate>}>
+      <div className="grid gap-4 sm:grid-cols-2 sm:gap-6">
+        <div className="sm:col-span-2">
+          <InputField
+            id="seo-page-title"
+            label={labelWithTip(<Translate>Page title</Translate>, tips.seoPageTitle)}
+            {...register('seo.title')}
+            value={watch('seo.title') ?? ''}
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <Textarea
+            id="seo-meta-description"
+            rows={3}
+            resize="vertical"
+            label={labelWithTip(<Translate>Meta description</Translate>, tips.seoMetaDescription)}
+            {...register('seo.description')}
+            value={watch('seo.description') ?? ''}
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <SectionHeading>
+            <Translate>Open Graph</Translate>
+          </SectionHeading>
+        </div>
+        <div className="sm:col-span-2">
+          <InputField
+            id="seo-og-title"
+            label={labelWithTip(<Translate>og:title</Translate>, tips.seoOgTitle)}
+            {...register('seo.ogTitle')}
+            value={watch('seo.ogTitle') ?? ''}
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <Textarea
+            id="seo-og-description"
+            rows={3}
+            resize="vertical"
+            label={labelWithTip(<Translate>og:description</Translate>, tips.seoOgDescription)}
+            {...register('seo.ogDescription')}
+            value={watch('seo.ogDescription') ?? ''}
+          />
+        </div>
+        <CustomUploadImagePicker
+          id="seo-og-image"
+          label={labelWithTip(<Translate>og:image</Translate>, tips.seoOgImage)}
+          registerProps={register('seo.ogImage')}
+          value={watch('seo.ogImage')}
+          onChange={v => setValue('seo.ogImage', v, { shouldDirty: true })}
+          files={customUploadFiles}
+          selectButtonTitle={<Translate>Select Open Graph image</Translate>}
+          recommendedSize="1200x630 px"
+          sizeRule={ogImageSizeRule}
+        />
+      </div>
+    </Card>
+  </div>
+);
+
+export { SeoSettingsCard };
+export type { SeoSettingsCardProps };

--- a/app/react/V2/Routes/Settings/Collection/Theming/CustomUploadImagePicker.tsx
+++ b/app/react/V2/Routes/Settings/Collection/Theming/CustomUploadImagePicker.tsx
@@ -10,8 +10,6 @@ import { CustomUploadImagePickerModal } from './CustomUploadImagePickerModal.js'
 import { ImageValidationIconButton } from './ImageValidationIconButton.js';
 import { useCustomUploadImagePickerLogic } from './useCustomUploadImagePickerLogic.js';
 
-type AssetField = 'site_logo' | 'favicon';
-
 const defaultPreviewClass =
   'max-h-full max-w-full rounded object-contain [box-shadow:0_0_0_1px_color-mix(in_srgb,var(--color-theme-text-primary)_45%,transparent),0_0_0_2px_color-mix(in_srgb,var(--color-theme-surface-raised,var(--color-theme-bg-surface))_92%,transparent)]';
 
@@ -20,7 +18,7 @@ const defaultPreviewWrapperClass =
 
 type CustomUploadImagePickerProps = {
   id: string;
-  registerProps?: UseFormRegisterReturn<AssetField>;
+  registerProps?: UseFormRegisterReturn<string>;
   value: string | undefined;
   onChange: (url: string) => void;
   files: FileType[];

--- a/app/react/V2/Routes/Settings/Collection/Theming/brandImageUploadRules.ts
+++ b/app/react/V2/Routes/Settings/Collection/Theming/brandImageUploadRules.ts
@@ -19,3 +19,13 @@ export const themeLogotypeImageSizeRule: ImageSizeRule = {
   maxHeight: 256,
   square: false,
 };
+
+export const ogImageSizeRule: ImageSizeRule = {
+  policy: 'soft',
+  assetLabel: 'ogImage',
+  minWidth: 600,
+  maxWidth: 2400,
+  minHeight: 315,
+  maxHeight: 1260,
+  square: false,
+};

--- a/app/react/V2/Routes/Settings/Collection/Theming/customUploadImagePickerLib.ts
+++ b/app/react/V2/Routes/Settings/Collection/Theming/customUploadImagePickerLib.ts
@@ -9,7 +9,7 @@ type ImageFeedback = {
 };
 type ImageSizeRule = {
   policy: ImageSizePolicy;
-  assetLabel: 'favicon' | 'logotype';
+  assetLabel: 'favicon' | 'logotype' | 'ogImage';
   minWidth: number;
   maxWidth: number;
   minHeight: number;

--- a/app/react/V2/Routes/Settings/Collection/Theming/index.ts
+++ b/app/react/V2/Routes/Settings/Collection/Theming/index.ts
@@ -2,3 +2,4 @@ export { CustomUploadImagePicker } from './CustomUploadImagePicker.js';
 export { ThemeSettingsSidepanel } from './ThemeSettingsSidepanel.js';
 export { faviconImageSizeRule } from './brandImageUploadRules.js';
 export { themeLogotypeImageSizeRule } from './brandImageUploadRules.js';
+export { ogImageSizeRule } from './brandImageUploadRules.js';

--- a/app/react/V2/Routes/Settings/Collection/collectionSettingsTips.tsx
+++ b/app/react/V2/Routes/Settings/Collection/collectionSettingsTips.tsx
@@ -193,3 +193,37 @@ export const filterUnauthorizedRelated = (
     knowing restricted content exists.
   </Translate>
 );
+
+export const seoPageTitle = (
+  <Translate translationKey="SEO page title description">
+    A clear and descriptive title for the website. This is used as the default HTML page title in
+    browser tabs and search results.
+  </Translate>
+);
+
+export const seoMetaDescription = (
+  <Translate translationKey="SEO meta description">
+    A short description of what this collection provides. Search engines may show this text in
+    results. Aim for about 150–160 characters.
+  </Translate>
+);
+
+export const seoOgTitle = (
+  <Translate translationKey="SEO og title description">
+    Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other
+    social media. If empty, the page title is used.
+  </Translate>
+);
+
+export const seoOgDescription = (
+  <Translate translationKey="SEO og description">
+    Description used in social media previews. If empty, the meta description is used.
+  </Translate>
+);
+
+export const seoOgImage = (
+  <Translate translationKey="SEO og image description">
+    Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is
+    1200×630 pixels.
+  </Translate>
+);

--- a/app/react/V2/Routes/Settings/Collection/specs/SeoSettingsCard.spec.tsx
+++ b/app/react/V2/Routes/Settings/Collection/specs/SeoSettingsCard.spec.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { ClientSettings } from '#app/apiResponseTypes.js';
+import { TestAtomStoreProvider, TestRouterContext } from '#V2/testing/index.js';
+import { SeoSettingsCard } from '../SeoSettingsCard.js';
+
+const Wrapper = ({ defaults }: { defaults?: ClientSettings['seo'] }) => {
+  const { register, watch, setValue } = useForm<ClientSettings>({
+    defaultValues: { seo: defaults ?? {} },
+  });
+
+  return (
+    <TestAtomStoreProvider initialValues={[]}>
+      <TestRouterContext>
+        <SeoSettingsCard
+          register={register}
+          watch={watch}
+          setValue={setValue}
+          customUploadFiles={[]}
+        />
+      </TestRouterContext>
+    </TestAtomStoreProvider>
+  );
+};
+
+describe('SeoSettingsCard', () => {
+  it('should render page title, meta description and Open Graph fields', async () => {
+    render(
+      <Wrapper
+        defaults={{
+          title: 'Page title value',
+          description: 'Meta description value',
+          ogTitle: 'OG title value',
+          ogDescription: 'OG description value',
+        }}
+      />
+    );
+
+    expect(await screen.findByRole('textbox', { name: /Page title/ })).toHaveValue(
+      'Page title value'
+    );
+    expect(screen.getByRole('textbox', { name: /Meta description/ })).toHaveValue(
+      'Meta description value'
+    );
+    expect(screen.getByRole('textbox', { name: /og:title/ })).toHaveValue('OG title value');
+    expect(screen.getByRole('textbox', { name: /og:description/ })).toHaveValue(
+      'OG description value'
+    );
+    expect(screen.getByText('og:image')).toBeInTheDocument();
+  });
+});

--- a/app/react/V2/atoms/index.ts
+++ b/app/react/V2/atoms/index.ts
@@ -10,6 +10,7 @@ export { relationshipTypesAtom } from './relationshipTypes.js';
 export { deletedEntityAtom } from './deletedEntityAtom.js';
 export { entityPageViewAtom } from './entityPageViewAtom.js';
 export { serverIsMobileAtom, isMobileOverrideAtom } from './isMobileAtom.js';
+export { requestOriginAtom } from './requestOriginAtom.js';
 export { themeModeAtom } from './themeModeAtom.js';
 export { aiAssistantOpenAtom } from './aiAssistantOpenAtom.js';
 export {

--- a/app/react/V2/atoms/requestOriginAtom.ts
+++ b/app/react/V2/atoms/requestOriginAtom.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai';
+
+const requestOriginAtom = atom('');
+
+export { requestOriginAtom };

--- a/app/react/V2/atoms/specs/hydrateAtomStore.spec.ts
+++ b/app/react/V2/atoms/specs/hydrateAtomStore.spec.ts
@@ -1,6 +1,12 @@
 import { createStore } from 'jotai';
 import { hydrateAtomStore } from '../store.js';
-import { localeAtom, settingsAtom, translationsAtom, userAtom } from '../index.js';
+import {
+  localeAtom,
+  requestOriginAtom,
+  settingsAtom,
+  translationsAtom,
+  userAtom,
+} from '../index.js';
 
 const minimalEmbedAtomStoreData = {
   locale: 'en',
@@ -22,5 +28,12 @@ describe('hydrateAtomStore', () => {
     expect(store.get(localeAtom)).toBe('en');
     expect(store.get(settingsAtom)?.private).toBe(false);
     expect(store.get(userAtom)).toEqual({});
+  });
+
+  it('should hydrate the request origin used for absolute SEO URLs', () => {
+    const store = createStore();
+    hydrateAtomStore({ ...minimalEmbedAtomStoreData, origin: 'https://example.org' } as any, store);
+
+    expect(store.get(requestOriginAtom)).toBe('https://example.org');
   });
 });

--- a/app/react/V2/atoms/store.ts
+++ b/app/react/V2/atoms/store.ts
@@ -16,6 +16,7 @@ import { translationsAtom, localeAtom } from './translationsAtoms.js';
 import { userAtom } from './userAtom.js';
 import { thesauriAtom } from './thesauriAtom.js';
 import { serverIsMobileAtom } from './isMobileAtom.js';
+import { requestOriginAtom } from './requestOriginAtom.js';
 import { acceptedSuggestions as ixAcceptedSuggestions } from '../Routes/Settings/IX/components/atoms/index.js';
 
 type AtomStoreData = {
@@ -30,6 +31,7 @@ type AtomStoreData = {
   translations: ClientTranslationSchema[];
   acceptedSuggestions?: Set<string>;
   isMobile?: boolean;
+  origin?: string;
 };
 
 // eslint-disable-next-line max-statements
@@ -41,6 +43,7 @@ const hydrateAtomStore = (data: AtomStoreData, store: ReturnType<typeof createSt
   if (data.templates) store.set(templatesAtom, data.templates);
   if (data.relationTypes) store.set(relationshipTypesAtom, data.relationTypes);
   if (data.isMobile !== undefined) store.set(serverIsMobileAtom, data.isMobile);
+  store.set(requestOriginAtom, data.origin || '');
   store.set(userAtom, data.user);
   store.set(translationsAtom, data.translations ?? []);
   store.set(localeAtom, data.locale || 'en');

--- a/app/react/entry-server.tsx
+++ b/app/react/entry-server.tsx
@@ -238,6 +238,7 @@ const prepareStores = async (req: ExpressRequest, settings: ClientSettings, lang
       translations: translationsApiResponse,
       relationTypes: sortBy(relationTypesApiResponse, 'name'),
       isMobile: isMobileDevice(userAgent),
+      origin: `${req.protocol}://${req.get('host')}`,
     },
   });
 

--- a/app/shared/types/settingsSchema.ts
+++ b/app/shared/types/settingsSchema.ts
@@ -324,6 +324,17 @@ const settingsSchema = {
     __v: { type: 'number' },
     project: { type: 'string' },
     site_name: { type: 'string' },
+    seo: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: { type: 'string', maxLength: 200 },
+        description: { type: 'string', maxLength: 320 },
+        ogTitle: { type: 'string', maxLength: 200 },
+        ogDescription: { type: 'string', maxLength: 320 },
+        ogImage: { type: 'string', maxLength: 2048 },
+      },
+    },
     favicon: { type: 'string' },
     site_logo: { type: 'string' },
     themeAssets: {

--- a/app/shared/types/settingsType.d.ts
+++ b/app/shared/types/settingsType.d.ts
@@ -55,6 +55,13 @@ export interface Settings {
   __v?: number;
   project?: string;
   site_name?: string;
+  seo?: {
+    title?: string;
+    description?: string;
+    ogTitle?: string;
+    ogDescription?: string;
+    ogImage?: string;
+  };
   favicon?: string;
   site_logo?: string;
   themeAssets?: {

--- a/app/shared/types/specs/settingsSchema.spec.ts
+++ b/app/shared/types/specs/settingsSchema.spec.ts
@@ -1,0 +1,38 @@
+import { validateSettings } from '../settingsSchema.js';
+
+describe('settingsSchema SEO', () => {
+  it('should accept instance SEO metadata', async () => {
+    await expect(
+      validateSettings({
+        site_name: 'My collection',
+        seo: {
+          title: 'Human rights database',
+          description: 'A collection of documents and cases.',
+          ogTitle: 'Share this collection',
+          ogDescription: 'Open data on human rights.',
+          ogImage: '/assets/og-image.png',
+        },
+      })
+    ).resolves.toMatchObject({
+      site_name: 'My collection',
+      seo: {
+        title: 'Human rights database',
+        description: 'A collection of documents and cases.',
+        ogTitle: 'Share this collection',
+        ogDescription: 'Open data on human rights.',
+        ogImage: '/assets/og-image.png',
+      },
+    });
+  });
+
+  it('should reject unknown SEO fields', async () => {
+    await expect(
+      validateSettings({
+        seo: {
+          title: 'Human rights database',
+          unknown: 'nope',
+        },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/contents/ui-translations/ar.csv
+++ b/contents/ui-translations/ar.csv
@@ -725,6 +725,7 @@ Members,أعضاء
 Menu,قائمة التحكم
 Message,رسالة
 Message sent,Message sent
+Meta description,Meta description
 Metadata,البيانات الوصفية
 Metadata Extraction,استخلاص البيانات الوصفية
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -862,6 +863,9 @@ OCR error,خطأ في الOCR
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,تشغيل خاصية الOCR على الPDF
 of,من
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,موافق
 OK,موافق
 On this entity,On this entity
@@ -880,6 +884,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -899,6 +904,7 @@ p.,p.
 Page,صفحة
 Page not found,لم يتم العثور على الصفحة
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,الصفحات
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1127,6 +1133,7 @@ Select files on your device,اختر الملفات في جهازك
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,اختر نوع العلاقة
 Select site logo image,Select site logo image
@@ -1148,6 +1155,12 @@ Send recovery email,إرسل بريد الكتروني للاستعادة
 Sending email,البريد الالكتروني المرسل
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,تعيين كافتراضي

--- a/contents/ui-translations/el.csv
+++ b/contents/ui-translations/el.csv
@@ -727,6 +727,7 @@ Members,Μέλη
 Menu,Μενού
 Message,Μήνυμα
 Message sent,Το μήνυμα στάλθηκε
+Meta description,Meta description
 Metadata,Μεταδεδομένα
 Metadata Extraction,Εξαγωγή μεταδεδομένων
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -864,6 +865,9 @@ OCR error,Σφάλμα OCR
 OCR error tip,Η υπηρεσία OCR δεν μπόρεσε να διαβάσει το έγγραφο λόγω εσφαλμένης μορφής. Τελευταία ενημέρωση:
 OCR PDF,OCR PDF
 of,από
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,Εντάξει
 OK,Εντάξει
 On this entity,On this entity
@@ -882,6 +886,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Μόνο ο εξαγωγέας θα διαγραφεί, όλες οι δημιουργημένες οντότητες θα παραμείνουν στη βιβλιοθήκη."
 Open,Άνοιγμα
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Άνοιγμα ομάδας
 Open link,Open link
 Open PDF,Άνοιγμα PDF
@@ -901,6 +906,7 @@ p.,p.
 Page,Σελίδα
 Page not found,Η σελίδα δεν βρέθηκε
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Σελίδες
 Paragrap number extraction property (numeric),Ιδιότητα εξαγωγής αριθμού παραγράφου (αριθμός)
 Paragraph,Παράγραφος
@@ -1129,6 +1135,7 @@ Select files on your device,Επιλογή αρχείων στη συσκευή 
 Select from computer,Επιλογή από τον υπολογιστή
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,Επιλογή τύπου σχέσης
 Select site logo image,Επιλογή εικόνας λογότυπου ιστότοπου
@@ -1150,6 +1157,12 @@ Send recovery email,Αποστολή email ανάκτησης
 Sending email,Αποστολή email
 Sending email description,"Αυτή είναι η διεύθυνση email που θα εμφανίζεται ως αποστολέας όταν αποστέλλεται ένα μήνυμα email από την Uwazi συλλογή σας σε εγγεγραμμένους χρήστες. Η προεπιλεγμένη διεύθυνση είναι *uwazi@uwazi.io*. Μπορείτε να ορίσετε μια προσαρμοσμένη διεύθυνση, εισάγοντας εδώ τη διεύθυνση email που επιθυμείτε."
 Sending labeled data,Αποστολή επισημασμένων δεδομένων
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Υπηρεσίες
 Set as default,Ορισμός ως προεπιλογή

--- a/contents/ui-translations/en.csv
+++ b/contents/ui-translations/en.csv
@@ -728,6 +728,7 @@ Members,Members
 Menu,Menu
 Message,Message
 Message sent,Message sent
+Meta description,Meta description
 Metadata,Metadata
 Metadata Extraction,Metadata Extraction
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -865,6 +866,9 @@ OCR error,OCR error
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,OCR PDF
 of,of
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,Ok
 OK,OK
 On this entity,On this entity
@@ -883,6 +887,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -902,6 +907,7 @@ p.,p.
 Page,Page
 Page not found,Page not found
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Pages
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1130,6 +1136,7 @@ Select files on your device,Select files on your device
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,Select relationship type
 Select site logo image,Select site logo image
@@ -1151,6 +1158,12 @@ Send recovery email,Send recovery email
 Sending email,Sending email
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,Set as default

--- a/contents/ui-translations/es.csv
+++ b/contents/ui-translations/es.csv
@@ -724,6 +724,7 @@ Members,Miembros
 Menu,Menú
 Message,Mensaje
 Message sent,Mensaje enviado
+Meta description,Meta description
 Metadata,Metadatos
 Metadata Extraction,Extracción de metadatos
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -860,6 +861,9 @@ OCR error,Error ROC
 OCR error tip,El motor de OCR no pudo leer el documento debido a un formato incorrecto. Última actualización
 OCR PDF,ROC PDF
 of,de
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,De acuerdo
 OK,OK
 On this entity,En esta entidad
@@ -878,6 +882,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Abrir entidad
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -897,6 +902,7 @@ p.,p.
 Page,Página
 Page not found,Página no encontrada
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Páginas
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1125,6 +1131,7 @@ Select files on your device,Seleccionar archivos de tu dispositivo
 Select from computer,Seleccionar desde la computadora
 Select image,Seleccionar imagen
 Select media,Seleccionar media
+Select Open Graph image,Select Open Graph image
 Select relationship,Seleccionar relación
 Select relationship type,Seleccionar tipo de relación
 Select site logo image,Seleccionar imagen del logotipo del sitio
@@ -1146,6 +1153,12 @@ Send recovery email,Enviar correo electrónico de recuperación
 Sending email,Correo electrónico de envío
 Sending email description,Esta es la dirección de correo electrónico que aparecerá como remitente cuando se envíe un correo electrónico desde tu colección Uwazi a usuarios registrados. La dirección predeterminada es *no-reply@uwazi.io*. Puedes configurar una dirección personalizada aquí.
 Sending labeled data,Enviando datos etiquetados
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Servicios
 Set as default,Establecer como predeterminado

--- a/contents/ui-translations/fr.csv
+++ b/contents/ui-translations/fr.csv
@@ -725,6 +725,7 @@ Members,Members
 Menu,Menu
 Message,Message
 Message sent,Message sent
+Meta description,Meta description
 Metadata,Métadonnées
 Metadata Extraction,Metadata Extraction
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -862,6 +863,9 @@ OCR error,Erreur OCR
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,OCR PDF
 of,de
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,Ok
 OK,OK
 On this entity,On this entity
@@ -880,6 +884,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -899,6 +904,7 @@ p.,p.
 Page,Page
 Page not found,Page non trouvée
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Pages
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1127,6 +1133,7 @@ Select files on your device,Sélectionnez les fichiers sur votre appareil
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,Sélectionner le type de relation
 Select site logo image,Sélectionner l'image du logo du site
@@ -1148,6 +1155,12 @@ Send recovery email,Envoyer mail de récupération
 Sending email,Envoi d'e-mail
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,Définir par défaut

--- a/contents/ui-translations/ko.csv
+++ b/contents/ui-translations/ko.csv
@@ -726,6 +726,7 @@ Members,멤버
 Menu,메뉴
 Message,메세지
 Message sent,Message sent
+Meta description,Meta description
 Metadata,메타데이터
 Metadata Extraction,메타데이터 추출
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -863,6 +864,9 @@ OCR error,OCR 에러
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,PDF OCR 읽기
 of,의
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,확인
 OK,확인
 On this entity,On this entity
@@ -881,6 +885,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -900,6 +905,7 @@ p.,p.
 Page,페이지
 Page not found,Page not found
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,페이지
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1128,6 +1134,7 @@ Select files on your device,기기에서 파일을 선택하십시오.
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,연결 유형 선택
 Select site logo image,Select site logo image
@@ -1149,6 +1156,12 @@ Send recovery email,복구 이메일 전송
 Sending email,발신 이메일 주소
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,기본으로 설정

--- a/contents/ui-translations/my.csv
+++ b/contents/ui-translations/my.csv
@@ -726,6 +726,7 @@ Members,အဖွဲ့ဝင်များ
 Menu,မီနူး
 Message,မက်ဆေ့ချ်
 Message sent,Message sent
+Meta description,Meta description
 Metadata,မီတာဒေတာ
 Metadata Extraction,မီတာဒေတာ ထုတ်ယူခြင်း
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -863,6 +864,9 @@ OCR error,OCR error
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,OCR PDF
 of,၏
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,အိုကေ
 OK,အိုကေ
 On this entity,On this entity
@@ -881,6 +885,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -900,6 +905,7 @@ p.,p.
 Page,စာမျက်နှာ
 Page not found,Page not found
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,စာမျက်နှာများ
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1128,6 +1134,7 @@ Select files on your device,သင့်စက်ပေါ်ရှိ ဖို
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,ဆက်နွှယ်မှု အမျိုးအစား ရွေးချယ်ရန်
 Select site logo image,Select site logo image
@@ -1149,6 +1156,12 @@ Send recovery email,ပြန်လည်ရယူရန်အတွက် အ�
 Sending email,Sending email
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,နဂိုမူလအဖြစ် သတ်မှတ်ရန်

--- a/contents/ui-translations/ru.csv
+++ b/contents/ui-translations/ru.csv
@@ -723,6 +723,7 @@ Members,Участники
 Menu,Меню
 Message,Сообщение
 Message sent,Message sent
+Meta description,Meta description
 Metadata,Метаданные
 Metadata Extraction,Извлечение метаданных
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -860,6 +861,9 @@ OCR error,Ошибка оптического распознавания сим�
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,Оптическое распознавание символов PDF
 of,из
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,Окей
 OK,Окей
 On this entity,On this entity
@@ -878,6 +882,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -897,6 +902,7 @@ p.,p.
 Page,Страница
 Page not found,Page not found
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Страницы
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1125,6 +1131,7 @@ Select files on your device,Выбрать файлы на вашем устро
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,Выберите тип взаимосвязей
 Select site logo image,Select site logo image
@@ -1146,6 +1153,12 @@ Send recovery email,Отправить письмо для восстановл�
 Sending email,Электронная почта отправителя
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,Установить по умолчанию

--- a/contents/ui-translations/th.csv
+++ b/contents/ui-translations/th.csv
@@ -726,6 +726,7 @@ Members,สมาชิก
 Menu,เมนู
 Message,ข้อความ
 Message sent,Message sent
+Meta description,Meta description
 Metadata,เมทาดาทา
 Metadata Extraction,ค้นหาเมตาดาต้า
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -863,6 +864,9 @@ OCR error,OCR error
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,OCR PDF
 of,ของ
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,ตกลง
 OK,ตกลง
 On this entity,On this entity
@@ -881,6 +885,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -900,6 +905,7 @@ p.,p.
 Page,หน้า
 Page not found,Page not found
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,หน้า
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1128,6 +1134,7 @@ Select files on your device,เลือกไฟล์บนอุปกรณ�
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,เลือกประเภทความสัมพันธ์
 Select site logo image,Select site logo image
@@ -1149,6 +1156,12 @@ Send recovery email,ส่งอีเมลการกู้คืน
 Sending email,Sending email
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,ตั้งเป็นค่าเริ่มต้น

--- a/contents/ui-translations/tr.csv
+++ b/contents/ui-translations/tr.csv
@@ -726,6 +726,7 @@ Members,Üyeler
 Menu,Menü
 Message,Mesaj
 Message sent,Message sent
+Meta description,Meta description
 Metadata,Meta veri
 Metadata Extraction,Meta veri özütleme
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -863,6 +864,9 @@ OCR error,OKT hatası
 OCR error tip,The OCR engine couldn't read the document due to a malformed format. Last updated
 OCR PDF,OKT PDF
 of,nın-nin
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,Tamam
 OK,TAMAM
 On this entity,On this entity
@@ -881,6 +885,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Only the extractor will be deleted, all created entities will remain on the library."
 Open,Open
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Open group
 Open link,Open link
 Open PDF,Open PDF
@@ -900,6 +905,7 @@ p.,p.
 Page,Sayfa
 Page not found,Page not found
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Sayfalar
 Paragrap number extraction property (numeric),Paragrap number extraction property (numeric)
 Paragraph,Paragraph
@@ -1128,6 +1134,7 @@ Select files on your device,Cihazınızdaki dosyaları seçin
 Select from computer,Select from computer
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,İlişki türü seç
 Select site logo image,Select site logo image
@@ -1149,6 +1156,12 @@ Send recovery email,Kurtarma e-postası gönder
 Sending email,Sending email
 Sending email description,This is the email address that will appear as the sender when an email is sent from your Uwazi collection to registered users. The default address is *no-reply@uwazi.io*. You can set a custom one by including your desired email address here.
 Sending labeled data,Sending labeled data
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Services
 Set as default,Varsayılan olarak ayarla

--- a/contents/ui-translations/uk.csv
+++ b/contents/ui-translations/uk.csv
@@ -728,6 +728,7 @@ Members,Учасники
 Menu,Меню
 Message,Повідомлення
 Message sent,Повідомлення надіслано
+Meta description,Meta description
 Metadata,Метадані
 Metadata Extraction,Видобування метаданих
 "Metric shows a single total count. Select Pie, Bar, or another chart type above to
@@ -865,6 +866,9 @@ OCR error,Помилка оптичного розпізнавання симв�
 OCR error tip,модуль оптичного розпізнавання символів не зміг прочитати документ через неправильно сформований формат. Останнє оновлення
 OCR PDF,Оптичне розпізнавання символів PDF
 of,з
+og:description,og:description
+og:image,og:image
+og:title,og:title
 Ok,Гаразд
 OK,ГАРАЗД.
 On this entity,On this entity
@@ -883,6 +887,7 @@ Only published entities are counted.,Only published entities are counted.
 "Only the extractor will be deleted, all created entities will remain on the library.","Буде видалено лише розпакувальник, всі створені сутності залишаться у бібліотеці."
 Open,Відкрито
 Open entity,Open entity
+Open Graph,Open Graph
 Open group,Відкрита група
 Open link,Open link
 Open PDF,Відкрити PDF
@@ -902,6 +907,7 @@ p.,p.
 Page,Сторінка
 Page not found,Сторінку не знайдено
 Page published successfully.,Page published successfully.
+Page title,Page title
 Pages,Сторінки
 Paragrap number extraction property (numeric),Властивість вилучення номера абзацу (числова)
 Paragraph,Абзац
@@ -1130,6 +1136,7 @@ Select files on your device,Вибрати файли на вашому прис
 Select from computer,Виберіть з комп'ютера
 Select image,Select image
 Select media,Select media
+Select Open Graph image,Select Open Graph image
 Select relationship,Select relationship
 Select relationship type,Виберіть тип взаємозв'язків
 Select site logo image,Вибрати зображення логотипу сайту
@@ -1151,6 +1158,12 @@ Send recovery email,Відправити лист для відновлення 
 Sending email,Електронна пошта відправника
 Sending email description,"Це адреса електронної пошти, яка буде вказана як відправник при надсиланні листа з вашої колекції Uwazi зареєстрованим користувачам. Адреса за замовчуванням - *no-reply@uwazi.io*. Ви можете встановити власну, ввівши тут бажану адресу електронної пошти."
 Sending labeled data,Відправлення маркованих даних
+SEO,SEO
+SEO meta description,A short description of what this collection provides. Search engines may show this text in results. Aim for about 150–160 characters.
+SEO og description,"Description used in social media previews. If empty, the meta description is used."
+SEO og image description,"Image shown in social media previews (LinkedIn, Facebook, and others). Recommended size is 1200×630 pixels."
+SEO og title description,"Title used when this collection is shared on platforms such as LinkedIn, Facebook, and other social media. If empty, the page title is used."
+SEO page title description,A clear and descriptive title for the website. This is used as the default HTML page title in browser tabs and search results.
 Series,Series
 Services,Послуги
 Set as default,Встановити за замовчуванням

--- a/cypress/e2e/settings/collection.cy.ts
+++ b/cypress/e2e/settings/collection.cy.ts
@@ -54,6 +54,15 @@ describe('Collection', () => {
     cy.get('#matomo-analytics').type('matomo-analytics-key', { delay: 0 });
   });
 
+  it('should save SEO metadata', () => {
+    cy.get('[data-testid="settings-seo"]').scrollIntoView();
+    cy.get('#seo-page-title').clear();
+    cy.get('#seo-page-title').type('Human rights database', { delay: 0 });
+    cy.get('#seo-meta-description').type('A collection of documents and cases.', { delay: 0 });
+    cy.get('#seo-og-title').type('Share this collection', { delay: 0 });
+    cy.get('#seo-og-description').type('Open data on human rights.', { delay: 0 });
+  });
+
   it('should save Forms and email configurations successfully', () => {
     cy.get('#sending-email').type('email@mailer.com', { delay: 0 });
     cy.get('#receiving-email').type('reciever@mailer.com', { delay: 0 });
@@ -97,6 +106,10 @@ describe('Collection', () => {
 
   it('should have saved values in all collection inputs', () => {
     cy.get('#collection-name').should('have.value', 'New Collection Name');
+    cy.get('#seo-page-title').should('have.value', 'Human rights database');
+    cy.get('#seo-meta-description').should('have.value', 'A collection of documents and cases.');
+    cy.get('#seo-og-title').should('have.value', 'Share this collection');
+    cy.get('#seo-og-description').should('have.value', 'Open data on human rights.');
     cy.get('#google-analytics').should('have.value', 'google-analytics-key');
     cy.get('#matomo-analytics').should('have.value', 'matomo-analytics-key');
     cy.get('#sending-email').should('have.value', 'email@mailer.com');

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -19,3 +19,15 @@ Frontend is in `app/react`
 - **Monolith:** the SSR entry imports backend modules directly (`templatesApi`, `thesauriApi`, `ExecutionContext`, `tenants`) — frontend and backend run in the same Express process.
 - **Two state systems coexist:** Redux (legacy, deprecated) + Jotai (V2), kept in sync via `V2/atoms/syncReduxFromAtoms.js`. Target Jotai for new work.
 - **Two API clients:** `api` (`#app/utils/api.js`, legacy) + `apiClient` (`#V2/api/client.js`, V2). Target `apiClient` for new work.
+
+## Translations
+
+UI copy is collected from `<Translate>` and `t('System', …)` into CSV files under `contents/ui-translations/`.
+
+After a change that **adds, edits, or removes** translatable strings, run:
+
+```sh
+yarn update-translations-csv
+```
+
+That command scans `app/react`, reports missing/obsolete keys, and updates the locale CSVs. Commit those CSV diffs with the feature. Use `yarn update-translations-csv --dry` to inspect the report without writing files.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a Collection settings section for instance SEO so admins can configure the HTML page title, meta description, and Open Graph title, description, and image used when the site is shared.

## What changed
- New **SEO** card in Settings → Collection (`Page title`, `Meta description`, `og:title`, `og:description`, `og:image`) using existing Tailwind form components (`Card`, `InputField`, `Textarea`, `CustomUploadImagePicker`).
- Settings schema stores an optional `seo` object and exposes it in public settings so SSR/anonymous pages can render the tags.
- Instance-level `<title>`, `description`, and Open Graph tags are emitted globally. Entity and page views override `og:title` (and entity `og:description`) so those shares keep their own preview.
- `docs/frontend.md` now documents running `yarn update-translations-csv` after adding, editing, or removing translatable UI strings.
- Regenerated `contents/ui-translations/*.csv` with the new SEO keys so Check Translations CI can import them.

## Testing
- Unit tests for schema validation, public whitelist, meta-tag builder, SEO form card, and SSR origin hydration.
- Type check and type-aware lint on the affected scopes.
- Cypress collection settings coverage for the new text fields.
- `yarn update-translations-csv --dry` reports no missing keys after the CSV update.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b262704-1a59-4465-99d7-55e868af720d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b262704-1a59-4465-99d7-55e868af720d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

