### PR TITLE
Include default height in Dataviz page embed copy snippet

### DIFF
--- a/app/react/V2/Dataviz/utils/buildEmbedSnippet.ts
+++ b/app/react/V2/Dataviz/utils/buildEmbedSnippet.ts
@@ -1,4 +1,7 @@
-export const buildPageEmbedSnippet = (id: string): string => `<Dataviz id="${id}" />`;
+const DEFAULT_PAGE_EMBED_HEIGHT = 320;
+
+export const buildPageEmbedSnippet = (id: string): string =>
+  `<Dataviz id="${id}" height="${DEFAULT_PAGE_EMBED_HEIGHT}"/>`;
 
 export const buildEmbedSnippet = buildPageEmbedSnippet;
 

--- a/app/react/V2/Dataviz/utils/specs/buildEmbedSnippet.spec.ts
+++ b/app/react/V2/Dataviz/utils/specs/buildEmbedSnippet.spec.ts
@@ -1,0 +1,9 @@
+import { buildPageEmbedSnippet } from '../buildEmbedSnippet.js';
+
+describe('buildPageEmbedSnippet', () => {
+  it('should include the default height so page authors can see it is configurable', () => {
+    expect(buildPageEmbedSnippet('6aa3306eb1d2d149374eac69')).toBe(
+      '<Dataviz id="6aa3306eb1d2d149374eac69" height="320"/>'
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The page embed copy snippet now includes the default `height` so authors can see that the chart height is configurable:

```html
<Dataviz id="6aa3306eb1d2d149374eac69" height="320"/>
```

`buildPageEmbedSnippet` is what the Dataviz editor copies into “Embed in pages”. The markdown `<Dataviz />` component already accepts `height`; this only makes that default visible in the copied tag.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [x] Smoke test the functionality described in the issue
- [x] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8468380b-5c26-4430-a411-5ac9ba393684?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8468380b-5c26-4430-a411-5ac9ba393684&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

