### PR TITLE
Fix collection migration inserts under Postgres RLS

### DIFF
--- a/app/api/core/infrastructure/postgresql/common/PostgresTable.ts
+++ b/app/api/core/infrastructure/postgresql/common/PostgresTable.ts
@@ -60,6 +60,10 @@ export class PostgresTable<TRow = Record<string, unknown>> {
     return this.cfg.tenantId;
   }
 
+  get transactionManager(): PostgresTransactionManager {
+    return this.cfg.transactionManager;
+  }
+
   query<T = TRow>(): PostgresTable<T> {
     return this.chain(this.cfg.knex(this.cfg.tableName)) as any;
   }

--- a/app/api/core/infrastructure/postgresql/migrations/MigrateCollectionToPostgres.ts
+++ b/app/api/core/infrastructure/postgresql/migrations/MigrateCollectionToPostgres.ts
@@ -34,6 +34,19 @@ const rowsMapperOf = (
 ): ((doc: Record<string, unknown>) => Record<string, unknown>[]) =>
   'mapRows' in config ? doc => config.mapRows(doc) : doc => [config.mapDocument(doc)];
 
+const SYSTEM_PERMISSION_CONTEXT = { bypass: true, refIds: [] as string[] };
+
+const serializeRow = (row: Record<string, unknown>): Record<string, unknown> => {
+  const serialized = { ...row };
+  for (const key of Object.keys(serialized)) {
+    const value = serialized[key];
+    if (typeof value === 'object' && value !== null) {
+      serialized[key] = JSON.stringify(value);
+    }
+  }
+  return serialized;
+};
+
 const insertBatch = async (
   table: PostgresTable,
   batch: Record<string, unknown>[],
@@ -42,12 +55,15 @@ const insertBatch = async (
   if (!batch.length) {
     return;
   }
+  const rows = batch.map(row => serializeRow({ ...row, tenant_id: table.tenantId }));
   try {
-    if (force) {
-      await table.upsert(batch, { ignore: true });
-    } else {
-      await table.insert(batch);
-    }
+    await table.transactionManager.withConnection(async trx => {
+      if (force) {
+        await trx(table.tableName).insert(rows).onConflict(['_id', 'tenant_id']).ignore();
+      } else {
+        await trx(table.tableName).insert(rows);
+      }
+    }, SYSTEM_PERMISSION_CONTEXT);
   } catch (err: unknown) {
     // eslint-disable-next-line no-console
     console.error(


### PR DESCRIPTION
The Mongo-to-Postgres collection migration can now insert rows even though Row-Level Security is active.

**Why:** the migration previously inserted via `table.insert()` / `table.upsert()`, which run through `withConnection()` without a permission context — so RLS applied and the migration (a system process with no user `refIds`) could not write rows.

**What changed:**
- `MigrateCollectionToPostgres` now runs inserts inside `transactionManager.withConnection(..., SYSTEM_PERMISSION_CONTEXT)`, which sets `uwazi.bypass_rls = true` on the connection.
- Rows are serialized (object values JSON-stringified for JSONB) and `tenant_id` is stamped explicitly.
- `force` mode keeps its semantics via `insert(...).onConflict(['_id', 'tenant_id']).ignore()`.
- `PostgresTable` exposes its `transactionManager` so the migration can use it.